### PR TITLE
Fix the way we source ghe-backup-config

### DIFF
--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -8,8 +8,7 @@
 set -e
 
 # Bring in the backup configuration
-cd $(dirname "$0")/../..
-. share/github-backup-utils/ghe-backup-config
+. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage


### PR DESCRIPTION
Use the new way introduced by @snh in https://github.com/github/backup-utils/pull/199