### PR TITLE
Backup and restore the appliance UUID

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -238,6 +238,13 @@ if ! $cluster; then
   fi
 fi
 
+# Restore UUID if present and not restoring to cluster.
+if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $cluster; then
+  echo "Restoring UUID ..."
+  cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of='$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
+fi
+
 echo "Restoring MySQL database ..."
 bm_start "ghe-import-mysql"
 gzip -dc "$GHE_RESTORE_SNAPSHOT_PATH/mysql.sql.gz" | ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-mysql'

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -51,6 +51,10 @@ if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
     echo "Error: Enterprise Cluster is not configured yet, backup will fail" >&2
     exit 1
   fi
+else
+  if ghe-ssh "$host" -- "sudo cat $GHE_REMOTE_DATA_USER_DIR/common/uuid 2>/dev/null" > uuid; then
+    echo "* Transferring UUID ..." 1>&3
+  fi
 fi
 
 bm_end "$(basename $0)"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -46,6 +46,9 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
 
     mkdir -p "$GHE_REMOTE_DATA_USER_DIR/alambic_assets/github-enterprise-releases/0001"
     touch "$GHE_REMOTE_DATA_USER_DIR/alambic_assets/github-enterprise-releases/0001/1ed78298-522b-11e3-9dc0-22eed1f8132d"
+
+    # Create a fake UUID
+    echo "fake uuid" > "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
 fi
 
 # Create some fake elasticsearch data in the remote data directory
@@ -130,9 +133,7 @@ begin_test "ghe-backup first snapshot"
     # verify manage-password file was backed up under v2.x VMs
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         [ "$(cat "$GHE_DATA_DIR/current/manage-password")" = "fake password hash data" ]
-    fi
 
-    if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         # verify all hookshot user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/hookshot" "$GHE_DATA_DIR/current/hookshot"
 
@@ -147,6 +148,9 @@ begin_test "ghe-backup first snapshot"
 
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/alambic_assets" "$GHE_DATA_DIR/current/alambic_assets"
+
+        # verify the UUID was transferred
+        diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
     fi
 
     # verify that ghe-backup wrote its version information to the host
@@ -213,9 +217,7 @@ begin_test "ghe-backup subsequent snapshot"
     # verify manage-password file was backed up under v2.x VMs
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         [ "$(cat "$GHE_DATA_DIR/current/manage-password")" = "fake password hash data" ]
-    fi
 
-    if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         # verify all hookshot user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/hookshot" "$GHE_DATA_DIR/current/hookshot"
 
@@ -230,6 +232,9 @@ begin_test "ghe-backup subsequent snapshot"
 
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/alambic_assets" "$GHE_DATA_DIR/current/alambic_assets"
+
+        # verify the UUID was transferred
+        diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
     fi
 )
 end_test
@@ -312,9 +317,7 @@ begin_test "ghe-backup with relative data dir path"
     # verify manage-password file was backed up under v2.x VMs
     if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         [ "$(cat "$GHE_DATA_DIR/current/manage-password")" = "fake password hash data" ]
-    fi
 
-    if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
         # verify all hookshot user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/hookshot" "$GHE_DATA_DIR/current/hookshot"
 
@@ -329,6 +332,9 @@ begin_test "ghe-backup with relative data dir path"
 
         # verify all alambic assets user data was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/alambic_assets" "$GHE_DATA_DIR/current/alambic_assets"
+
+        # verify the UUID was transferred
+        diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
     fi
 
     # verify that ghe-backup wrote its version information to the host
@@ -459,8 +465,8 @@ end_test
 
 begin_test "ghe-backup with leaked SSH host key detection for current backup"
 (
-  set -e 
-  
+  set -e
+
   SHARED_UTILS_PATH=$(dirname $(which ghe-detect-leaked-ssh-keys))
   # Inject the fingerprint into the blacklist
   echo 98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60 >> "$SHARED_UTILS_PATH/ghe-ssh-leaked-host-keys-list.txt"


### PR DESCRIPTION
When backing up and restoring GitHub Enterprise 2.8.X, we need to copy the UUID over,
which is located in `/data/user/common/uuid`.

Without this UUID, the appliance will have a different UUID
after the restore, breaking all the existing routes for repositories and leaving
repositories inaccessible after the restore.

No data loss happens. The issue can be easily fixed by manually re-creating the
UUID file after a restore (before re-configuring the appliance), adding the right UUID to it.

This fix is required for customers running GitHub Enterprise 2.8.X (clusters not affected).

It's highly recommended to backup a 2.8.X appliance with backup-utils 2.8.2, that will include
a fix for this.

Customers backing up and restoring older GitHub Enterprise versions are not affected.

/cc @github/backup-utils 