### PR TITLE
Update ghe-host-check to detect extra port 22 error

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -37,7 +37,7 @@ set -e
 if [ $rc -ne 0 ]; then
     case $rc in
         255)
-            if echo "$output" | grep -i "port 22: connection refused\|Connection timed out during banner exchange" >/dev/null; then
+            if echo "$output" | grep -i "port 22: connection refused\|port 22: no route to host\|Connection timed out during banner exchange" >/dev/null; then
                 exec "bin/$(basename $0)" "$hostname:122"
             fi
 


### PR DESCRIPTION
In some situations where port 22 is blocked, `ssh` will return a `port 22: No route to host` error instead of a `port 22: Connection refused` error. This PR adds handling to `bin/ghe-host-check` for this alternative error.