### PR TITLE
warn and prompt when replication is configured

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -97,9 +97,9 @@ elif [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     restore_settings=true
 fi
 
-# If you restore to a server in a replication pair
+# Figure out if this instance is in a replication pair
 if ghe-ssh "$GHE_HOSTNAME" -- "ghe-repl-status -r 2>/dev/null" \
-  | grep -E "replica|primary"; then
+  | grep -Eq "replica|primary"; then
   instance_configured=true
   echo "WARNING: Restoring to a server with replication enabled interrupts replication."
   echo "You will need to reconfigure replication after the restore completes."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -97,6 +97,14 @@ elif [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     restore_settings=true
 fi
 
+# If you restore to a server in a replication pair
+if ghe-ssh "$GHE_HOSTNAME" -- "ghe-repl-status -r 2>/dev/null" \
+  | grep -E "replica|primary"; then
+  instance_configured=true
+  echo "WARNING: Restoring to a server with replication enabled interrupts replication."
+  echo "You will need to reconfigure replication after the restore completes."
+fi
+
 # Prompt to verify the restore host given is correct. Restoring overwrites
 # important data on the destination appliance that cannot be recovered. This is
 # mostly to prevent accidents where the backup host is given to restore instead

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -102,7 +102,7 @@ if ghe-ssh "$GHE_HOSTNAME" -- "ghe-repl-status -r 2>/dev/null" \
   | grep -Eq "replica|primary"; then
   instance_configured=true
   echo "WARNING: Restoring to a server with replication enabled interrupts replication."
-  echo "You will need to reconfigure replication after the restore completes."
+  echo "         You will need to reconfigure replication after the restore completes."
 fi
 
 # Prompt to verify the restore host given is correct. Restoring overwrites


### PR DESCRIPTION
This PR adds an additional check to warn and prompt when restoring to a server in a replication pair. Restoring to a server in a replication pair will interrupt replication, and requires that replication be reconfigured.