### PR TITLE
report mysqldump failures

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -100,8 +100,8 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-ssh-host-keys' > ssh-host-keys.tar ||
 failures="$failures ssh-host-keys"
 
 echo "Backing up MySQL database ..."
-echo 'ghe-export-mysql | gzip' |
-ghe-ssh "$GHE_HOSTNAME" -- /bin/sh > mysql.sql.gz ||
+echo 'set -o pipefail; ghe-export-mysql | gzip' |
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz ||
 failures="$failures mysql"
 
 echo "Backing up Redis database ..."

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -51,7 +51,7 @@ opts="-l $user $opts"
 
 # Bail out with error if the simple command form is used with complex commands.
 # Complex
-if echo "$*" | grep -q "[|;]" || [ $(echo "$*" | wc -l) -gt 1 ]; then
+if echo "$*" | grep "[|;]" >/dev/null || [ $(echo "$*" | wc -l) -gt 1 ]; then
     echo "fatal: ghe-ssh: Attempt to invoke complex command with simple command form." 1>&2
     echo "See ghe-ssh --help for more on correcting." 1>&2
     exit 1

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #/ Usage: ghe-ssh [<option>...] <host> [<simple-command>...]
-#/        echo <complex-command>... | ghe-ssh [<option>...] <host> /bin/sh
+#/        echo 'set -o pipefail; <complex-command>...' | ghe-ssh [<option>...] <host> /bin/bash
 #/ Helper to ssh into a GitHub instance with the right user and port. The first
 #/ form should be used for simple commands; the second form should be used for
 #/ complex commands that include pipelines or multiple commands.
@@ -51,7 +51,7 @@ opts="-l $user $opts"
 
 # Bail out with error if the simple command form is used with complex commands.
 # Complex
-if echo "$*" | grep "[|;]" >/dev/null || [ $(echo "$*" | wc -l) -gt 1 ]; then
+if echo "$*" | grep -q "[|;]" || [ $(echo "$*" | wc -l) -gt 1 ]; then
     echo "fatal: ghe-ssh: Attempt to invoke complex command with simple command form." 1>&2
     echo "See ghe-ssh --help for more on correcting." 1>&2
     exit 1


### PR DESCRIPTION
`ghe-export-mysql` errors were not correctly reported because the gzip in the pipeline succeeds even when mysqldump does not.

This fixes mysql backup error reporting by switching from sh to bash and setting '-o pipefail'.