### PR TITLE
Fix offline cluster node detection

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -271,7 +271,7 @@ ghe_remote_logger () {
 # Returns the online nodes with a certain role in cluster
 ghe_cluster_online_nodes () {
     role=$1
-    echo "ghe-config --get-regexp cluster.*.$role | egrep 'true$' | awk '{ print \$1; }' | awk 'BEGIN { FS=\".\" }; { print \$2 };' | xargs -I{} -n1 bash -c 'if [ \"\$(ghe-config cluster.\$hostname.offline)\" != true ]; then ghe-config cluster.{}.hostname; fi'" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+    echo "ghe-config --get-regexp cluster.*.$role | egrep 'true$' | awk '{ print \$1; }' | awk 'BEGIN { FS=\".\" }; { print \$2 };' | xargs -I{} -n1 bash -c 'if [ \"\$(ghe-config cluster.{}.offline)\" != true ]; then ghe-config cluster.{}.hostname; fi'" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
 }
 
 # Usage: ghe_verbose <message>


### PR DESCRIPTION
The _ghe_cluster_online_nodes_ function currently fails to exclude offline nodes. As a consquence, if a cluster node is marked as offline, the backup utilities still attempts to backup from this node, and the backup fails as a result.

This is because of a syntax error in the _xargs_ command:
```
xargs -I{} -n1 bash -c 'if [ \"\$(ghe-config cluster.\$hostname.offline)\" != true ]; then ghe-config cluster.{}.hostname; fi'
```

The correct syntax is:

```
xargs -I{} -n1 bash -c 'if [ \"\$(ghe-config cluster.{}.offline)\" != true ]; then ghe-config cluster.{}.hostname; fi'
```

/cc @github/backup-utils for review