### PR TITLE
ghe-host-check: handle ssh_exchange_identification error

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -37,7 +37,7 @@ set -e
 if [ $rc -ne 0 ]; then
     case $rc in
         255)
-            if echo "$output" | grep -i "port 22: connection refused\|port 22: no route to host\|Connection timed out during banner exchange" >/dev/null; then
+            if echo "$output" | grep -i "port 22: connection refused\|port 22: no route to host\|ssh_exchange_identification: Connection closed by remote host\|Connection timed out during banner exchange" >/dev/null; then
                 exec "bin/$(basename $0)" "$hostname:122"
             fi
 


### PR DESCRIPTION
This may also happen when trying to connect to a GHE instance using port
22:

```
ssh_exchange_identification: Connection closed by remote host
```

Handling this error improves port 122 autodetection.

/cc @github/backup-utils 