### PR TITLE
Prevent restoring a cluster snapshot to a standalone GHE appliance

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -105,6 +105,13 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
   restore_settings=false
 fi
 
+# Restoring a cluster backup to a standalone appliance is not supported
+if ! $cluster && [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
+  echo "Error: Snapshot from a GitHub Enterprise cluster cannot be restored" \
+    "to a standalone appliance. Aborting." >&2
+  exit 1
+fi
+
 # Figure out if we're restoring into a cluster with an unsupported snapshot
 if $cluster; then
   snapshot_instance_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -506,7 +506,7 @@ begin_test "ghe-restore cluster backup to non-cluster appliance"
     mkdir -p "$GHE_REMOTE_DATA_USER_DIR/repositories"
 
     echo "cluster" > "$GHE_DATA_DIR/current/strategy"
-    output=$(ghe-restore -v -f localhost 2>&1) || true
+    ! output=$(ghe-restore -v -f localhost 2>&1)
 
     echo $output | grep -q "Snapshot from a GitHub Enterprise cluster cannot be restored"
 )

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -484,3 +484,30 @@ begin_test "ghe-restore with tarball strategy"
     echo "$output" | grep -q 'fake ghe-export-repositories data'
 )
 end_test
+
+begin_test "ghe-restore cluster backup to non-cluster appliance"
+(
+    set -e
+    rm -rf "$GHE_REMOTE_ROOT_DIR"
+    setup_remote_metadata
+
+    # create file used to determine if instance has been configured.
+    if [ "$GHE_VERSION_MAJOR" -le 1 ]; then
+        touch "$GHE_REMOTE_DATA_DIR/enterprise/dna.json"
+    else
+        touch "$GHE_REMOTE_ROOT_DIR/etc/github/configured"
+    fi
+
+    # create file used to determine if instance is in maintenance mode.
+    mkdir -p "$GHE_REMOTE_DATA_DIR/github/current/public/system"
+    touch "$GHE_REMOTE_DATA_DIR/github/current/public/system/maintenance.html"
+
+    # Create fake remote repositories dir
+    mkdir -p "$GHE_REMOTE_DATA_USER_DIR/repositories"
+
+    echo "cluster" > "$GHE_DATA_DIR/current/strategy"
+    output=$(ghe-restore -v -f localhost 2>&1) || true
+
+    echo $output | grep -q "Snapshot from a GitHub Enterprise cluster cannot be restored"
+)
+end_test


### PR DESCRIPTION
This case isn't supported currently, and will fail with a somewhat confusing error message. I've added a check and early exit to make things a bit more clear.

/cc @github/backup-utils 