### PR TITLE
Fix typo in comment

### DIFF
--- a/libexec/ghe-restore-es-tarball
+++ b/libexec/ghe-restore-es-tarball
@@ -20,6 +20,6 @@ host="$1"
 # us run this script directly.
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
-# Restore ElasticSearch indexes from tarball snapshot.
+# Restore ElasticSearch indices from tarball snapshot.
 ghe-ssh "$host" -- 'ghe-import-es-indices' \
     < "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/elasticsearch.tar" 1>&3


### PR DESCRIPTION
Just noting that `ghe-restore-es-tarball` restores ElasticSearch indices instead of Pages data. :wink:
