### PR TITLE
Tell rsync to preserve hard links for git objects/packs direcotries

### DIFF
--- a/libexec/ghe-backup-repositories-rsync
+++ b/libexec/ghe-backup-repositories-rsync
@@ -152,7 +152,7 @@ RULES
 # since these files are already well compressed.
 echo 1>&3
 echo "* Transferring objects and packs ..." 1>&3
-rsync_repository_data <<RULES
+rsync_repository_data -H <<RULES
 - /__*__/
 + /*/
 + /*/*.git

--- a/libexec/ghe-restore-repositories-rsync
+++ b/libexec/ghe-restore-repositories-rsync
@@ -22,7 +22,7 @@ host="$1"
 
 # Transfer all git repository data from the latest snapshot to the GitHub
 # instance in a single rsync invocation.
-ghe-rsync -av --delete \
+ghe-rsync -avH --delete \
     -e "ghe-ssh -p $(ssh_port_part "$host")" \
     --rsync-path="sudo -u git rsync" \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/" \


### PR DESCRIPTION
Without -H option the rsync will sync the files that are hardlinked on the source side as separate file on receiver side. In some situations this might make it impossible to restore appliance from backup as restored repository filesystem contents can be several times bigger than original contents used to create backup.
