### PR TITLE
Backup and restore custom CA certificates

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -45,7 +45,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     fi
 fi
 
-if ghe-ssh "$host" -- "which ghe-export-ssl-ca-certificates"; then
+if ghe-ssh "$host" -- "which ghe-export-ssl-ca-certificates 1>/dev/null"; then
   echo "* Transferring CA certificates ..." 1>&3
   ghe-ssh "$host" -- "ghe-export-ssl-ca-certificates" > ssl-ca-certificates.tar
 fi

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -45,7 +45,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     fi
 fi
 
-if ghe-ssh "$host" -- "type ghe-export-ssl-ca-certificates"; then
+if ghe-ssh "$host" -- "which ghe-export-ssl-ca-certificates"; then
   echo "* Transferring CA certificates ..." 1>&3
   ghe-ssh "$host" -- "ghe-export-ssl-ca-certificates" > ssl-ca-certificates.tar
 fi

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -45,6 +45,10 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     fi
 fi
 
+if ghe-ssh "$host" -- "ghe-export-ssl-ca-certificates" > ssl-ca-certificates.tar; then
+  echo "* Transferring CA certificates ..." 1>&3
+fi
+
 if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
   echo "* Transferring cluster configuration ..." 1>&3
   if ! ghe-ssh "$host" -- "sudo cat $GHE_REMOTE_CLUSTER_CONF_FILE 2>/dev/null" > cluster.conf; then

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -45,8 +45,9 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     fi
 fi
 
-if ghe-ssh "$host" -- "ghe-export-ssl-ca-certificates" > ssl-ca-certificates.tar; then
+if ghe-ssh "$host" -- "type ghe-export-ssl-ca-certificates"; then
   echo "* Transferring CA certificates ..." 1>&3
+  ghe-ssh "$host" -- "ghe-export-ssl-ca-certificates" > ssl-ca-certificates.tar
 fi
 
 if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #/ Usage: ghe-backup-settings
-#/ Restore settings from a snapshot to the given <host>.
+#/ Backup settings from a snapshot to the given <host>.
 set -e
 
 # Bring in the backup configuration

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -62,7 +62,7 @@ fi
 if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/ssl-ca-certificates.tar" ]; then
     echo "Restoring CA certificates ..."
     cat "$GHE_RESTORE_SNAPSHOT_PATH/ssl-ca-certificates.tar" |
-    ghe-ssh "$GHE_HOSTNAME" -- "ghe-import-ssl-ca-certificates >/dev/null"
+    ghe-ssh "$GHE_HOSTNAME" -- "ghe-import-ssl-ca-certificates"
 fi
 
 bm_start "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -58,4 +58,11 @@ if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/saml-keys.tar" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "sudo tar -C $GHE_REMOTE_DATA_USER_DIR/common/ -xf -"
 fi
 
+# Restore CA certificates if present.
+if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/ssl-ca-certificates.tar" ]; then
+    echo "Restoring CA certificates ..."
+    cat "$GHE_RESTORE_SNAPSHOT_PATH/ssl-ca-certificates.tar" |
+    ghe-ssh "$GHE_HOSTNAME" -- "ghe-import-ssl-ca-certificates >/dev/null"
+fi
+
 bm_start "$(basename $0)"

--- a/test/bin/ghe-export-ssl-ca-certificates
+++ b/test/bin/ghe-export-ssl-ca-certificates
@@ -1,0 +1,1 @@
+ghe-fake-export-command

--- a/test/bin/ghe-import-ssl-ca-certificates
+++ b/test/bin/ghe-import-ssl-ca-certificates
@@ -1,0 +1,1 @@
+ghe-fake-import-command

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -151,6 +151,9 @@ begin_test "ghe-backup first snapshot"
 
         # verify the UUID was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
+
+        # check that ca certificates were backed up
+        [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]
     fi
 
     # verify that ghe-backup wrote its version information to the host
@@ -235,6 +238,9 @@ begin_test "ghe-backup subsequent snapshot"
 
         # verify the UUID was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
+
+        # check that ca certificates were backed up
+        [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]
     fi
 )
 end_test
@@ -335,6 +341,9 @@ begin_test "ghe-backup with relative data dir path"
 
         # verify the UUID was transferred
         diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
+
+        # check that ca certificates were backed up
+        [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]
     fi
 
     # verify that ghe-backup wrote its version information to the host

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -79,6 +79,7 @@ echo "fake ghe-export-es-indices data" > "$GHE_DATA_DIR/current/elasticsearch.ta
 echo "fake ghe-export-ssh-host-keys data" > "$GHE_DATA_DIR/current/ssh-host-keys.tar"
 echo "fake ghe-export-repositories data" > "$GHE_DATA_DIR/current/repositories.tar"
 echo "fake ghe-export-settings data" > "$GHE_DATA_DIR/current/settings.json"
+echo "fake ghe-export-ssl-ca-certificates data" > "$GHE_DATA_DIR/current/ssl-ca-certificates.tar"
 echo "fake license data" > "$GHE_DATA_DIR/current/enterprise.ghl"
 echo "fake manage password hash data" > "$GHE_DATA_DIR/current/manage-password"
 echo "rsync" > "$GHE_DATA_DIR/current/strategy"
@@ -288,6 +289,9 @@ begin_test "ghe-restore -c into unconfigured vm"
 
         # verify the UUID was transferred
         diff -ru "$GHE_DATA_DIR/current/uuid" "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
+
+        # verify ghe-export-ssl-ca-certificates was run
+        grep -q "fake ghe-export-ssl-ca-certificates data" "$TRASHDIR/restore-out"
     fi
 )
 end_test
@@ -355,6 +359,9 @@ begin_test "ghe-restore into unconfigured vm"
 
         # verify the UUID was transferred
         diff -ru "$GHE_DATA_DIR/current/uuid" "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
+
+        # verify ghe-export-ssl-ca-certificates was run
+        grep -q "fake ghe-export-ssl-ca-certificates data" "$TRASHDIR/restore-out"
 
         # verify no config run after restore on unconfigured instance
         ! grep -q "ghe-config-apply OK" "$TRASHDIR/restore-out"


### PR DESCRIPTION
Using enhancements added in GitHub Enterprise 2.8.0, adds support for the backup and restore of custom CA certificates.

These certificates are only restored if an appliance is unconfigured, or the restore is performed with the `-c` flag.

Requires GitHub Enterprise 2.8.0 or later.

Fixes https://github.com/github/backup-utils/issues/163

/cc @github/backup-utils for review