### PR TITLE
Ignore errors from ps

### DIFF
--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-ppid_script=$(ps -o args= $PPID | awk '{print $2}')
+ppid_script=$(ps -o args= $PPID 2>/dev/null | awk '{print $2}')
 if [ -n "$ppid_script" ]; then
   ppid_name=$(basename $ppid_script)
 fi


### PR DESCRIPTION
Some implementations of `ps` lack support for the `-o` option as used by `share/github-backup-utils/ghe-detect-leaked-ssh-keys`. This leads to errors such as the following:

```
$ bin/ghe-backup
Starting backup of XXXXXX in snapshot XXXXXX
Connect XXXXXX:122 OK (v2.7.4)
Backing up GitHub settings ...
Backing up SSH authorized keys ...
Backing up SSH host keys ...
Backing up MySQL database ...
Backing up Redis database ...
Backing up audit log ...
Backing up hookshot logs ...
Backing up Git repositories ...
Backing up GitHub Pages ...
Backing up asset attachments ...
Backing up storage data ...
Backing up hook deliveries ...
Backing up custom Git hooks ...
Backing up Elasticsearch indices ...
Pruning 1 failed snapshot(s) ...
Completed backup of XXXXXX:122 in snapshot XXXXXX at XXXXXX
Checking for leaked ssh keys ...
ps: unknown option -- o
Try `ps --help' for more information.
```

As this `ps` is only used to determine the parent process for purposes of customising the output message, it is safe to ignore this error in the rare instances `-o` support is missing, as a generic output message will be used instead should leaked keys be found.

/cc @github/backup-utils
