### PR TITLE
Revert "Don't change working directory when loading in ghe-backup-config"

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -8,7 +8,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+cd $(dirname "$0")/..
+. share/github-backup-utils/ghe-backup-config
 
 # Used to record failed backup steps
 failures=

--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -4,8 +4,9 @@
 #/ provided, the $GHE_HOSTNAME configured in backup.config is assumed.
 set -e
 
-# Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+# Bring in the backup configuration.
+cd $(dirname "$0")/..
+. share/github-backup-utils/ghe-backup-config
 
 # Use the host provided on the command line if provided, or fallback on the
 # $GHE_HOSTNAME configured in backup.config when not present.
@@ -37,7 +38,7 @@ if [ $rc -ne 0 ]; then
     case $rc in
         255)
             if echo "$output" | grep -i "port 22: connection refused\|port 22: no route to host\|ssh_exchange_identification: Connection closed by remote host\|Connection timed out during banner exchange" >/dev/null; then
-                exec "$(basename $0)" "$hostname:122"
+                exec "bin/$(basename $0)" "$hostname:122"
             fi
 
             echo "$output" 1>&2
@@ -50,7 +51,7 @@ if [ $rc -ne 0 ]; then
             ;;
         1)
             if [ "${port:-22}" -eq 22 ] && echo "$output" | grep "use port 122" >/dev/null; then
-                exec "$(basename $0)" "$hostname:122"
+                exec "bin/$(basename $0)" "$hostname:122"
             else
                 echo "$output" 1>&2
             fi

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -21,8 +21,9 @@
 #/ <https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access>
 set -e
 
-# Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+# Bring in the backup configuration.
+cd $(dirname "$0")/..
+. share/github-backup-utils/ghe-backup-config
 
 # Parse arguments
 restore_settings=false

--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Set up remote host and root backup snapshot directory based on config
 host="$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -5,20 +5,18 @@
 # This file is sourced by the various utilities under bin and share/github-backup-utils to
 # load in backup configuration and ensure things are configured properly.
 #
-# All commands in share/github-backup-utils/ should start with the following:
+# All commands should start with the following:
 #
-#     . $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
-#
-# And all commands in bin/ should start with the following:
-#
-#     . $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+#     cd $(dirname "$0")/../..
+#     . share/github-backup-utils/ghe-backup-config
 #
 
-# Assume this script lives in share/github-backup-utils/ when setting the root
-GHE_BACKUP_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+# Assume the current directory is the root. This should be fine so long as all
+# scripts source us in according to the instructions above.
+GHE_BACKUP_ROOT="$(pwd)"
 
 # Get the version from the version file.
-BACKUP_UTILS_VERSION="$(cat $GHE_BACKUP_ROOT/share/github-backup-utils/version)"
+BACKUP_UTILS_VERSION="$(cat share/github-backup-utils/version)"
 
 # Add the bin and share/github-backup-utils dirs to PATH
 PATH="$GHE_BACKUP_ROOT/bin:$GHE_BACKUP_ROOT/share/github-backup-utils:$PATH"

--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Set up remote host and root elastic backup directory based on config
 host="$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-es-hookshot
+++ b/share/github-backup-utils/ghe-backup-es-hookshot
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Set up remote host and root elastic backup directory based on config
 host="$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-es-rsync
+++ b/share/github-backup-utils/ghe-backup-es-rsync
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Set up remote host and root elastic backup directory based on config
 host="$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-es-tarball
+++ b/share/github-backup-utils/ghe-backup-es-tarball
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Snapshot all Elasticsearch data or fake it when no /data/elasticsearch
 # directory exists.

--- a/share/github-backup-utils/ghe-backup-pages-cluster
+++ b/share/github-backup-utils/ghe-backup-pages-cluster
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Set up remote host and root backup snapshot directory based on config
 host="$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-pages-rsync
+++ b/share/github-backup-utils/ghe-backup-pages-rsync
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/pages"

--- a/share/github-backup-utils/ghe-backup-pages-tarball
+++ b/share/github-backup-utils/ghe-backup-pages-tarball
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Snapshot all Pages data or fake it when no /data/pages directory exists.
 echo '

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -9,7 +9,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -9,7 +9,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-repositories-cluster
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster
@@ -32,7 +32,8 @@ set -e
 #      <http://rsync.samba.org/ftp/rsync/rsync.html>
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")

--- a/share/github-backup-utils/ghe-backup-repositories-rsync
+++ b/share/github-backup-utils/ghe-backup-repositories-rsync
@@ -32,7 +32,8 @@ set -e
 #      <http://rsync.samba.org/ftp/rsync/rsync.html>
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Set up remote host and root backup snapshot directory based on config
 host="$GHE_HOSTNAME"

--- a/share/github-backup-utils/ghe-backup-repositories-tarball
+++ b/share/github-backup-utils/ghe-backup-repositories-tarball
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Snapshot all Git repository data
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-repositories' > "$GHE_SNAPSHOT_DIR"/repositories.tar

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -4,7 +4,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"

--- a/share/github-backup-utils/ghe-backup-store-version
+++ b/share/github-backup-utils/ghe-backup-store-version
@@ -4,11 +4,12 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
-if [ -d $GHE_BACKUP_ROOT/.git ]; then
+if [ -d .git ]; then
   version_info="$BACKUP_UTILS_VERSION"
-  ref=$(git --git-dir=$GHE_BACKUP_ROOT/.git rev-parse HEAD || true)
+  ref=$(git rev-parse HEAD || true)
   if [ -n "$ref" ]; then
     version_info="$version_info:$ref"
   fi

--- a/share/github-backup-utils/ghe-backup-userdata
+++ b/share/github-backup-utils/ghe-backup-userdata
@@ -6,7 +6,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Verify rsync is available.
 if ! rsync --version 1>/dev/null 2>&1; then

--- a/share/github-backup-utils/ghe-gc-disable
+++ b/share/github-backup-utils/ghe-gc-disable
@@ -9,7 +9,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 while true; do
     case "$1" in

--- a/share/github-backup-utils/ghe-gc-enable
+++ b/share/github-backup-utils/ghe-gc-enable
@@ -9,7 +9,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 while true; do
     case "$1" in

--- a/share/github-backup-utils/ghe-maintenance-mode-disable
+++ b/share/github-backup-utils/ghe-maintenance-mode-disable
@@ -5,7 +5,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-maintenance-mode-enable
+++ b/share/github-backup-utils/ghe-maintenance-mode-enable
@@ -6,7 +6,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Parse args
 wait_procs=true

--- a/share/github-backup-utils/ghe-maintenance-mode-status
+++ b/share/github-backup-utils/ghe-maintenance-mode-status
@@ -4,7 +4,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Parse args
 while true; do

--- a/share/github-backup-utils/ghe-prune-snapshots
+++ b/share/github-backup-utils/ghe-prune-snapshots
@@ -4,7 +4,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # First prune all incomplete / failed snapshot directories
 prune_dirs="$(ls -1 "$GHE_DATA_DIR"/[0-9]*/incomplete 2>/dev/null || true)"

--- a/share/github-backup-utils/ghe-restore-alambic-cluster
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ $# -lt 1 ] && print_usage

--- a/share/github-backup-utils/ghe-restore-es-rsync
+++ b/share/github-backup-utils/ghe-restore-es-rsync
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-es-tarball
+++ b/share/github-backup-utils/ghe-restore-es-tarball
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Grab the host arg
 GHE_HOSTNAME="$1"

--- a/share/github-backup-utils/ghe-restore-pages-dpages
+++ b/share/github-backup-utils/ghe-restore-pages-dpages
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-pages-rsync
+++ b/share/github-backup-utils/ghe-restore-pages-rsync
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-pages-tarball
+++ b/share/github-backup-utils/ghe-restore-pages-tarball
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Grab the host arg
 GHE_HOSTNAME="$1"

--- a/share/github-backup-utils/ghe-restore-repositories-dgit
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-repositories-rsync
+++ b/share/github-backup-utils/ghe-restore-repositories-rsync
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-repositories-tarball
+++ b/share/github-backup-utils/ghe-restore-repositories-tarball
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Grab the host arg
 GHE_HOSTNAME="$1"

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -4,7 +4,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage

--- a/share/github-backup-utils/ghe-restore-snapshot-path
+++ b/share/github-backup-utils/ghe-restore-snapshot-path
@@ -6,8 +6,10 @@
 
 set -e
 
-# Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+# Bring in the backup configuration.
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
+
 
 if [ -n "$1" ]; then
   GHE_RESTORE_SNAPSHOT="$(basename "$1")"

--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -6,7 +6,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ $# -lt 2 ] && print_usage

--- a/share/github-backup-utils/ghe-rsync
+++ b/share/github-backup-utils/ghe-rsync
@@ -8,7 +8,8 @@
 set -o pipefail
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 # Filter vanished file warnings from both stdout (rsync versions < 3.x) and
 # stderr (rsync versions >= 3.x). The complex redirections are necessary to

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+cd $(dirname "$0")/../..
+. share/github-backup-utils/ghe-backup-config
 
 opts="$GHE_EXTRA_SSH_OPTS"
 while true; do

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -47,7 +47,7 @@ export GHE_TEST_REMOTE_VERSION
 
 # Source in the backup config and set GHE_REMOTE_XXX variables based on the
 # remote version established above or in the environment.
-. $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+. $ROOTDIR/share/github-backup-utils/ghe-backup-config
 ghe_parse_remote_version "$GHE_TEST_REMOTE_VERSION"
 ghe_remote_version_config "$GHE_TEST_REMOTE_VERSION"
 


### PR DESCRIPTION
Reverts github/backup-utils#190

This may have changed behaviour and it's problematic when `GHE_DATA_DIR` is using a relative path like `data/2.5-backup`. Discovered it while trying to use the new fsck option:

```
rubiojr@enterprise2-dev:~/backup-utils$ ./bin/ghe-backup
Starting backup of 10.0.1.78 in snapshot 20160419T091140
Connect 10.0.1.78:122 OK (v2.6.0)
Backing up GitHub settings ...
Backing up SSH authorized keys ...
Backing up SSH host keys ...
Backing up MySQL database ...
Backing up Redis database ...
Backing up audit log ...
Backing up hookshot logs ...
Backing up Git repositories ...
Backing up GitHub Pages ...
Backing up asset attachments ...
Backing up storage data ...
Backing up hook deliveries ...
Backing up Elasticsearch indices ...
Running git fsck on repos...
Error: data/2.6-storage/20160419T091140 is not a valid snapshot.
Completed backup of 10.0.1.78:122 in snapshot 20160419T091140 at 09:13:13
Error: Snapshot incomplete. Some steps failed: fsck.
````

The snapshot directory is nested multiple times apparently:

```
rubiojr@enterprise2-dev:~/backup-utils$ ls data/2.6-storage/20160419T091140/
authorized-keys.json  data  incomplete  mysql.sql.gz  redis.rdb  ssh-host-keys.tar  strategy  version

rubiojr@enterprise2-dev:~/backup-utils$ ls data/2.6-storage/20160419T091140/data/2.6-storage/20160419T091140/
alambic_assets  data           enterprise.ghl  manage-password+  repositories   storage
audit-log       elasticsearch  hookshot        pages             settings.json

rubiojr@enterprise2-dev:~/backup-utils$ ls data/2.6-storage/20160419T091140/data/2.6-storage/20160419T091140/data/2.6-storage/
```

Setting `GHE_DATA_DIR=data/test` in the config file should be enough to reproduce it.

@snh: reverting for now but wanna take care of this? 