### PR TITLE
Fix rendering of "How does backup utilities..." link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository includes backup and recovery utilities for [GitHub Enterprise][1
 - **[Using the backup and restore commands](#using-the-backup-and-restore-commands)**
 - **[Scheduling backups](#scheduling-backups)**
 - **[Backup snapshot file structure](#backup-snapshot-file-structure)**
-- **[How does backup utilities differ from a High Availability replica?](#how-does-backup-utilities-differ-from-an-ha-high-availability-replica)**
+- **[How does backup utilities differ from a High Availability replica?](#how-does-backup-utilities-differ-from-a-high-availability-replica)**
 - **[Support](#support)**
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository includes backup and recovery utilities for [GitHub Enterprise][1
 - **[Using the backup and restore commands](#using-the-backup-and-restore-commands)**
 - **[Scheduling backups](#scheduling-backups)**
 - **[Backup snapshot file structure](#backup-snapshot-file-structure)**
-- **[How does backup utilities differ from a High Availability replica?](#how-does-backup-utilities-differ-from-an-ha-high-availability-replica)
+- **[How does backup utilities differ from a High Availability replica?](#how-does-backup-utilities-differ-from-an-ha-high-availability-replica)**
 - **[Support](#support)**
 
 ### Features


### PR DESCRIPTION
Fixes the rendering and link for the "How does backup utilities differ from a High Availability replica?" link.