### PR TITLE
Log git-hooks restores for cluster

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -240,6 +240,8 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-authorized-keys' < "$GHE_RESTORE_SNAPSHOT
 if $cluster; then
   echo "Restoring storage data ..."
   ghe-restore-alambic-cluster "$GHE_HOSTNAME" 1>&3
+  
+  echo "Restoring custom Git hooks ..."
   ghe-restore-git-hooks-cluster "$GHE_HOSTNAME" 1>&3
 elif [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
   echo "Restoring asset attachments ..."


### PR DESCRIPTION
Minor, cosmetic issue but we should also log git-hooks restores for clusters.

/cc @github/backup-utils