### PR TITLE
We want rsync to be verbose when using ghe-backup -v

### DIFF
--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -77,7 +77,7 @@ for hostname in $hostnames; do
   echo "* Transferring storage files ..." 1>&3
 
   # Transfer all data from the user data directory using rsync.
-  ghe-rsync -az \
+  ghe-rsync -avz \
       -e "ssh -q $opts -p 122 -F $config_file -l $user" \
       --rsync-path='sudo -u git rsync' \
       $link_dest \

--- a/share/github-backup-utils/ghe-backup-pages-cluster
+++ b/share/github-backup-utils/ghe-backup-pages-cluster
@@ -77,7 +77,7 @@ for hostname in $hostnames; do
   echo "* Transferring pages files ..." 1>&3
 
   # Transfer all data from the user data directory using rsync.
-  ghe-rsync -az \
+  ghe-rsync -avz \
       -e "ssh -q $opts -p 122 -F $config_file -l $user" \
       --rsync-path='sudo -u git rsync' \
       $link_dest \

--- a/share/github-backup-utils/ghe-backup-repositories-cluster
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster
@@ -161,7 +161,7 @@ rsync_repository_data () {
     host=$(ssh_host_part "$1")
 
     shift
-    ghe-rsync -a \
+    ghe-rsync -av \
         -e "ssh -q $opts -p $port -F $config_file -l $user" \
         $link_dest "$@" \
         --rsync-path='sudo -u git rsync' \


### PR DESCRIPTION
Useful with `ghe-backup -v` and also consistent with other scripts.

/cc @github/backup-utils