### PR TITLE
Fix ghe-backup-config test flakiness

### DIFF
--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -20,8 +20,9 @@ begin_test "ghe-backup-config GHE_CREATE_DATA_DIR disabled"
     set -e
 
     export GHE_DATA_DIR="$TRASHDIR/create-enabled-data"
-    output=$(. share/github-backup-utils/ghe-backup-config 2>&1)
-    echo $output | grep -q "Creating the backup data directory ..."
+    export GHE_VERBOSE=1
+    . share/github-backup-utils/ghe-backup-config |
+      grep -q "Creating the backup data directory ..."
     test -d $GHE_DATA_DIR
     rm -rf $GHE_DATA_DIR
 

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -20,8 +20,8 @@ begin_test "ghe-backup-config GHE_CREATE_DATA_DIR disabled"
     set -e
 
     export GHE_DATA_DIR="$TRASHDIR/create-enabled-data"
-    . share/github-backup-utils/ghe-backup-config 2>&1 \
-      | grep -q "Creating the backup data directory ..."
+    output=$(. share/github-backup-utils/ghe-backup-config 2>&1)
+    echo $output | grep -q "Creating the backup data directory ..."
     test -d $GHE_DATA_DIR
     rm -rf $GHE_DATA_DIR
 


### PR DESCRIPTION
Updates the _ghe-backup-config test_ so that it stores the `ghe-backup-config` output in a variable.

This appears to resolve the flakiness this test experiences on OS X.

/cc @github/backup-utils 
