### PR TITLE
Fix pages backups and restores in GitHub Enterprise 11.10

### DIFF
--- a/share/github-backup-utils/ghe-backup-userdata
+++ b/share/github-backup-utils/ghe-backup-userdata
@@ -25,7 +25,11 @@ ghe_remote_version_required "$host"
 
 # Verify that the user data directory exists. Bail out if not, which may be due
 # to an older version of GHE or no data has been added to this directory yet.
-ghe-ssh "$host" -- "sudo -u git [ -d '$GHE_REMOTE_DATA_USER_DIR/$dirname' ]" || exit 0
+if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+  ghe-ssh "$host" -- "sudo -u git [ -d '$GHE_REMOTE_DATA_USER_DIR/$dirname' ]" || exit 0
+else
+  ghe-ssh "$host" -- "[ -d '$GHE_REMOTE_DATA_USER_DIR/$dirname' ]" || exit 0
+fi
 
 # If we have a previous increment and it is not empty, avoid transferring existing files via rsync's
 # --link-dest support. This also decreases physical space usage considerably.

--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -30,12 +30,17 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # us run this script directly.
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
+# Create the remote user data directory
+if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+  ghe-ssh "$host" -- "sudo -u git mkdir -p $GHE_REMOTE_DATA_USER_DIR/$dirname"
+fi
+
 # Transfer data from the latest snapshot to the GitHub instance in a single
 # rsync invocation.
 if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/$dirname" ]; then
   ghe-rsync -avz --delete \
       -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
-      --rsync-path="sudo -u git mkdir -p $GHE_REMOTE_DATA_USER_DIR/$dirname && sudo -u git rsync" \
+      --rsync-path="sudo -u git rsync" \
       "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/$dirname/" \
       "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/$dirname" 1>&3
 fi

--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -30,14 +30,14 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # us run this script directly.
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
-# Create the remote user data directory
-if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
-  ghe-ssh "$host" -- "sudo -u git mkdir -p $GHE_REMOTE_DATA_USER_DIR/$dirname"
-fi
-
 # Transfer data from the latest snapshot to the GitHub instance in a single
 # rsync invocation.
 if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/$dirname" ]; then
+  # Create the remote user data directory
+  if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "sudo -u git mkdir -p $GHE_REMOTE_DATA_USER_DIR/$dirname"
+  fi
+  
   ghe-rsync -avz --delete \
       -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
       --rsync-path="sudo -u git rsync" \


### PR DESCRIPTION
As access to `sudo` as `git` is heavily restricted in 11.10, testing for the existence of the remote user data directory during a backup, and creating the directory upon a restore, fail when attempted using `sudo -u git`.

While `ghe-backup-userdata` and `ghe-restore-userdata` are used for multiple stages in GitHub Enterprise 2, these are only used to backup and restore _Pages_ data in 11.10. As a result, this PR updates:

- The directory test to run as the `admin` user on 11.10 during a backup.
- Skips the directory creation on 11.10 during a restore. As the parent directory (`/data`) already exists, the subsquent `rsync` is able to create `/data/pages` itself.

This was missed by the tests, as we replace `sudo` with a logicless placeholder for testing purposes.

/cc @github/backup-utils