### PR TITLE
Use Trusty for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       script: make test
     - os: linux
       dist: trusty
-      sudo: false
+      sudo: true
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ matrix:
       sudo: false
       addons:
         apt:
-          packages: devscripts
+          packages:
+            - devscripts
+            - debhelper
       script: debuild -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
         - brew install gnu-tar
       script: make test
     - os: linux
+      dist: trusty
       sudo: false
       addons:
         apt:


### PR DESCRIPTION
In #265 we briefly tried Travis's Trusty-based build environment, but [had to revert it](https://github.com/github/backup-utils/pull/265/commits/8fcdedc1efdcd90effed0ca2f0cea1675feae546) because the `devscripts` package wasn't yet available. It is now (cc https://github.com/travis-ci/apt-package-whitelist/issues/3653), so this PR makes the Trusty switch.

/cc @github/backup-utils @snh 