### PR TITLE
Fix the way we source ghe-backup-config

### DIFF
--- a/share/github-backup-utils/ghe-backup-git-hooks-cluster
+++ b/share/github-backup-utils/ghe-backup-git-hooks-cluster
@@ -7,8 +7,7 @@
 set -e
 
 # Bring in the backup configuration
-cd $(dirname "$0")/../..
-. share/github-backup-utils/ghe-backup-config
+. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
 
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")

--- a/share/github-backup-utils/ghe-restore-git-hooks-cluster
+++ b/share/github-backup-utils/ghe-restore-git-hooks-cluster
@@ -7,8 +7,7 @@
 set -e
 
 # Bring in the backup configuration
-cd $(dirname "$0")/../..
-. share/github-backup-utils/ghe-backup-config
+. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
 
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage


### PR DESCRIPTION
My last PR [1] missed these two.

1: https://github.com/github/backup-utils/pull/214

/cc @github/backup-utils