### PR TITLE
Remove redundant hookshot elasticsearch index backups and restores

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -159,11 +159,11 @@ if [ $GHE_VERSION_MAJOR -ge 2 ]; then
   echo "Backing up audit log ..."
   ghe-backup-es-audit-log ||
   failures="$failures audit-log"
-fi
 
-echo "Backing up hookshot logs ..."
-ghe-backup-es-hookshot ||
-failures="$failures hookshot"
+  echo "Backing up hookshot logs ..."
+  ghe-backup-es-hookshot ||
+  failures="$failures hookshot"
+fi
 
 echo "Backing up Git repositories ..."
 if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -322,13 +322,13 @@ fi
 if $cluster; then
   echo "Restoring ElasticSearch Audit logs"
   ghe-restore-es-audit-log "$GHE_HOSTNAME" 1>&3
+
+  echo "Restoring hookshot logs ..."
+  ghe-restore-es-hookshot "$GHE_HOSTNAME" 1>&3
 else
   echo "Restoring Elasticsearch indices ..."
   ghe-restore-es-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 fi
-
-echo "Restoring hookshot logs ..."
-ghe-restore-es-hookshot "$GHE_HOSTNAME" 1>&3
 
 # Restart an already running memcached to reset the cache after restore
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then


### PR DESCRIPTION
When restoring to a non-cluster environment, we don't need to individually restore Elasticsearch based hookshot indices, as these will be included in the overall Elasticsearch restore.

As some housekeeping, also updated the backup process so that `ghe-backup-es-hookshot` is only called during backups of 2.x appliances.

/cc @github/backup-utils 
  