### PR TITLE
Added ghe_verbose helper

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -271,3 +271,11 @@ ghe_cluster_online_nodes () {
     role=$1
     echo "ghe-config --get-regexp cluster.*.$role | egrep 'true$' | awk '{ print \$1; }' | awk 'BEGIN { FS=\".\" }; { print \$2 };' | xargs -I{} -n1 bash -c 'if [ \"\$(ghe-config cluster.\$hostname.offline)\" != true ]; then ghe-config cluster.{}.hostname; fi'" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
 }
+
+# Usage: ghe_verbose <message>
+# Log if verbose mode is enabled (GHE_VERBOSE or `-v`).
+ghe_verbose() {
+  if [ -n "$GHE_VERBOSE" ]; then
+    echo "$@" 1>&3
+  fi
+}


### PR DESCRIPTION
Should be used when logging things that will be printed
using `ghe-restore` or `ghe-backup` `--verbose` mode.