### PR TITLE
ghe-rsync-backup doesn't need --delete or -r args

### DIFF
--- a/scripts/ghe-rsync-backup
+++ b/scripts/ghe-rsync-backup
@@ -98,7 +98,7 @@ ssh "$host" -- "
 # specific files to be transferred in the run, which are combined with
 # general arguments and exclude rules.
 rsync_repository_data() {
-    rsync_args=(-ar --verbose --rsync-path='sudo -u git rsync')
+    rsync_args=(-a --verbose --rsync-path='sudo -u git rsync')
 
     # use previous snapshot when present for incremental backup
     if [ -d "$backup_current" ]; then


### PR DESCRIPTION
Just realized `--delete` isn't needed at all since we're transferring into a new clean snapshot directory each time. All files will be new. The `-r` argument is included with `-a` as well so drop that while here.
