### PR TITLE
Revert "Remove hookshot backup/restore"

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -123,6 +123,10 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     echo "Backing up asset attachments ..."
     ghe-backup-userdata alambic_assets ||
     failures="$failures alambic_assets"
+
+    echo "Backing up hook deliveries ..."
+    ghe-backup-userdata hookshot ||
+    failures="$failures hookshot"
 fi
 
 echo "Backing up Elasticsearch indices ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -194,6 +194,9 @@ ghe-restore-pages-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     echo "Restoring asset attachments ..."
     ghe-restore-userdata alambic_assets "$GHE_HOSTNAME" 1>&3
+
+    echo "Restoring hook deliveries ..."
+    ghe-restore-userdata hookshot "$GHE_HOSTNAME" 1>&3
 fi
 
 echo "Restoring MySQL database ..."

--- a/share/github-backup-utils/ghe-backup-repositories-rsync
+++ b/share/github-backup-utils/ghe-backup-repositories-rsync
@@ -247,9 +247,9 @@ rsync_repository_data -H <<RULES
 RULES
 
 # Sync __special__ data directories, including the __alambic_assets__,
-# and __purgatory__ directories. The __nodeload_archives__,
+# __hookshot__, and __purgatory__ directories. The __nodeload_archives__,
 # __gitmon__, and __render__ directories are excludes since they act only as
-# caches. The __hookshot__ directory is also excluded since it only contains log files.
+# caches.
 #
 # Under v2.x and greater, only the special __purgatory__ directory remains under
 # /data/repositories. All other special user data directories have been moved under
@@ -260,7 +260,6 @@ rsync_repository_data <<RULES
 - /__nodeload_archives__/
 - /__gitmon__/
 - /__render__/
-- /__hookshot__/
 + /__*__/
 + /__*__/**
 + /info/

--- a/share/github-backup-utils/ghe-backup-userdata
+++ b/share/github-backup-utils/ghe-backup-userdata
@@ -2,7 +2,7 @@
 #/ Usage: ghe-backup-userdata <dirname>
 #/ Take an online, incremental snapshot of a user data directory. This is used
 #/ for a number of different simple datastores kept under /data/user on the
-#/ remote appliance, including alambic_assets and pages data.
+#/ remote appliance, including: hookshot, alambic_assets, and pages data.
 set -e
 
 # Bring in the backup configuration

--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -2,7 +2,7 @@
 #/ Usage: ghe-restore-userdata <dirname> <host>
 #/ Restore a special user data directory via rsync. This is used
 #/ for a number of different simple datastores kept under /data/user on the
-#/ remote appliance, including alambic_assets and pages data.
+#/ remote appliance, including: hookshot, alambic_assets, and pages data.
 set -e
 
 # Bring in the backup configuration

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -17,6 +17,14 @@ touch alice/index.html bob/index.html
 mkdir -p "$GHE_REMOTE_DATA_USER_DIR/common"
 echo "fake password hash data" > "$GHE_REMOTE_DATA_USER_DIR/common/manage-password"
 
+# Create some fake hookshot data in the remote data directory
+if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+    mkdir -p "$GHE_REMOTE_DATA_USER_DIR/hookshot"
+    cd "$GHE_REMOTE_DATA_USER_DIR/hookshot"
+    mkdir -p repository-123 repository-456
+    touch repository-123/test.bpack repository-456/test.bpack
+fi
+
 # Create some fake alambic data in the remote data directory
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     mkdir -p "$GHE_REMOTE_DATA_USER_DIR/alambic_assets/github-enterprise-assets/0000"
@@ -109,6 +117,9 @@ begin_test "ghe-backup first snapshot"
     fi
 
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+        # verify all hookshot user data was transferred
+        diff -ru "$GHE_REMOTE_DATA_USER_DIR/hookshot" "$GHE_DATA_DIR/current/hookshot"
+
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/alambic_assets" "$GHE_DATA_DIR/current/alambic_assets"
     fi
@@ -178,6 +189,9 @@ begin_test "ghe-backup subsequent snapshot"
     fi
 
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+        # verify all hookshot user data was transferred
+        diff -ru "$GHE_REMOTE_DATA_USER_DIR/hookshot" "$GHE_DATA_DIR/current/hookshot"
+
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/alambic_assets" "$GHE_DATA_DIR/current/alambic_assets"
     fi

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -18,6 +18,14 @@ mkdir -p gh-enterprise-es/node/0
 touch gh-enterprise-es/node/0/stuff1
 touch gh-enterprise-es/node/0/stuff2
 
+# Create some fake hookshot data in the remote data directory
+if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+    mkdir -p "$GHE_DATA_DIR/1/hookshot"
+    cd "$GHE_DATA_DIR/1/hookshot"
+    mkdir -p repository-123 repository-456
+    touch repository-123/test.bpack repository-456/test.bpack
+fi
+
 # Create some fake alambic data in the remote data directory
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     mkdir -p "$GHE_DATA_DIR/1/alambic_assets/github-enterprise-assets/0000"
@@ -107,6 +115,9 @@ begin_test "ghe-restore into configured vm"
     diff -ru "$GHE_DATA_DIR/current/pages" "$GHE_REMOTE_DATA_USER_DIR/pages"
 
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+        # verify all hookshot user data was transferred
+        diff -ru "$GHE_DATA_DIR/current/hookshot" "$GHE_REMOTE_DATA_USER_DIR/hookshot"
+
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_DATA_DIR/current/alambic_assets" "$GHE_REMOTE_DATA_USER_DIR/alambic_assets"
     fi
@@ -213,6 +224,9 @@ begin_test "ghe-restore -c into unconfigured vm"
     diff -ru "$GHE_DATA_DIR/current/pages" "$GHE_REMOTE_DATA_USER_DIR/pages"
 
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+        # verify all hookshot user data was transferred
+        diff -ru "$GHE_DATA_DIR/current/hookshot" "$GHE_REMOTE_DATA_USER_DIR/hookshot"
+
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_DATA_DIR/current/alambic_assets" "$GHE_REMOTE_DATA_USER_DIR/alambic_assets"
     fi
@@ -266,6 +280,9 @@ begin_test "ghe-restore into unconfigured vm"
         # verify all pages data was transferred to the restore location
         diff -ru "$GHE_DATA_DIR/current/pages" "$GHE_REMOTE_DATA_USER_DIR/pages"
 
+        # verify all hookshot user data was transferred
+        diff -ru "$GHE_DATA_DIR/current/hookshot" "$GHE_REMOTE_DATA_USER_DIR/hookshot"
+
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_DATA_DIR/current/alambic_assets" "$GHE_REMOTE_DATA_USER_DIR/alambic_assets"
 
@@ -309,6 +326,9 @@ begin_test "ghe-restore with host arg"
     diff -ru "$GHE_DATA_DIR/current/pages" "$GHE_REMOTE_DATA_USER_DIR/pages"
 
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+        # verify all hookshot user data was transferred
+        diff -ru "$GHE_DATA_DIR/current/hookshot" "$GHE_REMOTE_DATA_USER_DIR/hookshot"
+
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_DATA_DIR/current/alambic_assets" "$GHE_REMOTE_DATA_USER_DIR/alambic_assets"
     fi


### PR DESCRIPTION
Reverts github/backup-utils#134

Following discussions regarding keeping a backup of the hookshot logs, it has been decided to revert this change as the number of logs will be significantly fewer on later releases of GitHub Enterprise.

This does however reintroduce the severe delay when migrating from GitHub Enterprise 11.10.3xx to 2.x as GitHub Enterprise 11.10.3xx doesn't prune the log files like 2.2 does.