### PR TITLE
Redirect standard error to standard output in CRON examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ a log file and errors generating an email:
 
     MAILTO=admin@example.com
 
-    0 * * * * /opt/backup-utils/bin/ghe-backup -v 1>>/opt/backup-utils/backup.log
+    0 * * * * /opt/backup-utils/bin/ghe-backup -v 1>>/opt/backup-utils/backup.log 2>&1
 
 To schedule nightly backup snapshots instead, use:
 
     MAILTO=admin@example.com
 
-    0 0 * * * /opt/backup-utils/bin/ghe-backup -v 1>>/opt/backup-utils/backup.log
+    0 0 * * * /opt/backup-utils/bin/ghe-backup -v 1>>/opt/backup-utils/backup.log 2>&1
 
 ### Backup snapshot file structure
 


### PR DESCRIPTION
When using the [CRON examples](https://github.com/github/backup-utils/blob/master/README.md#scheduling-backups) provided in `README.md`, standard errors are not written to the log file. While some of these errors can be identified by running the same command interactively in a Shell, some only occur when run via CRON, making them difficult to troubleshoot.

This PR adds a simple `2>&1` redirection to the examples.

Example log before change:

```
Starting backup of X.X.X.X in snapshot 20160830T004301
```

Example log after change:

```
Starting backup of X.X.X.X in snapshot 20160830T004901
Permission denied (publickey).
Error: ssh connection with 'X.X.X.X' failed
Note that your SSH key needs to be setup on X.X.X.X as described in:
* https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access
```

/cc @github/backup-utils for review