### PR TITLE
Fix remote logging output to correctly show snapshot being restored

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -213,10 +213,10 @@ echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $
 
 # Exit non-zero and list the steps that failed.
 if [ -z "$failures" ]; then
-    ghe_remote_logger "Completed backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP successfully."
+    ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP successfully."
 else
     steps="$(echo $failures | sed 's/ /, /g')"
-    ghe_remote_logger "Completed backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP with failures: ${steps}."
+    ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP with failures: ${steps}."
     echo "Error: Snapshot incomplete. Some steps failed: ${steps}. "
     exit 1
 fi

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -94,7 +94,7 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
 fi
 
 # Log backup start message in /var/log/syslog on remote instance
-ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
+ghe_remote_logger "Starting backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
 
 # Determine whether to use the rsync or tarball backup strategy based on the
 # remote appliance version. The tarball strategy must be used with GitHub

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -94,7 +94,7 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
 fi
 
 # Log backup start message in /var/log/syslog on remote instance
-ghe_remote_logger "Starting backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
+ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
 
 # Determine whether to use the rsync or tarball backup strategy based on the
 # remote appliance version. The tarball strategy must be used with GitHub
@@ -213,10 +213,10 @@ echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $
 
 # Exit non-zero and list the steps that failed.
 if [ -z "$failures" ]; then
-    ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP successfully."
+    ghe_remote_logger "Completed backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP successfully."
 else
     steps="$(echo $failures | sed 's/ /, /g')"
-    ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP with failures: ${steps}."
+    ghe_remote_logger "Completed backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP with failures: ${steps}."
     echo "Error: Snapshot incomplete. Some steps failed: ${steps}. "
     exit 1
 fi

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -144,7 +144,7 @@ fi
 
 # Log restore start message locally and in /var/log/syslog on remote instance
 echo "Starting restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
-ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
+ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT ..."
 
 # Update remote restore state file and setup failure trap
 trap "update_restore_status failed" EXIT
@@ -275,7 +275,7 @@ trap "" EXIT
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance
-ghe_remote_logger "Completed restore from $(hostname) / snapshot ${GHE_SNAPSHOT_TIMESTAMP}."
+ghe_remote_logger "Completed restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT successfully."
 
 if ! $cluster; then
   echo "Restoring SSH host keys ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -144,7 +144,7 @@ fi
 
 # Log restore start message locally and in /var/log/syslog on remote instance
 echo "Starting restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
-ghe_remote_logger "Starting restore from $(hostname) in snapshot $GHE_RESTORE_SNAPSHOT ..."
+ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT ..."
 
 # Update remote restore state file and setup failure trap
 trap "update_restore_status failed" EXIT
@@ -275,7 +275,7 @@ trap "" EXIT
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance
-ghe_remote_logger "Completed restore from $(hostname) in snapshot $GHE_RESTORE_SNAPSHOT successfully."
+ghe_remote_logger "Completed restore from $(hostname) / snapshot ${GHE_RESTORE_SNAPSHOT}."
 
 if ! $cluster; then
   echo "Restoring SSH host keys ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -144,7 +144,7 @@ fi
 
 # Log restore start message locally and in /var/log/syslog on remote instance
 echo "Starting restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
-ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT ..."
+ghe_remote_logger "Starting restore from $(hostname) in snapshot $GHE_RESTORE_SNAPSHOT ..."
 
 # Update remote restore state file and setup failure trap
 trap "update_restore_status failed" EXIT
@@ -275,7 +275,7 @@ trap "" EXIT
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance
-ghe_remote_logger "Completed restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT successfully."
+ghe_remote_logger "Completed restore from $(hostname) in snapshot $GHE_RESTORE_SNAPSHOT successfully."
 
 if ! $cluster; then
   echo "Restoring SSH host keys ..."


### PR DESCRIPTION
This small PR fixes the remote logging output so that it correctly shows the snapshot being used for the restore. It currently incorrectly outputs a timestamp of when the restore started rather than that of the snapshot being used.

Also incorporates a couple of minor tweaks to the wording of the remote logging messages to make them consistent.

/cc @github/backup-utils 