### PR TITLE
Quiet dd

### DIFF
--- a/share/github-backup-utils/ghe-backup-store-version
+++ b/share/github-backup-utils/ghe-backup-store-version
@@ -14,5 +14,5 @@ if [ -d .git ]; then
     version_info="$version_info:$ref"
   fi
   echo "$version_info" |
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of=$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of=$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version >/dev/null 2>&1"
 fi


### PR DESCRIPTION
You'll see some noise otherwise:

```
./bin/ghe-backup
Starting backup of ghe.io in snapshot 20160414T140703
Connect ghe.io:122 OK (v2.6.0)
0+1 records in
0+1 records out
47 bytes (47 B) copied, 0.100804 s, 0.5 kB/s
```

/cc @mutle 