### PR TITLE
Update some bash bangpaths to use /usr/bin/env

### DIFF
--- a/share/github-backup-utils/bm.sh
+++ b/share/github-backup-utils/bm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bm.sh: benchmarking Bash code blocks
 #
 # Example:

--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #/ Usage: ghe-detect-leaked-ssh-key [-s <snapshot-id>]
 #/
 #/ This utility will check each snapshot's existing SSH host keys against the list


### PR DESCRIPTION
There are two files that have their bang paths set to #!/bin/bash. This is not consistent with the rest of the project and also results in these tools failing to work on FreeBSD and other platforms that don't default to bash use.