### PR TITLE
Change command line arguments parsing mechanics to allow the GHE_HOST…

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -28,6 +28,9 @@ set -e
 restore_settings=false
 force=false
 while true; do
+    if [ -z "$1" ]; then
+        break;
+    fi
     case "$1" in
         -f|--force)
             force=true
@@ -46,13 +49,12 @@ while true; do
             exit 1
             ;;
         *)
-            break
+            # Grab the host arg
+            GHE_HOSTNAME="${1:-$GHE_RESTORE_HOST}"
+            shift
             ;;
     esac
 done
-
-# Grab the host arg
-GHE_HOSTNAME="${1:-$GHE_RESTORE_HOST}"
 
 # Hostname without any port suffix
 hostname=$(echo "$GHE_HOSTNAME" | cut -f 1 -d :)


### PR DESCRIPTION
…NAME to be in variable position and not at the end of the line

previously:
./ghe-restore -s 20130201T150109 10.0.0.1:122
now possible:
./ghe-restore 10.0.0.1:122 -s 20130201T150109