### PR TITLE
Add explicit instruction about adding backup host SSH key to target for `ghe-restore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ After the initial backup, use the following commands:
  - The `ghe-backup` command creates incremental snapshots of repository data,
    along with full snapshots of all other pertinent data stores.
  - The `ghe-restore` command restores snapshots to the same or separate GitHub
-   Enterprise appliance. You must add the backup host's SSH key to the target GitHub Enterprise appliance before using this command.
+   Enterprise appliance. You must add the backup host's SSH key to the target
+    GitHub Enterprise appliance before using this command.
 
 ##### Example backup and restore usage
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ After the initial backup, use the following commands:
  - The `ghe-backup` command creates incremental snapshots of repository data,
    along with full snapshots of all other pertinent data stores.
  - The `ghe-restore` command restores snapshots to the same or separate GitHub
-   Enterprise appliance.
+   Enterprise appliance. You must add the backup host's SSH key to the target GitHub Enterprise appliance before using this command.
 
 ##### Example backup and restore usage
 


### PR DESCRIPTION
I received customer feedback that this was not explicit in the backup procedures and it caused some confusion during a test restore. Would :heart: to save future customers the same confusion when they are getting started.

Thanks!