### PR TITLE
Fix macOS/BSD regressions

### DIFF
--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -78,11 +78,7 @@ for tar_file in $ssh_tars; do
     if $(tar -tvf "$tar_file" $key &>/dev/null); then
       tar -C $TEMPDIR -xvf "$tar_file" $key &>/dev/null
       if $sshkeygen_multiple_hash_formats; then
-<<<<<<< HEAD
-        fingerprint=$(ssh-keygen -l -E md5 -f $TEMPDIR/$key | cut -d ' ' -f 2 | cut -f 2- -d ':')
-=======
         fingerprint=$(ssh-keygen -l -E md5 -f $TEMPDIR/$key | cut -d ' ' -f 2 | cut -f2- -d':')
->>>>>>> a3fac8e... add support for macOS Sierra ssh-keygen
       else
         fingerprint=$(ssh-keygen -lf $TEMPDIR/$key | cut -d ' ' -f 2)
       fi

--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -68,7 +68,7 @@ fi
 
 # Store the current backup snapshot folder
 if [ -L "$GHE_DATA_DIR/current" ]; then
-  current_dir=$(readlink -f "$GHE_DATA_DIR/current")
+  current_dir=$(cd "$GHE_DATA_DIR/current"; pwd -P)
 fi
 
 leaked_keys_found=false

--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -47,6 +47,11 @@ if [ -n "$ppid_script" ]; then
   ppid_name=$(basename $ppid_script)
 fi
 
+sshkeygen_multiple_hash_formats=false
+if (ssh-keygen -E 2>&1 | head -1 |  grep -q 'option requires an argument'); then
+  sshkeygen_multiple_hash_formats=true
+fi
+
 # Bring in the backup configuration
 . $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
 

--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -48,7 +48,7 @@ if [ -n "$ppid_script" ]; then
 fi
 
 sshkeygen_multiple_hash_formats=false
-if (ssh-keygen -E 2>&1 | head -1 |  grep -q 'option requires an argument'); then
+if (ssh-keygen --a-dedicated-help-flag-would-be-great 2>&1 | grep 'ssh-keygen -l ' | grep -q -- '-E'); then
   sshkeygen_multiple_hash_formats=true
 fi
 
@@ -78,7 +78,11 @@ for tar_file in $ssh_tars; do
     if $(tar -tvf "$tar_file" $key &>/dev/null); then
       tar -C $TEMPDIR -xvf "$tar_file" $key &>/dev/null
       if $sshkeygen_multiple_hash_formats; then
+<<<<<<< HEAD
         fingerprint=$(ssh-keygen -l -E md5 -f $TEMPDIR/$key | cut -d ' ' -f 2 | cut -f 2- -d ':')
+=======
+        fingerprint=$(ssh-keygen -l -E md5 -f $TEMPDIR/$key | cut -d ' ' -f 2 | cut -f2- -d':')
+>>>>>>> a3fac8e... add support for macOS Sierra ssh-keygen
       else
         fingerprint=$(ssh-keygen -lf $TEMPDIR/$key | cut -d ' ' -f 2)
       fi

--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -13,30 +13,22 @@ set -e
 
 usage() {
   grep '^#/' < "$0" | cut -c 4-
+  exit 2
 }
 
 TEMPDIR=$(mktemp -d)
-
-# Parse args.
-ARGS=$(getopt --name "$0" --long help,snapshot: --options hs -- "$@") || {
-  usage
-  exit 2
-}
-eval set -- $ARGS
 
 while [ $# -gt 0 ]; do
   case "$1" in
     -h|--help)
       usage
-      exit 2
       ;;
     -s|--snapshot)
-      shift 2
-      snapshot=$1
-      ;;
-    --)
+      snapshot=$2
       shift
-      break
+      ;;
+    *)
+      usage
       ;;
   esac
   shift
@@ -61,6 +53,10 @@ keys="ssh_host_dsa_key.pub ssh_host_ecdsa_key.pub ssh_host_ed25519_key.pub ssh_h
 
 # Get all the host ssh keys tar from all snapshots directories
 if [ -n "$snapshot" ]; then
+  if [ ! -d "$snapshot" ]; then
+    echo "Invalid snapshot directory: $snapshot" >&2
+    exit 1
+  fi
   ssh_tars=$(find "$snapshot" -maxdepth 1 -type f -iname 'ssh-host-keys.tar')
 else
   ssh_tars=$(find "$GHE_DATA_DIR" -maxdepth 2 -type f -iname 'ssh-host-keys.tar')

--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -77,7 +77,11 @@ for tar_file in $ssh_tars; do
   for key in $keys; do
     if $(tar -tvf "$tar_file" $key &>/dev/null); then
       tar -C $TEMPDIR -xvf "$tar_file" $key &>/dev/null
-      fingerprint=$(ssh-keygen -lf $TEMPDIR/$key | cut -d ' ' -f 2)
+      if $sshkeygen_multiple_hash_formats; then
+        fingerprint=$(ssh-keygen -l -E md5 -f $TEMPDIR/$key | cut -d ' ' -f 2 | cut -f 2- -d ':')
+      else
+        fingerprint=$(ssh-keygen -lf $TEMPDIR/$key | cut -d ' ' -f 2)
+      fi
       if echo "$fingerprint_blacklist" | grep -q "$fingerprint"; then
         leaked_keys_found=true
         if [ "$current_dir" == $(dirname "$tar_file") ]; then

--- a/test/test-ghe-detect-leaked-ssh-keys.sh
+++ b/test/test-ghe-detect-leaked-ssh-keys.sh
@@ -25,7 +25,7 @@ begin_test "ghe-detect-leaked-ssh-keys check -h dispays help message"
 (
   set -e
 
-  ghe-detect-leaked-ssh-keys -h | grep "--help"
+  ghe-detect-leaked-ssh-keys -h | grep "\-\-help"
 )
 end_test
 


### PR DESCRIPTION
backup-utils 2.7.1 introduced two incompatibilities with OS X.

For one, `readlink -f $path` isn't supported, `cd $path; pwd -P` is an alternative that at least works on Linux and OS X.

Secondly, at least macOS Sierra ships with OpenSSH 7.2 which introduces new semantics for `ssh-keygen -l`:

Debian Jessie:

```
$ ssh -V
OpenSSH_6.7p1 Debian-5+deb8u3, OpenSSL 1.0.1t  3 May 2016
$ ssh-keygen --help 2>&1  | grep -- 'ssh-keygen -l'
       ssh-keygen -l [-f input_keyfile]
$ ssh-keygen -l -f /etc/ssh/ssh_host_dsa_key
1024 52:05:f8:fd:71:f6:9f:3a:12:17:f7:02:65:c2:ac:fa /etc/ssh/ssh_host_dsa_key.pub (DSA)
```

macOS Sierra:

```
$ ssh -V
OpenSSH_7.2p2, LibreSSL 2.4.1
$ ssh-keygen --help 2>&1  | grep -- 'ssh-keygen -l'
       ssh-keygen -l [-v] [-E fingerprint_hash] [-f input_keyfile]
$ ssh-keygen -l -f ssh_host_rsa_key
2048 SHA256:hImpUgI3KSK2ess0yPkN5S/gAuSh4qHNh1P3ZyB4V9Q root@enterprise2-deploy5-cp1-prd.iad.github.net (RSA)
$ ssh-keygen -l -E MD5 -f ssh_host_rsa_key
2048 MD5:d6:ac:83:bd:60:ca:5d:c7:de:28:af:e7:23:6a:32:aa root@enterprise2-deploy5-cp1-prd.iad.github.net (RSA)
```

/cc @terrorobe @github/backup-utils 
