### PR TITLE
Remove restoring cluster.conf on restore

### DIFF
--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -51,12 +51,6 @@ if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/manage-password" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-import-passwords"
 fi
 
-if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
-  echo "Restoring cluster configuration ..."
-    cat "$GHE_RESTORE_SNAPSHOT_PATH/cluster.conf" |
-    ghe-ssh "$GHE_HOSTNAME" -- "sudo tee $GHE_REMOTE_CLUSTER_CONF_FILE >/dev/null"
-fi
-
 # Restore SAML keys if present.
 if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/saml-keys.tar" ]; then
     echo "Restoring SAML keys ..."


### PR DESCRIPTION
This breaks restoring in a differently layed out cluster which is explicitly supported.

cc @rubiojr @github/backup-utils 