### PR TITLE
Prevent multiple restores

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -146,10 +146,6 @@ fi
 echo "Starting restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
 ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT ..."
 
-# Update remote restore state file and setup failure trap
-trap "update_restore_status failed" EXIT
-update_restore_status "restoring"
-
 # Verify the host has been fully configured at least once if when running
 # against v11.10.x appliances and the -c option wasn't specified.
 if [ "$GHE_VERSION_MAJOR" -le 1 ] && ! $restore_settings && ! $instance_configured; then
@@ -167,6 +163,16 @@ if [ "$GHE_VERSION_MAJOR" -le 1 ] && [ "$GHE_BACKUP_STRATEGY" = "rsync" ]; then
         fi
     fi
 fi
+
+# Make sure the appliance doesn't already have a restore underway
+if [ "$GHE_VERSION_MAJOR" -ge 2 ] && ghe-ssh "$GHE_HOSTNAME" -- "sudo grep -q restoring  $GHE_REMOTE_DATA_USER_DIR/common/ghe-restore-status 2>/dev/null"; then
+    echo "Error: $GHE_HOSTNAME already has a restore underway. Aborting." 1>&2
+    exit 1
+fi
+
+# Update remote restore state file and setup failure trap
+trap "update_restore_status failed" EXIT
+update_restore_status "restoring"
 
 # Make sure the GitHub appliance is in maintenance mode.
 if $instance_configured; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -171,7 +171,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ] && ghe-ssh "$GHE_HOSTNAME" -- "sudo grep -q re
 fi
 
 # Update remote restore state file and setup failure trap
-trap "update_restore_status failed" EXIT
+trap "update_restore_status failed" EXIT SIGINT SIGTERM
 update_restore_status "restoring"
 
 # Make sure the GitHub appliance is in maintenance mode.
@@ -277,7 +277,7 @@ fi
 # Update the remote status to "complete". This has to happen before importing
 # ssh host keys because subsequent commands will fail due to the host key
 # changing otherwise.
-trap "" EXIT
+trap "" EXIT SIGINT SIGTERM
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -171,7 +171,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ] && ghe-ssh "$GHE_HOSTNAME" -- "sudo grep -q re
 fi
 
 # Update remote restore state file and setup failure trap
-trap "update_restore_status failed" EXIT 2 15
+trap "update_restore_status failed" EXIT 1 2 3 15
 update_restore_status "restoring"
 
 # Make sure the GitHub appliance is in maintenance mode.
@@ -277,7 +277,7 @@ fi
 # Update the remote status to "complete". This has to happen before importing
 # ssh host keys because subsequent commands will fail due to the host key
 # changing otherwise.
-trap "" EXIT 2 15
+trap "" EXIT 1 2 3 15
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -171,7 +171,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ] && ghe-ssh "$GHE_HOSTNAME" -- "sudo grep -q re
 fi
 
 # Update remote restore state file and setup failure trap
-trap "update_restore_status failed" EXIT 1 2 3 15
+trap "update_restore_status failed" EXIT HUP INT QUIT TERM
 update_restore_status "restoring"
 
 # Make sure the GitHub appliance is in maintenance mode.
@@ -277,7 +277,7 @@ fi
 # Update the remote status to "complete". This has to happen before importing
 # ssh host keys because subsequent commands will fail due to the host key
 # changing otherwise.
-trap "" EXIT 1 2 3 15
+trap "" EXIT HUP INT QUIT TERM
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -171,7 +171,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ] && ghe-ssh "$GHE_HOSTNAME" -- "sudo grep -q re
 fi
 
 # Update remote restore state file and setup failure trap
-trap "update_restore_status failed" EXIT SIGINT SIGTERM
+trap "update_restore_status failed" EXIT 2 15
 update_restore_status "restoring"
 
 # Make sure the GitHub appliance is in maintenance mode.
@@ -277,7 +277,7 @@ fi
 # Update the remote status to "complete". This has to happen before importing
 # ssh host keys because subsequent commands will fail due to the host key
 # changing otherwise.
-trap "" EXIT SIGINT SIGTERM
+trap "" EXIT 2 15
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -410,3 +410,37 @@ begin_test "ghe-restore with tarball strategy"
     echo "$output" | grep -q 'fake ghe-export-repositories data'
 )
 end_test
+
+begin_test "ghe-restore aborts when another restore is underway"
+(
+    set -e
+    # This test is only valid for version 2 and above
+    if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+      rm -rf "$GHE_REMOTE_ROOT_DIR"
+      setup_remote_metadata
+
+      # create file used to determine if instance has been configured.
+      touch "$GHE_REMOTE_ROOT_DIR/etc/github/configured"
+
+      # create file used to determine if instance is in maintenance mode.
+      mkdir -p "$GHE_REMOTE_DATA_DIR/github/current/public/system"
+      touch "$GHE_REMOTE_DATA_DIR/github/current/public/system/maintenance.html"
+
+      # create file to indicate restore is underway
+      echo "restoring" > "$GHE_REMOTE_DATA_USER_DIR/common/ghe-restore-status"
+
+      # set restore host environ var
+      GHE_RESTORE_HOST=127.0.0.1
+      export GHE_RESTORE_HOST
+
+      # run ghe-restore and write output to file for asserting against
+      # this should fail due to the appliance being in an unconfigured state
+      ! ghe-restore -v > "$TRASHDIR/restore-out" 2>&1
+
+      cat $TRASHDIR/restore-out
+
+      # verify that ghe-restore failed due a restore already being underway
+      grep -q -e "already has a restore underway" "$TRASHDIR/restore-out"
+    fi
+)
+end_test


### PR DESCRIPTION
New version of #166 that traps SIGINT, SIGTERM, SIGHUP, and SIGQUIT to ensure that future restores aren't incorrectly blocked by a stale `/data/user/common/ghe-restore-status` file that incorrectly indicates a restore is still in progress.

I would appreciate some advice on how best to handle a cluster scenario... At the moment this PR only checks the host specified as the restore host (either via `GHE_RESTORE_HOST` in the config file, or specified at the command line when running `ghe-restore`). 

This is in part because this is the only place we currently maintain a `/data/user/common/ghe-restore-status` file.

In its current form this will prevent multiple restores in a cluster environment where the same host is specified as the restore host, but not where different hosts are specified that are part of the same cluster. For automated scenarios, which I believe is likely to be the most common scenario where multiple restores run at the same time, I imagine the same host is generally used.

/cc @github/backup-utils @rubiojr 