### PR TITLE
Tighten ssh-keygen feature test

### DIFF
--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -40,7 +40,7 @@ if [ -n "$ppid_script" ]; then
 fi
 
 sshkeygen_multiple_hash_formats=false
-if (ssh-keygen --a-dedicated-help-flag-would-be-great 2>&1 | grep 'ssh-keygen -l ' | grep -q -- '-E'); then
+if (ssh-keygen -E 2>&1 | head -1 |  grep -q 'option requires an argument'); then
   sshkeygen_multiple_hash_formats=true
 fi
 


### PR DESCRIPTION
Accidentally reverted in #256 by dbbec580548b6d3f58f96d9977502c5b6045d5ff

Fixes compatibility issue with older versions of OpenSSH's `ssh-keygen` implementation.

/cc @github/backup-utils @terrorobe @jatoben 