### PR TITLE
Only use --link-dest when backing up populated directories

### DIFF
--- a/share/github-backup-utils/ghe-backup-userdata
+++ b/share/github-backup-utils/ghe-backup-userdata
@@ -26,9 +26,9 @@ ghe_remote_version_required "$host"
 # to an older version of GHE or no data has been added to this directory yet.
 ghe-ssh "$host" -- "[ -d '$GHE_REMOTE_DATA_USER_DIR/$dirname' ]" || exit 0
 
-# If we have a previous increment, avoid transferring existing files via rsync's
+# If we have a previous increment and it is not empty, avoid transferring existing files via rsync's
 # --link-dest support. This also decreases physical space usage considerably.
-if [ -d "$GHE_DATA_DIR/current/$dirname" ]; then
+if [ -d "$GHE_DATA_DIR/current/$dirname" ] && [ "$(ls -A $GHE_DATA_DIR/current/$dirname)" ]; then
     link_dest="--link-dest=../../current/$dirname"
 fi
 

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -251,3 +251,16 @@ begin_test "ghe-backup without manage-password file"
     [ ! -f "$GHE_DATA_DIR/current/manage-password" ]
 )
 end_test
+
+begin_test "ghe-backup emtpy hookshot directory"
+(
+  set -e
+
+  rm -rf $GHE_REMOTE_DATA_USER_DIR/hookshot/repository-*
+  rm -rf $GHE_DATA_DIR/current/hookshot/repository-*
+  ghe-backup
+
+  # Check that the "--link-dest arg does not exist" message hasn't occurred.
+  [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
+)
+end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -252,7 +252,7 @@ begin_test "ghe-backup without manage-password file"
 )
 end_test
 
-begin_test "ghe-backup emtpy hookshot directory"
+begin_test "ghe-backup empty hookshot directory"
 (
   set -e
 


### PR DESCRIPTION
Rsync 3.0.0 and later appears to have some optimizations which results in...

```
--link-dest arg does not exist: ../../current/hookshot
```

... errors when using the `--link-dest` argument is used with empty directories.  As there is nothing to hardlink to, we don't really need to use this argument so lets not use it.

This resolves https://github.com/github/backup-utils/issues/137 (and is dependent on https://github.com/github/backup-utils/issues/136 being merged first).