### PR TITLE
use nice and ionice for backup commands sent over ssh

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -20,7 +20,7 @@ options="
 "
 
 # SSH to the GHE host and run a simple command to check SSH connectivity
-if ! ghe-ssh "$host" $options -- "true"; then
+if ! ghe-ssh $options "$host" -- "true"; then
     echo "Error: ssh to '$host' failed." 1>&2
     echo "Note that your SSH key needs to be setup on $host as described in:" 1>&2
     echo "* https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access" 1>&2

--- a/libexec/ghe-backup-config
+++ b/libexec/ghe-backup-config
@@ -80,6 +80,10 @@ GHE_SNAPSHOT_DIR="$GHE_DATA_DIR"/"$GHE_SNAPSHOT_TIMESTAMP"
 # allows the location to be overridden in tests.
 : ${GHE_REMOTE_LICENSE_FILE:="/data/enterprise/enterprise.ghl"}
 
+# CPU and IO throttling to keep backups and restores from thrashing around.
+: ${GHE_NICE:="nice -n 19"}
+: ${GHE_IONICE:="ionice -c 3"}
+
 ###############################################################################
 ### Utility functions
 

--- a/libexec/ghe-ssh
+++ b/libexec/ghe-ssh
@@ -38,4 +38,4 @@ user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
 # Exec ssh command with modified host / port args
-exec ssh $opts -p "$port" -l "$user" "$host" "$@"
+exec ssh $opts -p "$port" -l "$user" "$host" "$GHE_NICE $GHE_IONICE $@"


### PR DESCRIPTION
Seems to work and subcommands inherit the nice setting.

```
admin@ghe-io:~$ ps -e -o pid,nice,fname | grep ghe
27038  19 ghe-expo
admin@ghe-io:~$ ps -ef | grep 27038
root     27038 27036  0 23:13 ?        00:00:00 /bin/sh /data/enterprise-manage/current/admin/root/ghe-export-es-indices
root     27040 27038  6 23:13 ?        00:00:01 tar -cf - -C /data elasticsearch
admin    27089 20893  0 23:14 pts/0    00:00:00 grep --color=auto 27038
admin@ghe-io:~$ ps -e -o pid,nice,fname | grep 27040
27040  19 tar
```
