### PR TITLE
add GHE_EXTRA_RSYNC_OPTS variable for backup.config

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -27,6 +27,10 @@ GHE_NUM_SNAPSHOTS=10
 #
 #GHE_EXTRA_SSH_OPTS=""
 
+# Any extra options passed to the rsync command. Nothing required by default
+#
+#GHE_EXTRA_RSYNC_OPTS=""
+
 # Add s3 bucket for configuring which bucket to use in ghe-s3-backup and
 # ghe-s3-restore
 # GHE_S3_BUCKET=""

--- a/share/github-backup-utils/ghe-rsync
+++ b/share/github-backup-utils/ghe-rsync
@@ -7,11 +7,15 @@
 
 set -o pipefail
 
+# Bring in the backup configuration
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
+
 # Filter vanished file warnings from both stdout (rsync versions < 3.x) and
 # stderr (rsync versions >= 3.x). The complex redirections are necessary to
 # filter stderr while also keeping stdout and stderr separated.
 IGNOREOUT='^(file has vanished: |rsync warning: some files vanished before they could be transferred)'
-(rsync "${@}" 3>&1 1>&2 2>&3 3>&- |
+(rsync $GHE_EXTRA_RSYNC_OPTS "${@}" 3>&1 1>&2 2>&3 3>&- |
   (egrep -v "$IGNOREOUT" || true)) 3>&1 1>&2 2>&3 3>&- |
   (egrep -v "$IGNOREOUT" || true)
 res=$?


### PR DESCRIPTION
add GHE_EXTRA_RSYNC_OPTS variable for backup.config.
To set the extra option to rsync like a GHE_EXTRA_SSH_OPTS.

example:
```
### backup.config
GHE_EXTRA_RSYNC_OPTS="--bwlimit 12500"

### rsync command of ghe-backup
rsync --bwlimit 12500 -av -e ghe-ssh -p 122 --link-dest=../../current/repositories -z --rsync-path=sudo -u git rsync --include-from=- --exclude=* {$GHE_HOSTNAME}:/data/user/repositories/ {$GHE_DATA_DIR}/20160217T113743/repositories
```