### PR TITLE
Restart memcached after restoring

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -177,10 +177,11 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
 fi
 
-echo "Restoring Git repositories ..."
 # Remove temporary 2.2 storage migration directory if it exists
 echo "if [ -d /data/user/repositories-nw-backup ]; then sudo rm -rf /data/user/repositories-nw-backup; fi" |
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
+
+echo "Restoring Git repositories ..."
 ghe-restore-repositories-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 
 echo "Restoring GitHub Pages ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -209,7 +209,9 @@ ghe-restore-es-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 
 # Restart an already running memcached to reset the cache after restore
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
-    echo "sudo restart -q memcached 2>&1 || true" | ghe-ssh "$GHE_HOSTNAME"
+    echo "Restarting memcached ..." 1>&3
+    echo "sudo restart -q memcached 2>/dev/null || true" |
+        ghe-ssh "$GHE_HOSTNAME" -- /bin/sh
 fi
 
 # When restoring to a host that has already been configured, kick off a

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -207,6 +207,11 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-authorized-keys' < "$GHE_RESTORE_SNAPSHOT
 echo "Restoring Elasticsearch indices ..."
 ghe-restore-es-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 
+# Restart an already running memcached to reset the cache after restore
+if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "sudo restart -q memcached 2>&1 || true"
+fi
+
 # When restoring to a host that has already been configured, kick off a
 # config run to perform data migrations.
 if $instance_configured; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -209,7 +209,7 @@ ghe-restore-es-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 
 # Restart an already running memcached to reset the cache after restore
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
-    ghe-ssh "$GHE_HOSTNAME" -- "sudo restart -q memcached 2>&1 || true"
+    echo "sudo restart -q memcached 2>&1 || true" | ghe-ssh "$GHE_HOSTNAME"
 fi
 
 # When restoring to a host that has already been configured, kick off a


### PR DESCRIPTION
When restoring to an already configured GHE instance that's had some real use, memcached will be out of sync with the newly restored data. This PR causes the memcached daemon to be restarted after restoring all data to flush the cache.

Internal ticket: https://github.com/github/enterprise2/issues/3859

/cc @github/enterprise-releases, @jatoben 