### PR TITLE
Support for systems lacking readlink -m

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -74,9 +74,12 @@ if [ -z "$GHE_HOSTNAME" ]; then
     exit 2
 fi
 
-# Canonicalize the data directory path, basing any relative paths on the
-# backup-utils root.
-GHE_DATA_DIR="$( cd "$GHE_BACKUP_ROOT" && readlink -m "$GHE_DATA_DIR" )"
+# Convert the data directory path to an absolute path, basing any relative
+# paths on the backup-utils root, and using readlink, if available, to
+# canonicalize the path.
+if [ ${GHE_DATA_DIR:0:1} != "/" ]; then
+  GHE_DATA_DIR="$( cd "$GHE_BACKUP_ROOT" && readlink -m "$GHE_DATA_DIR" 2> /dev/null || echo "$GHE_BACKUP_ROOT/$GHE_DATA_DIR" )"
+fi
 
 GHE_CREATE_DATA_DIR=${GHE_CREATE_DATA_DIR:-yes}
 


### PR DESCRIPTION
Fixes #205, by falling back to a simplistic approach where `readlink -m` isn't available.

I investigated a number of other options, but our need to handle a path that may not yet exist caused most of them to be unsuitable.

/cc @github/backup-utils 