### PR TITLE
Fix OS X Travis Builds

### DIFF
--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -19,13 +19,13 @@ begin_test "ghe-backup-config GHE_CREATE_DATA_DIR disabled"
 (
     set -e
 
-    export GHE_DATA_DIR=$(mktemp -d -u)
+    export GHE_DATA_DIR="$TRASHDIR/create-enabled-data"
     . share/github-backup-utils/ghe-backup-config 2>&1 \
       | grep -q "Creating the backup data directory ..."
     test -d $GHE_DATA_DIR
     rm -rf $GHE_DATA_DIR
 
-    export GHE_DATA_DIR=$(mktemp -d -u)
+    export GHE_DATA_DIR="$TRASHDIR/create-disabled-data"
     export GHE_CREATE_DATA_DIR=no
     set +e
     error=$(. share/github-backup-utils/ghe-backup-config 2>&1)

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -66,7 +66,6 @@ atexit () {
     # cleanup injected test key
     shared_path=$(dirname $(which ghe-detect-leaked-ssh-keys))
     sed -i.bak '/98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60/d' "$shared_path/ghe-ssh-leaked-host-keys-list.txt"
-    rm -f "$shared_path/ghe-ssh-leaked-host-keys-list.txt.bak"
 
     [ -z "$KEEPTRASH" ] && rm -rf "$TRASHDIR"
     if [ $failures -gt 0 ]

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -66,6 +66,7 @@ atexit () {
     # cleanup injected test key
     shared_path=$(dirname $(which ghe-detect-leaked-ssh-keys))
     sed -i.bak '/98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60/d' "$shared_path/ghe-ssh-leaked-host-keys-list.txt"
+    rm -f "$shared_path/ghe-ssh-leaked-host-keys-list.txt.bak"
 
     [ -z "$KEEPTRASH" ] && rm -rf "$TRASHDIR"
     if [ $failures -gt 0 ]

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -65,7 +65,8 @@ atexit () {
 
     # cleanup injected test key
     shared_path=$(dirname $(which ghe-detect-leaked-ssh-keys))
-    sed -i '/98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60/d' "$shared_path/ghe-ssh-leaked-host-keys-list.txt"
+    sed -i.bak '/98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60/d' "$shared_path/ghe-ssh-leaked-host-keys-list.txt"
+    rm -f "$shared_path/ghe-ssh-leaked-host-keys-list.txt.bak"
 
     [ -z "$KEEPTRASH" ] && rm -rf "$TRASHDIR"
     if [ $failures -gt 0 ]


### PR DESCRIPTION
The sed command in OS X requires an extension be passed when using the in-place flag. 

While it is possible to specify no extension, the way this is accomplished differs between the implementations.

It is therefore simpler to specify a valid extension, and remove the resulting backup file immediately afterwards.

There has also been some reliability issues involving the use of the `mktemp` `-u` flag on OS X in one of our tests, so this has been replaced with a safer approach.

This should fix the Travis CI OS X test.

/cc @github/backup-utils @jatoben 