### PR TITLE
Help and Verbose output for commands in bin/

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -7,6 +7,28 @@
 #/ transferred.
 set -e
 
+# If -h or --help are passed into the command prompt, spit out
+# the help documents
+usage() {
+  grep '^#/' < $0 | cut -c4-
+  exit 2
+}
+
+# Depending on the variables passed in, either spit out the help, be more
+# verbose, or just continue
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 2
+      ;;
+    -v|--verbose)
+      set -x
+      ;;
+  esac
+  shift
+done
+
 # Bring in the backup configuration
 . $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
 

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-#/ Usage: ghe-backup [-v]
+#/ Usage: ghe-backup [options]
 #/ Take snapshots of all GitHub Enterprise data, including Git repository data,
 #/ the MySQL database, instance settings, GitHub Pages data, etc.
 #/
 #/ With -v, enable verbose output and show more information about what's being
 #/ transferred.
+#/ OPTIONS:
+#/   -h | --help     Show this message.
+#/   -v | --verbose  Run this script in verbose mode
 set -e
 
 # If -h or --help are passed into the command prompt, spit out

--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -1,8 +1,33 @@
 #!/usr/bin/env bash
-#/ Usage: ghe-host-check [<host>]
+#/ Usage: ghe-host-check [options] <host>
 #/ Verify connectivity with the GitHub Enterprise host. When no <host> is
 #/ provided, the $GHE_HOSTNAME configured in backup.config is assumed.
+#/ OPTIONS:
+#/   -h | --help     Show this message.
+#/   -v | --verbose  Run this script in verbose mode
 set -e
+
+# If -h or --help are passed into the command prompt, spit out
+# the help documents
+usage() {
+  grep '^#/' < $0 | cut -c4-
+  exit 2
+}
+
+# Depending on the variables passed in, either spit out the help, be more
+# verbose, or just continue
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 2
+      ;;
+    -v|--verbose)
+      set -x
+      ;;
+  esac
+  shift
+done
 
 # Bring in the backup configuration
 . $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -14,12 +14,20 @@
 #/   -s <snapshot-id>  Restore from the snapshot with the given id. Available
 #/                     snapshots may be listed under the data directory.
 #/   -v                Enable verbose output.
+#/   -h | --help       Show this message.
 #/
 #/ Note that the host must be reachable and your SSH key must be setup as
 #/ described in the following help article:
 #/
 #/ <https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access>
 set -e
+
+# If -h or --help are passed into the command prompt, spit out
+# the help documents
+usage() {
+  grep '^#/' < $0 | cut -c4-
+  exit 2
+}
 
 # Bring in the backup configuration
 . $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
@@ -32,6 +40,10 @@ while true; do
         -f|--force)
             force=true
             shift
+            ;;
+        -h|--help)
+            usage
+            exit 2
             ;;
         -s)
             snapshot_id="$(basename "$2")"


### PR DESCRIPTION
I noticed while working on another branch that everything in `./bin/` was missing a `-v` or `-h`. This fixes it!

cc @github/backup-utils or putting this on whatever radar you may have!
