### PR TITLE
Check home directory for configuration file

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -44,7 +44,7 @@ GHE_HOSTNAME_PRESERVE="$GHE_HOSTNAME"
 # first and then fall back to the backup-utils root, home directory and system.
 config_found=false
 for f in "$GHE_BACKUP_CONFIG" "$GHE_BACKUP_ROOT/backup.config" \
-  "$HOME/github-backup-utils/backup.config" "/etc/github-backup-utils/backup.config"; do
+  "$HOME/.github-backup-utils/backup.config" "/etc/github-backup-utils/backup.config"; do
     if [ -f "$f" ]; then
         GHE_BACKUP_CONFIG="$f"
         . "$GHE_BACKUP_CONFIG"
@@ -58,7 +58,7 @@ if ! $config_found; then
     echo "Error: No backup configuration file found. Tried:" 1>&2
     [ -n "$GHE_BACKUP_CONFIG" ] && echo " - $GHE_BACKUP_CONFIG" 1>&2
     echo " - $GHE_BACKUP_ROOT/backup.config" 1>&2
-    echo " - $HOME/github-backup-utils/backup.config" 1>&2
+    echo " - $HOME/.github-backup-utils/backup.config" 1>&2
     echo " - /etc/github-backup-utils/backup.config" 1>&2
     exit 2
 fi

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -59,6 +59,7 @@ done
 if ! $config_found; then
     echo "Error: No backup configuration file found. Tried:" 1>&2
     echo " - $GHE_BACKUP_CONFIG" 1>&2
+    echo " - $HOME/github-backup-utils/backup.config" 1>&2
     echo " - /etc/github-backup-utils/backup.config" 1>&2
     exit 2
 fi

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -21,9 +21,6 @@ BACKUP_UTILS_VERSION="$(cat share/github-backup-utils/version)"
 # Add the bin and share/github-backup-utils dirs to PATH
 PATH="$GHE_BACKUP_ROOT/bin:$GHE_BACKUP_ROOT/share/github-backup-utils:$PATH"
 
-# The backup config file. This may be set in the environment.
-: ${GHE_BACKUP_CONFIG:="$GHE_BACKUP_ROOT/backup.config"}
-
 # Parse out -v (verbose) argument
 if [ "$1" = "-v" ]; then
     GHE_VERBOSE=true
@@ -43,10 +40,11 @@ fi
 # backup.config value when set.
 GHE_HOSTNAME_PRESERVE="$GHE_HOSTNAME"
 
-# Source in the backup config file from the local working copy location first
-# and then falling back to the system location.
+# Source in the backup config file from the copy specified in the environment
+# first and then fall back to the backup-utils root, home directory and system.
 config_found=false
-for f in "$GHE_BACKUP_CONFIG" "$HOME/github-backup-utils/backup.config" "/etc/github-backup-utils/backup.config"; do
+for f in "$GHE_BACKUP_CONFIG" "$GHE_BACKUP_ROOT/backup.config" \
+  "$HOME/github-backup-utils/backup.config" "/etc/github-backup-utils/backup.config"; do
     if [ -f "$f" ]; then
         GHE_BACKUP_CONFIG="$f"
         . "$GHE_BACKUP_CONFIG"
@@ -58,7 +56,8 @@ done
 # Check that the config file exists before we source it in.
 if ! $config_found; then
     echo "Error: No backup configuration file found. Tried:" 1>&2
-    echo " - $GHE_BACKUP_CONFIG" 1>&2
+    [ -n "$GHE_BACKUP_CONFIG" ] && echo " - $GHE_BACKUP_CONFIG" 1>&2
+    echo " - $GHE_BACKUP_ROOT/backup.config" 1>&2
     echo " - $HOME/github-backup-utils/backup.config" 1>&2
     echo " - /etc/github-backup-utils/backup.config" 1>&2
     exit 2

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -46,7 +46,7 @@ GHE_HOSTNAME_PRESERVE="$GHE_HOSTNAME"
 # Source in the backup config file from the local working copy location first
 # and then falling back to the system location.
 config_found=false
-for f in "$GHE_BACKUP_CONFIG" "/etc/github-backup-utils/backup.config"; do
+for f in "$GHE_BACKUP_CONFIG" "$HOME/github-backup-utils/backup.config" "/etc/github-backup-utils/backup.config"; do
     if [ -f "$f" ]; then
         GHE_BACKUP_CONFIG="$f"
         . "$GHE_BACKUP_CONFIG"


### PR DESCRIPTION
Adds an extra supported location for the backup config.

backup-utils will attempt to load the backup configuration from the following locations, in this order:

1. `$GHE_BACKUP_CONFIG` (User configurable)
2. `$GHE_BACKUP_ROOT/backup.config` (Root directory of backup-utils install)
3. `$HOME/github-backup-utils/backup.config` (New)
4. `/etc/github-backup-utils/backup.config`

This is useful for situations where the user running backup-utils does not have write access to the install location or `/etc`, and does not wish to set an environment variable. Users of the Debian package are the main target audience for this PR.

/cc @github/backup-utils 