### PR TITLE
Adds documentation about GHE_EXTRA_SSH_OPTS in example config file

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -22,3 +22,7 @@ GHE_NUM_SNAPSHOTS=10
 # ghe-restore so use of this variable isn't strictly required.
 #
 #GHE_RESTORE_HOST="github-standby.example.com"
+
+# Any extra options passed to the SSH command.  Nothing required by default
+#
+#GHE_EXTRA_SSH_OPTS=""


### PR DESCRIPTION
I need to specify a particular SSH key to communicate with my GitHub enterprise server:

`ssh -i /path/to/non/default/key admin@ghe_hostname.example.com`

I dug into the code and saw that I could easily specify this by setting:
`GHE_EXTRA_SSH_OPTS="-i /path/to/non/default/key"` in backup config.

It would have been useful to me if this option was documented as being available in the example configuration file.
