### PR TITLE
Ask for index name when using Elasticsearch _cat API

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -147,9 +147,11 @@ else
     failures="$failures redis"
 fi
 
-echo "Backing up audit log ..."
-ghe-backup-es-audit-log ||
-failures="$failures audit-log"
+if [ $GHE_VERSION_MAJOR -ge 2 ]; then
+  echo "Backing up audit log ..."
+  ghe-backup-es-audit-log ||
+  failures="$failures audit-log"
+fi
 
 echo "Backing up hookshot logs ..."
 ghe-backup-es-hookshot ||

--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -19,7 +19,11 @@ ghe_remote_version_required "$host"
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/audit-log"
 
-indices=$(ghe-ssh "$host" 'curl -s "localhost:9201/_cat/indices/audit_log*?h=index"') || true
+if ! indices=$(ghe-ssh "$host" 'curl -s "localhost:9201/_cat/indices/audit_log*?h=index"'); then
+  echo "Error: failed to retrieve audit log indices." 1>&2
+  exit 1
+fi
+
 current_index=audit_log-$(ghe-ssh "$host" 'date +"%Y-%m"')
 
 for index in $indices; do

--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -19,7 +19,13 @@ ghe_remote_version_required "$host"
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/audit-log"
 
-if ! indices=$(ghe-ssh "$host" 'curl -s "localhost:9201/_cat/indices/audit_log*?h=index"'); then
+if [ $GHE_VERSION_MAJOR -ge 2 ] && [ $GHE_VERSION_MINOR -ge 2 ]; then
+  es_port=9201
+else
+  es_port=9200
+fi
+
+if ! indices=$(ghe-ssh "$host" "curl -s \"localhost:$es_port/_cat/indices/audit_log*?h=index"\"); then
   echo "Error: failed to retrieve audit log indices." 1>&2
   exit 1
 fi
@@ -31,6 +37,6 @@ for index in $indices; do
     # Hard link any older indices since they are read only and won't change
     ln $GHE_DATA_DIR/current/audit-log/$index.gz $GHE_SNAPSHOT_DIR/audit-log/$index.gz
   else
-    ghe-ssh "$host" "/usr/local/share/enterprise/ghe-es-dump-json 'http://localhost:9201/$index'" | gzip > $GHE_SNAPSHOT_DIR/audit-log/$index.gz
+    ghe-ssh "$host" "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:$es_port/$index\"" | gzip > $GHE_SNAPSHOT_DIR/audit-log/$index.gz
   fi
 done

--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -19,7 +19,7 @@ ghe_remote_version_required "$host"
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/audit-log"
 
-indices=$(ghe-ssh "$host" 'curl -s "localhost:9201/_cat/indices/audit_log*"' | cut -d ' ' -f 3)
+indices=$(ghe-ssh "$host" 'curl -s "localhost:9201/_cat/indices/audit_log*?h=index"') || true
 current_index=audit_log-$(ghe-ssh "$host" 'date +"%Y-%m"')
 
 for index in $indices; do

--- a/test/bin/curl
+++ b/test/bin/curl
@@ -3,6 +3,11 @@
 # Fake curl command stub for tests.
 set -e
 
+# Return empty list of indexes for ghe-backup-es-audit-log
+if echo "$@" | grep -q '_cat/indices/audit_log\*?h=index$'; then
+  exit 0
+fi
+
 # Write args to stdout
 echo "$@"
 


### PR DESCRIPTION
Elasticsearch 1.2 didn't return the index open/closed state in the `_cat` API response, so `ghe-backup-es-audit-log` would fail to get the index names correctly on GitHub Enterprise 2.2 and earlier. This would result in `ElasticsearchIllegalArgumentException[Malformed scrollId []]` failures during the backup.

Asking specifically for the index name avoids this issue.