### PR TITLE
Allow ghe-host-check to be run from within the bin directory

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -38,7 +38,7 @@ if [ $rc -ne 0 ]; then
     case $rc in
         255)
             if echo "$output" | grep -i "port 22: connection refused" >/dev/null; then
-                exec "$0" "$hostname:122"
+                exec "bin/$(basename $0)" "$hostname:122"
             fi
 
             echo "$output" 1>&2
@@ -51,7 +51,7 @@ if [ $rc -ne 0 ]; then
             ;;
         1)
             if [ "${port:-22}" -eq 22 ] && echo "$output" | grep "use port 122" >/dev/null; then
-                exec "$0" "$hostname:122"
+                exec "bin/$(basename $0)" "$hostname:122"
             else
                 echo "$output" 1>&2
             fi


### PR DESCRIPTION
At the moment `ghe-host-check` assumes it'll always be run via `bin/ghe-host-check` from within the `backup-utils` directory or via `ghe-host-check` with `backup-utils/bin` in the user's path.

This fails with:

```
$ ./ghe-host-check
./ghe-host-check: line 54: /path/to/backup-utils/ghe-host-check: No such file or directory
$
```

... on OS X, which is useful, or uselessly:

```
$ ./ghe-host-check
./ghe-host-check: 54: exec: ./ghe-host-check: not found
$
```

... on Ubuntu 14.04 (reproduced on AWS with ami-0307d674).

This PR corrects that and allows for running `ghe-host-check` from within the `backup-utils/bin` directory without affecting the other methods of calling it.