### PR TITLE
Ensure pages dir exists for rsync

### DIFF
--- a/share/github-backup-utils/ghe-backup-pages-rsync
+++ b/share/github-backup-utils/ghe-backup-pages-rsync
@@ -10,5 +10,8 @@ set -e
 cd $(dirname "$0")/../..
 . share/github-backup-utils/ghe-backup-config
 
+# Make sure root backup dir exists if this is the first run
+mkdir -p "$GHE_SNAPSHOT_DIR/pages"
+
 # Use the common user data rsync backup utility.
 ghe-backup-userdata pages


### PR DESCRIPTION
Backing up Pages over rsync when the appliance has no Pages and Pages is disabled results in an error on certain operating systems:

```
$ bin/ghe-backup
Starting backup of ghe.example.com in snapshot 20150217T222343
Connect ghe.example.com:122 OK (v2.1.2)
Backing up GitHub settings ...
Backing up SSH authorized keys ...
Backing up SSH host keys ...
Backing up MySQL database ...
Backing up Redis database ...
Backing up Git repositories ...
Backing up GitHub Pages ...
--link-dest arg does not exist: ../../current/pages
Backing up asset attachments ...
Backing up hook deliveries ...
Backing up Elasticsearch indices ...
Pruning 1 expired snapshot(s) ...
Completed backup of ghe.example.com:122 in snapshot 20150217T222343 at 22:24:45
```

This is readily reproducible on RedHat/CentOS 6.

This PR resolves this for all platforms by ensuring the pages backup directory already exists before an attempt is made to backup the contents.