### PR TITLE
Change to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ storage and must have network connectivity with the GitHub Enterprise appliance.
 ##### Backup host requirements
 
 Backup host software requirements are modest: Linux or other modern Unix
-operating system with [rsync][4] v2.6.4 or newer.
+operating system with bash and [rsync][4] v2.6.4 or newer.
 
 The backup host must be able to establish network connections outbound to the
 GitHub appliance over SSH. TCP port 122 is used to backup GitHub Enterprise 2.0 or newer instances, and TCP port 22 is used for older versions (11.10.34X).
@@ -211,8 +211,8 @@ backup snapshot of all relevant data stores. Repository, Search, and Pages data
 is stored efficiently via hard links.
 
 *Please note* Symlinks must be maintained when archiving backup snapshots.
-Dereferencing or excluding symlinks, or storing the snapshot contents on a 
-filesystem which does not support symlinks will result in operational 
+Dereferencing or excluding symlinks, or storing the snapshot contents on a
+filesystem which does not support symlinks will result in operational
 problems when the data is restored.
 
 The following example shows a snapshot file hierarchy for hourly frequency.

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup [-v]
 #/ Take snapshots of all GitHub Enterprise data, including Git repository data,
 #/ the MySQL database, instance settings, GitHub Pages data, etc.

--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-host-check [<host>]
 #/ Verify connectivity with the GitHub Enterprise host. When no <host> is
 #/ provided, the $GHE_HOSTNAME configured in backup.config is assumed.

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore [-v] [-s <snapshot-id>] [<host>]
 #/ Restores a GitHub instance from local backup snapshots. The <host> is the
 #/ hostname or IP of the GitHub instance. The <host> may be omitted when

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: script/cibuild [--no-package]
 set -e
 

--- a/script/package-deb
+++ b/script/package-deb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: script/package-deb
 # Script to build a deb release package from the current HEAD version.
 # The package version comes from the debian/changelog file so that should

--- a/script/package-tarball
+++ b/script/package-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: script/package-tarball
 # Script to build a tarball release package from the current HEAD version.
 # The package version comes from `git-describe --tags' so the release tag should

--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-alambic-cluster
 #/ Take an online, incremental snapshot of all Alambic Storage data
 #/

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: . ghe-backup-config
 # GitHub Enterprise backup shell configuration.
 #

--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-es-audit-log
 #/ Take a backup of audit logs in ElasticSearch.
 #/

--- a/share/github-backup-utils/ghe-backup-es-hookshot
+++ b/share/github-backup-utils/ghe-backup-es-hookshot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-es-hookshot
 #/ Take a backup of hookshot logs in ElasticSearch.
 #/

--- a/share/github-backup-utils/ghe-backup-es-rsync
+++ b/share/github-backup-utils/ghe-backup-es-rsync
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-es-rsync
 #/ Take an online, incremental snapshot of Elasticsearch indices.
 #/

--- a/share/github-backup-utils/ghe-backup-es-tarball
+++ b/share/github-backup-utils/ghe-backup-es-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-es-tarball
 #/ Take a tarball snapshot of all Elasticsearch data.
 #/

--- a/share/github-backup-utils/ghe-backup-pages-cluster
+++ b/share/github-backup-utils/ghe-backup-pages-cluster
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-pages-cluster
 #/ Take an online, incremental snapshot of all Pages data
 #/

--- a/share/github-backup-utils/ghe-backup-pages-rsync
+++ b/share/github-backup-utils/ghe-backup-pages-rsync
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-pages-rsync
 #/ Take an online, incremental snapshot of all Pages data.
 #/

--- a/share/github-backup-utils/ghe-backup-pages-tarball
+++ b/share/github-backup-utils/ghe-backup-pages-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-pages-tarball
 #/ Take a tarball snapshot of all Pages data.
 #/

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-redis
 #/ Take a snapshot of all Redis data. This is needed because older versions of
 #/ the remote side ghe-export-redis command use a blocking SAVE instead of a

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-redis-cluster
 #/ Take a snapshot of all Redis data. This is needed because older versions of
 #/ the remote side ghe-export-redis command use a blocking SAVE instead of a

--- a/share/github-backup-utils/ghe-backup-repositories-cluster
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-repositories-cluster
 #/ Take an online, incremental snapshot of all Git repository data.
 #/

--- a/share/github-backup-utils/ghe-backup-repositories-rsync
+++ b/share/github-backup-utils/ghe-backup-repositories-rsync
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-repositories-rsync
 #/ Take an online, incremental snapshot of all Git repository data.
 #/

--- a/share/github-backup-utils/ghe-backup-repositories-tarball
+++ b/share/github-backup-utils/ghe-backup-repositories-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-repositories-tarball
 #/ Take a tarball snapshot of all Git repository data.
 #/

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-settings
 #/ Restore settings from a snapshot to the given <host>.
 set -e

--- a/share/github-backup-utils/ghe-backup-userdata
+++ b/share/github-backup-utils/ghe-backup-userdata
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-backup-userdata <dirname>
 #/ Take an online, incremental snapshot of a user data directory. This is used
 #/ for a number of different simple datastores kept under /data/user on the

--- a/share/github-backup-utils/ghe-maintenance-mode-disable
+++ b/share/github-backup-utils/ghe-maintenance-mode-disable
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-maintenance-mode-disable <host>
 #/ Disable maintenance mode on GitHub appliance at <host>. This opens up access
 #/ to the appliance.

--- a/share/github-backup-utils/ghe-maintenance-mode-enable
+++ b/share/github-backup-utils/ghe-maintenance-mode-enable
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-maintenance-mode-enable [-w] <host>
 #/ Enable maintenance mode on GitHub appliance at <host>. This locks down all
 #/ access to the appliance to prevent writes to datastores and waits for all

--- a/share/github-backup-utils/ghe-maintenance-mode-status
+++ b/share/github-backup-utils/ghe-maintenance-mode-status
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-maintenance-mode-status <host>
 #/ Checks the status of maintenance mode on GitHub appliance at <host>.
 set -e

--- a/share/github-backup-utils/ghe-prune-snapshots
+++ b/share/github-backup-utils/ghe-prune-snapshots
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-prune-snapshots
 #/ Keep N latest backup snapshots.
 set -e

--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-es-audit-log
 #/ Take a backup of audit logs in ElasticSearch.
 #/

--- a/share/github-backup-utils/ghe-restore-es-rsync
+++ b/share/github-backup-utils/ghe-restore-es-rsync
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-es-rsync <host>
 #/ Restore an rsync snapshot of all Elasticsearch data to a GitHub instance.
 #/

--- a/share/github-backup-utils/ghe-restore-es-tarball
+++ b/share/github-backup-utils/ghe-restore-es-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-es-tarball <host>
 #/ Restore a tarball snapshot of all ES data to a GitHub instance.
 #/

--- a/share/github-backup-utils/ghe-restore-pages-rsync
+++ b/share/github-backup-utils/ghe-restore-pages-rsync
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-pages-rsync <host>
 #/ Restore an rsync snapshot of all Pages data to a GitHub instance.
 #/

--- a/share/github-backup-utils/ghe-restore-pages-tarball
+++ b/share/github-backup-utils/ghe-restore-pages-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-pages-tarball <host>
 #/ Restore a tarball snapshot of all Pages data to a GitHub instance.
 #/

--- a/share/github-backup-utils/ghe-restore-repositories-rsync
+++ b/share/github-backup-utils/ghe-restore-repositories-rsync
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-repositories-rsync <host>
 #/ Restore an rsync snapshot of all Git repository data to a GitHub instance.
 #/

--- a/share/github-backup-utils/ghe-restore-repositories-tarball
+++ b/share/github-backup-utils/ghe-restore-repositories-tarball
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-repositories-tarball <host>
 #/ Restore a tarball snapshot of all Git repository data to a GitHub instance.
 #/

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-settings <host>
 #/ Restore settings from a snapshot to the given <host>.
 set -e

--- a/share/github-backup-utils/ghe-restore-snapshot-path
+++ b/share/github-backup-utils/ghe-restore-snapshot-path
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-snapshot-path [snapshot]
 #/
 #/ Print the path to the given snapshot. Defaults to current if no argument given.

--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-restore-userdata <dirname> <host>
 #/ Restore a special user data directory via rsync. This is used
 #/ for a number of different simple datastores kept under /data/user on the

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: ghe-ssh [<option>...] <host> [<simple-command>...]
 #/        echo 'set -o pipefail; <complex-command>...' | ghe-ssh [<option>...] <host> /bin/bash
 #/ Helper to ssh into a GitHub instance with the right user and port. The first

--- a/test/bin/chown
+++ b/test/bin/chown
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Fake chown command for tests. Avoids needing to creating special users for
 # utlities that chown on the remote side.
 true

--- a/test/bin/curl
+++ b/test/bin/curl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: curl ...
 # Fake curl command stub for tests.
 set -e

--- a/test/bin/enterprise-configure
+++ b/test/bin/enterprise-configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: enterprise-configure
 # Emulates the remote GitHub enterprise-configure command. Tests use this
 # to assert that the command was executed.

--- a/test/bin/ghe-config-apply
+++ b/test/bin/ghe-config-apply
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: ghe-config-apply
 # Emulates the remote GitHub ghe-config-apply command. Tests use this
 # to assert that the command was executed.

--- a/test/bin/ghe-es-snapshot
+++ b/test/bin/ghe-es-snapshot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: ghe-es-snapshot
 # Emulates the remote GitHub ghe-service-ensure-mysql command. Tests use this
 # to assert that the command was executed.

--- a/test/bin/ghe-fake-export-command
+++ b/test/bin/ghe-fake-export-command
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Emulates a remote GitHub export command. Each of the ghe-export-* utilities
 # that are run on the remote side have corresponding commands in this directory
 # that symlink to this file. The command outputs a simple bit of text including

--- a/test/bin/ghe-fake-import-command
+++ b/test/bin/ghe-fake-import-command
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Emulates a remote GitHub import command. Each of the ghe-import-* utilities
 # that are run on the remote side have corresponding commands in this directory
 # that symlink to this file. The command just gobbles up stdin and writes a

--- a/test/bin/ghe-maintenance
+++ b/test/bin/ghe-maintenance
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Emulates a remote GitHub ghe-maintenance command. Tests use this to assert
 # that a command was executed.
 true

--- a/test/bin/ghe-service-ensure-elasticsearch
+++ b/test/bin/ghe-service-ensure-elasticsearch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: ghe-service-ensure-mysql
 # Emulates the remote GitHub ghe-service-ensure-mysql command. Tests use this
 # to assert that the command was executed.

--- a/test/bin/ghe-service-ensure-mysql
+++ b/test/bin/ghe-service-ensure-mysql
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: ghe-service-ensure-mysql
 # Emulates the remote GitHub ghe-service-ensure-mysql command. Tests use this
 # to assert that the command was executed.

--- a/test/bin/ionice-stub
+++ b/test/bin/ionice-stub
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Fake ionice command for environments that don't support it.
 exec "$@"

--- a/test/bin/python
+++ b/test/bin/python
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: python -c '...'
 # Fake python command stub for tests. Python is used on the remote side
 # only to parse JSON data retreived from the maintenance status API and produce

--- a/test/bin/redis-cli
+++ b/test/bin/redis-cli
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: redis-cli ...
 # Fake redis-cli command stub for tests. The redis-cli utlity is run on the
 # remote side by libexec/ghe-backup-redis to force a background save of redis

--- a/test/bin/ssh
+++ b/test/bin/ssh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: ssh [-o opt=val]... <host> <command>...
 # Fake ssh command that executes <command> locally. This is placed on PATH
 # during tests to fake out a remote host. Both normal ssh invocations and rsync

--- a/test/test-bashisms.sh
+++ b/test/test-bashisms.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # bashisms tests
 
 # Bring in testlib

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-backup-config lib tests
 
 # Bring in testlib

--- a/test/test-ghe-backup-repositories-rsync-nw.sh
+++ b/test/test-ghe-backup-repositories-rsync-nw.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-backup-repositories-rsync-nw command tests
 # uses the net-shard filesystem layout
 

--- a/test/test-ghe-backup-repositories-rsync.sh
+++ b/test/test-ghe-backup-repositories-rsync.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-backup-repositories-rsync command tests
 
 # Bring in testlib

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-backup command tests
 
 # Bring in testlib

--- a/test/test-ghe-host-check.sh
+++ b/test/test-ghe-host-check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-host-check command tests
 
 # Bring in testlib

--- a/test/test-ghe-prune-snapshots.sh
+++ b/test/test-ghe-prune-snapshots.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-prune-snapshots command tests
 
 # Bring in testlib

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-restore command tests
 
 # Bring in testlib

--- a/test/test-ghe-ssh.sh
+++ b/test/test-ghe-ssh.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # ghe-ssh command tests
 
 # Bring in testlib

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: . testlib.sh
 # Simple shell command language test library.
 #


### PR DESCRIPTION
Discussed in #176, this PR changes the shell used by _backup-utils_ from `#!/bin/sh` to `#!/usr/bin/env bash`.

Passes tests but requires extensive testing against a variety of GHE instances before merging.

/cc @github/backup-utils @rubiojr 