### PR TITLE
Verbose rsync when restoring gist repositories

### DIFF
--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -82,12 +82,12 @@ done
 
 # rsync all the gist repositories
 for route in $tempdir/*.rsync; do
-  ghe-rsync -arHR --delete \
+  ghe-rsync -avrHR --delete \
     -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
     --files-from=$route \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/./" \
-    "$(basename $route .rsync):$GHE_REMOTE_DATA_USER_DIR/repositories/"
+    "$(basename $route .rsync):$GHE_REMOTE_DATA_USER_DIR/repositories/" 1>&3
 done
 
 cat $to_restore | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/gist-cluster-restore-finalize


### PR DESCRIPTION
The output is sent to fd#3, so only available when using the verbose flag (-v).

This is consistent with the other scripts using rsync and also helpful for
support/troubleshooting.