### PR TITLE
Quiet audit-log restores if there are not indices

### DIFF
--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -19,7 +19,7 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 
 last_index=$(ghe-ssh "$GHE_HOSTNAME" 'curl -s "localhost:9201/_cat/indices/audit_log*"' | cut -d ' ' -f 3 | sort | tail -1)
 
-indices=$(ls -1 $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz | xargs -I{} -n1 basename {} .gz)
+indices=$(ls -1 $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz 2>/dev/null | xargs -I{} -n1 basename {} .gz)
 
 for index in $indices; do
   if [ -z "$last_index" ] || ! [ $index \< $last_index ]; then


### PR DESCRIPTION
Harmless but you'll see something like:

```
Restoring GitHub Pages into DPages...
Restoring SSH authorized keys ...
Restoring storage data ...
Restoring custom Git hooks ...
Restoring ElasticSearch Audit logs
ls: cannot access /home/rubiojr/backup-utils/data/26-snap/20160509T101107/audit-log/*.gz: No such file or directory
Configuring cluster ...
Completed restore of 10.0.1.172:122 from snapshot 20160509T101107
```

If there's nothing to restore.