### PR TITLE
Add "* No leaked keys found"

### DIFF
--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -124,6 +124,8 @@ if $leaked_keys_found; then
     echo "* (An upgrade may be required)"
     echo
   fi
+else 
+  echo "* No leaked keys found"  
 fi
 
 # Cleanup temp dir


### PR DESCRIPTION
Adds a message if No leaked keys are found.  The current behavior is to just echo **"Checking for leaked ssh keys ..."** and then exit if no leaked keys are found. (https://github.com/github/backup-utils/blob/c299602f863b808e45f1b90e8a4ad632ffb3c7ad/bin/ghe-backup#L261). This can sometimes be confusing if users are expecting output before the backup or restore process exits.