### PR TITLE
Light README updates for GitHub Enterprise v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ appliance at IP "5.5.5.5":
     Restoring SSH host keys ...
     Completed restore of 5.5.5.5 from snapshot 20140817T174152
     Visit https://5.5.5.5/setup/settings to configure the recovered appliance.
-    
-Any backup can be applied using the `-s` argument and the datestamp-named directory from the backup location.
+
+A different backup snapshot may be selected by passing the `-s` argument and the
+datestamp-named directory from the backup location.
 
 The `ghe-backup` and `ghe-restore` commands also have a verbose output mode
 (`-v`) that lists files as they're being transferred. It's often useful to


### PR DESCRIPTION
Adds some notes to the README about GitHub Enterprise 2.0, including a link to the [Migrating from GitHub Enterprise v11.10.34x](https://help.github.com/enterprise/2.0/admin-guide/migrating/) documentation.

Fixes https://github.com/github/backup-utils/issues/79.
