### PR TITLE
More granular ghe-host-checks

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -22,10 +22,10 @@ options="
 # The location of metadata file on the remote side.
 metadata_file="$GHE_REMOTE_DATA_DIR/enterprise/chef_metadata.json"
 
-set +x
-metadata=$(echo "cat \"$metadata\" 2>/dev/null || exit 101" | ghe-ssh $options $host -- /bin/sh)
+set +e
+metadata=$(echo "cat \"$metadata_file\" 2>/dev/null || exit 101" | ghe-ssh $options $host -- /bin/sh)
 rc=$?
-set -x
+set -e
 
 if [ $rc -ne 0 ]; then
     case $rc in


### PR DESCRIPTION
I was having a hard time specifically why `ghe-host-check` was failing, since it's checking a few things (ssh connectivity, metadata file, and version in that thing), so I split it out into three checks:
- ssh succeeds, or not
- $GHE_REMOTE_DATA_DIR/enterprise/chef_metadata.json exists or not
- $GHE_REMOTE_DATA_DIR/enterprise/chef_metadata.json contains a version

Output now looks like so:

```
$ GHE_REMOTE_DATA_DIR=/data/user bin/ghe-host-check trol.ol.ol.ol:22
Permission denied (publickey).
Error: ssh to 'trol.ol.ol.ol:22' failed
Note that your SSH key needs to be setup on trol.ol.ol.ol:22 as described in:
* https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access
$ GHE_REMOTE_DATA_DIR=/data/user bin/ghe-host-check trol.ol.ol.ol:122
Error: /data/user/enterprise/chef_metadata.json on 'trol.ol.ol.ol:122' doesn't exist or this isn't a GitHub appliance.
$ GHE_REMOTE_DATA_DIR=/data/user bin/ghe-host-check trol.ol.ol.ol:122
Error: failed to parse version from /data/user/enterprise/chef_metadata.json on 'trol.ol.ol.ol:122' or this isn't a GitHub appliance.
```
