### PR TITLE
remove GNU tar requirement for restoring to 2. add error message.

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -119,6 +119,16 @@ if ! $restore_settings &&
     exit 1
 fi
 
+# Restoring Elasticsearch to 11.10.3x via rsync requires GNU tar
+if [ "$GHE_VERSION_MAJOR.$GHE_VERSION_MINOR" = "1.0" ] && [ "$GHE_BACKUP_STRATEGY" = "rsync" ]; then
+    if ! tar --version | grep -q GNU; then
+        if ! command -v gtar >/dev/null 2>&1; then
+            echo "GNU tar is required.  Aborting." >&2
+            exit 1
+        fi
+    fi
+fi
+
 # Make sure the GitHub appliance is in maintenance mode and all writing
 # processes have bled out.
 ghe-maintenance-mode-enable "$host"

--- a/libexec/ghe-restore-es-rsync
+++ b/libexec/ghe-restore-es-rsync
@@ -26,12 +26,6 @@ ghe_remote_version_required "$host"
 # The directory holding the snapshot to restore
 snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 
-# Use GNU tar on BSDs.
-TAR=tar
-if ! tar --version | grep -q GNU; then
-    TAR=gtar
-fi
-
 # Transfer all ES data from the latest snapshot to the GitHub instance.
 if [ ! -d "$snapshot_dir/elasticsearch" ]; then
     echo "Warning: Elasticsearch backup missing. Skipping ..."
@@ -41,9 +35,8 @@ if [ ! -d "$snapshot_dir/elasticsearch" ]; then
 elif [ "$GHE_VERSION_MAJOR" -gt 1 -a -f "$snapshot_dir/elasticsearch/elasticsearch.yml" ]; then
     cd "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/elasticsearch"
     ghe-ssh "$host" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-legacy'" 1>&3
-
-    $TAR -cf - --owner=root --group=root . |
-    ghe-ssh "$host" -- "sudo tar -xf - -C '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-legacy'" 1>&3
+    tar -cf - . |
+    ghe-ssh "$host" -- "sudo tar --no-same-owner -xf - -C '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-legacy'" 1>&3
 
 # restoring v2.0 ES snapshot into a v2.0 appliance
 elif [ "$GHE_VERSION_MAJOR" -gt 1 ]; then
@@ -60,6 +53,11 @@ elif [ "$GHE_VERSION_MAJOR" -gt 1 ]; then
 
 # restoring v11.10.x ES snapshot into a v11.10.x appliance
 else
+    # Use GNU tar on BSDs.
+    TAR=tar
+    if ! tar --version | grep -q GNU; then
+            TAR=gtar
+    fi
     cd "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
     $TAR -cf - --owner=root --group=root elasticsearch |
     ghe-ssh "$host" -- 'ghe-import-es-indices' 1>&3


### PR DESCRIPTION
- Removes GNU tar requirement for restoring to 2 by using the `--no-same-owner` flag to set the owner to root on restore.
- Reports a more useful error if GNU tar is required and isn't installed.
- Moves GNU tar check to v11.10.x -> v11.10.x restore
