### PR TITLE
Ignore all dpkg-buildpackage generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /backup.config
 /data
 /dist
+dash

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,5 @@
+debhelper-build-stamp
+files
+github-backup-utils.debhelper.log
+github-backup-utils.substvars
+github-backup-utils/


### PR DESCRIPTION
Make sure we have a clean workspace after building the debian package
with 'dpkg-buildpackage'.
