### PR TITLE
Revert "restore host keys for cluster environment as well"

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -287,10 +287,6 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         ghe-ssh "$GHE_HOSTNAME" -- /bin/sh
 fi
 
-# restore host keys at last step before applying config changes
-echo "Restoring SSH host keys ..."
-ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-ssh-host-keys' < "$GHE_RESTORE_SNAPSHOT_PATH/ssh-host-keys.tar" 1>&3
-
 # When restoring to a host that has already been configured, kick off a
 # config run to perform data migrations.
 if $cluster; then
@@ -314,6 +310,11 @@ update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance
 ghe_remote_logger "Completed restore from $(hostname) / snapshot ${GHE_RESTORE_SNAPSHOT}."
+
+if ! $cluster; then
+  echo "Restoring SSH host keys ..."
+  ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-ssh-host-keys' < "$GHE_RESTORE_SNAPSHOT_PATH/ssh-host-keys.tar" 1>&3
+fi
 
 echo "Completed restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
 


### PR DESCRIPTION
Reverts github/backup-utils#228

Reverting for now, replacing host keys before the last config apply breaks `ghe-restore` and our integration test suite.

@shawnzhu missed this before merging, going to open a new PR with a slightly different fix.