### PR TITLE
clustering: fix git-hooks restore

### DIFF
--- a/share/github-backup-utils/ghe-restore-git-hooks-cluster
+++ b/share/github-backup-utils/ghe-restore-git-hooks-cluster
@@ -63,7 +63,7 @@ if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks" ]; then
     -e "ssh -q $opts -p $port -F $config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks" \
-    "$route:$GHE_REMOTE_DATA_USER_DIR/git-hooks" &
+    "$hostname:$GHE_REMOTE_DATA_USER_DIR/git-hooks" &
   done
 
   for pid in $(jobs -p); do

--- a/share/github-backup-utils/ghe-restore-git-hooks-cluster
+++ b/share/github-backup-utils/ghe-restore-git-hooks-cluster
@@ -59,11 +59,11 @@ trap 'cleanup' INT TERM EXIT
 
 if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks" ]; then
   for hostname in $hostnames; do
-    ghe-rsync -aHR --delete \
+    ghe-rsync -aH --delete \
     -e "ssh -q $opts -p $port -F $config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
-    "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks" \
-    "$hostname:$GHE_REMOTE_DATA_USER_DIR/git-hooks" &
+    "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks/" \
+    "$hostname:$GHE_REMOTE_DATA_USER_DIR/git-hooks/" &
   done
 
   for pid in $(jobs -p); do


### PR DESCRIPTION
Wrong variable name and re-creating the wrong remote directory.

/cc @github/backup-utils