### PR TITLE
Remove temporary 2.2 migration dir before restoring repos

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -179,7 +179,7 @@ fi
 
 echo "Restoring Git repositories ..."
 # Remove temporary 2.2 storage migration directory if it exists
-echo "[ -d /data/user/repositories-nw-backup ]; then sudo rm -rf /data/user/repositories-nw-backup; fi" |
+echo "if [ -d /data/user/repositories-nw-backup ]; then sudo rm -rf /data/user/repositories-nw-backup; fi" |
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
 ghe-restore-repositories-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -178,6 +178,9 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
 fi
 
 echo "Restoring Git repositories ..."
+# Remove temporary 2.2 storage migration directory if it exists
+echo "[ -d /data/user/repositories-nw-backup ]; then sudo rm -rf /data/user/repositories-nw-backup; fi" |
+ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
 ghe-restore-repositories-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 
 echo "Restoring GitHub Pages ..."


### PR DESCRIPTION
This PR removes the temporary /data/user/repositories-nw-backup directory that remains after successfully migrating the repository storage layout to the new format used on GHE 2.2.0 and later.

The removal of this directory allows for continual restoration to work on GHE 2.2.x.

/cc @rtomayko 