### PR TITLE
Log backup/restore start/complete on remote instance

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -67,6 +67,9 @@ echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 ghe_remote_version_required
 echo "$GHE_REMOTE_VERSION" > version
 
+# Log backup start message in /var/log/syslog on remote instance
+ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP"
+
 # Determine whether to use the rsync or tarball backup strategy based on the
 # remote appliance version. The tarball strategy must be used with GitHub
 # Enterprise versions prior to 11.10.340 since rsync is not available.
@@ -153,8 +156,11 @@ fi
 echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $(date +"%H:%M:%S")"
 
 # Exit non-zero and list the steps that failed.
-if [ -n "$failures" ]; then
+if [ -z "$failures" ]; then
+    ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP successfully."
+else
     steps="$(echo $failures | sed 's/ /, /g')"
+    ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP with failures: ${steps}."
     echo "Error: Snapshot incomplete. Some steps failed: ${steps}. "
     exit 1
 fi

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -68,7 +68,7 @@ ghe_remote_version_required
 echo "$GHE_REMOTE_VERSION" > version
 
 # Log backup start message in /var/log/syslog on remote instance
-ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP"
+ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
 
 # Determine whether to use the rsync or tarball backup strategy based on the
 # remote appliance version. The tarball strategy must be used with GitHub

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -237,7 +237,7 @@ trap "" EXIT
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance
-ghe_remote_logger "Completed restore from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
+ghe_remote_logger "Completed restore from $(hostname) / snapshot ${GHE_SNAPSHOT_TIMESTAMP}."
 
 echo "Restoring SSH host keys ..."
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-ssh-host-keys' < "$GHE_RESTORE_SNAPSHOT_PATH/ssh-host-keys.tar" 1>&3

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -133,7 +133,11 @@ if $instance_configured && ! $force; then
     echo
 fi
 
+# Log restore start message locally and in /var/log/syslog on remote instance
 echo "Starting restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
+ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
+
+# Update remote restore state file and setup failure trap
 trap "update_restore_status failed" EXIT
 update_restore_status "restoring"
 
@@ -231,6 +235,9 @@ fi
 # changing otherwise.
 trap "" EXIT
 update_restore_status "complete"
+
+# Log restore complete message in /var/log/syslog on remote instance
+ghe_remote_logger "Completed restore from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
 
 echo "Restoring SSH host keys ..."
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-ssh-host-keys' < "$GHE_RESTORE_SNAPSHOT_PATH/ssh-host-keys.tar" 1>&3

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -238,10 +238,6 @@ ssh_port_part () {
 # Log a message to /var/log/syslog on the remote instance.
 # Note: Use sparingly. Remote logging requires an ssh connection per invocation.
 ghe_remote_logger () {
-    if [ "$GHE_VERSION_MAJOR" -lt 2 ]; then
-        return 0
-    fi
-
     echo "$@" |
     ghe-ssh "$GHE_HOSTNAME" -- logger -t backup-utils || true
 }

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -243,5 +243,5 @@ ghe_remote_logger () {
     fi
 
     echo "$@" |
-    ghe-ssh "$GHE_HOSTNAME" -- logger -t backup-utils
+    ghe-ssh "$GHE_HOSTNAME" -- logger -t backup-utils || true
 }

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -233,3 +233,15 @@ ssh_host_part () {
 ssh_port_part () {
     [ "${1##*:}" = "$1" ] && echo 22 || echo "${1##*:}"
 }
+
+# Usage: ghe_remote_logger <message>...
+# Log a message to /var/log/syslog on the remote instance.
+# Note: Use sparingly. Remote logging requires an ssh connection per invocation.
+ghe_remote_logger () {
+    if [ "$GHE_VERSION_MAJOR" -lt 2 ]; then
+        return 0
+    fi
+
+    echo "$@" |
+    ghe-ssh "$GHE_HOSTNAME" -- logger -t backup-utils
+}


### PR DESCRIPTION
Adds logging to `/var/log/syslog` on the remote GHE instance to both `ghe-backup` and `ghe-restore`. The logging is fairly simple and records only start and completion but that should be fine for now. This should work with remote syslog configurations since `logger(1)` is used as well.

Example messages:

```
May 21 11:29:30 ghe-io backup-utils: Starting backup from rtko.local in snapshot 20150521T075236
May 21 11:29:40 ghe-io backup-utils: Completed backup from rtko.local / snapshot 20150521T075236 successfully.
May 21 11:30:00 ghe-io backup-utils: Starting restore from rtko.local / snapshot 20150521T075236 ...
May 21 11:30:30 ghe-io backup-utils: Completed restore from rtko.local / snapshot 20150521T075236 ...
```

Internal ticket: https://github.com/github/enterprise2/issues/3805#issuecomment-103219349.

/cc @donal, @dbussink, @jatoben, @cjs