### PR TITLE
Document hard link requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ patterns of the GitHub appliance. We recommend allocating at least 5x the amount
 of storage allocated to the primary GitHub appliance for historical snapshots
 and growth over time.
 
-As Repository, Search, and Pages data is stored efficiently via hard links,
-backup snapshots must be written to a filesystem which supports hard links.
+The backup utilities use [hard links][12] to store data efficiently, so the backup
+snapshots must be written to a filesystem with support for hard links.
 
 ##### GitHub Enterprise version requirements
 
@@ -281,3 +281,4 @@ site setup or recovery, please contact our [Enterprise support team][7] instead.
 [9]: https://enterprise.github.com/help/articles/restoring-enterprise-data
 [10]: https://help.github.com/enterprise/2.0/admin-guide/migrating-to-a-different-platform-or-from-github-enterprise-11-10-34x/
 [11]: https://help.github.com/enterprise/2.0/admin-guide/
+[12]: https://en.wikipedia.org/wiki/Hard_link

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Backup host software requirements are modest: Linux or other modern Unix
 operating system with bash and [rsync][4] v2.6.4 or newer.
 
 The backup host must be able to establish network connections outbound to the
-GitHub appliance over SSH. TCP port 122 is used to backup GitHub Enterprise 2.0 or newer instances, and TCP port 22 is used for older versions (11.10.34X).
+GitHub appliance over SSH. TCP port 122 is used to backup GitHub Enterprise 2.0
+or newer instances, and TCP port 22 is used for older versions (11.10.34X).
 
 ##### Storage requirements
 
@@ -56,6 +57,9 @@ Storage requirements vary based on current Git repository disk usage and growth
 patterns of the GitHub appliance. We recommend allocating at least 5x the amount
 of storage allocated to the primary GitHub appliance for historical snapshots
 and growth over time.
+
+As Repository, Search, and Pages data is stored efficiently via hard links,
+backup snapshots must be written to a filesystem which supports hard links.
 
 ##### GitHub Enterprise version requirements
 


### PR DESCRIPTION
While we do mention hard links later on in the README, we don't currently make it clear that backup snapshots must be written to a filesystem which supports hard links.

/cc @github/backup-utils 