### PR TITLE
Update S3 backup script

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -26,3 +26,7 @@ GHE_NUM_SNAPSHOTS=10
 # Any extra options passed to the SSH command.  Nothing required by default
 #
 #GHE_EXTRA_SSH_OPTS=""
+
+# Add s3 bucket for configuring which bucket to use in ghe-s3-backup and
+# ghe-s3-restore
+# GHE_S3_BUCKET=""

--- a/share/github-backup-utils/ghe-s3-backup
+++ b/share/github-backup-utils/ghe-s3-backup
@@ -22,5 +22,4 @@ ghe-backup
 s3cmd mb s3://$GHE_S3_BUCKET
 
 # Upload to S3.
-cd "$GHE_DATA_DIR"/current
-s3cmd sync --delete-removed --follow-symlinks * s3://$GHE_S3_BUCKET
+s3cmd sync --delete-removed --follow-symlinks "$GHE_DATA_DIR"/current/ s3://$GHE_S3_BUCKET

--- a/share/github-backup-utils/ghe-s3-backup
+++ b/share/github-backup-utils/ghe-s3-backup
@@ -23,4 +23,4 @@ s3cmd mb s3://$GHE_S3_BUCKET
 
 # Upload to S3.
 cd "$GHE_DATA_DIR"/current
-s3cmd --preserve put * s3://$GHE_S3_BUCKET
+s3cmd sync --delete-removed --follow-symlinks * s3://$GHE_S3_BUCKET

--- a/share/github-backup-utils/ghe-s3-backup
+++ b/share/github-backup-utils/ghe-s3-backup
@@ -22,4 +22,4 @@ ghe-backup
 s3cmd mb s3://$GHE_S3_BUCKET
 
 # Upload to S3.
-s3cmd sync --delete-removed --follow-symlinks "$GHE_DATA_DIR"/current/ s3://$GHE_S3_BUCKET
+s3cmd sync --delete-removed "$GHE_DATA_DIR"/current/ s3://$GHE_S3_BUCKET

--- a/share/github-backup-utils/ghe-s3-backup
+++ b/share/github-backup-utils/ghe-s3-backup
@@ -22,4 +22,5 @@ ghe-backup
 s3cmd mb s3://$GHE_S3_BUCKET
 
 # Upload to S3.
+# --delete-removed is to delete items in s3 that have been removed on the host
 s3cmd sync --delete-removed "$GHE_DATA_DIR"/current/ s3://$GHE_S3_BUCKET


### PR DESCRIPTION
It seems like the S3 backup script needs some :heart: (see #92, #148 and #149)

Using s3cmd's "sync" seems like a good place to start. By default an md5 checksum and file size of each file is compared, and anything that has changed in the specified directory will be transferred to S3. Using the "--delete-removed" flag will keep the S3 backup mirroring the number of backups currently created and kept by backup-utils. Removing this flag will keep a full backup history in S3.