### PR TITLE
Set the benchmark file path consistently

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -120,6 +120,9 @@ if [ "$GHE_BACKUP_STRATEGY" = "tarball" ]; then
     GHE_MAINTENANCE_MODE_ENABLED=true
 fi
 
+# Create benchmark file
+bm_file_path > /dev/null
+
 ghe-backup-store-version  ||
 echo "Warning: storing backup-utils version remotely failed."
 

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -121,7 +121,7 @@ if [ "$GHE_BACKUP_STRATEGY" = "tarball" ]; then
 fi
 
 # Create benchmark file
-bm_file_path > /dev/null
+bm_init > /dev/null
 
 ghe-backup-store-version  ||
 echo "Warning: storing backup-utils version remotely failed."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -203,7 +203,7 @@ if $instance_configured; then
 fi
 
 # Create benchmark file
-bm_file_path > /dev/null
+bm_init > /dev/null
 
 ghe-backup-store-version  ||
 echo "Warning: storing backup-utils version remotely failed."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -202,6 +202,9 @@ if $instance_configured; then
     fi
 fi
 
+# Create benchmark file
+bm_file_path > /dev/null
+
 ghe-backup-store-version  ||
 echo "Warning: storing backup-utils version remotely failed."
 

--- a/share/github-backup-utils/bm.sh
+++ b/share/github-backup-utils/bm.sh
@@ -17,6 +17,8 @@ bm_desc_to_varname(){
 bm_start()
 {
   eval "$(bm_desc_to_varname $@)_start=$(date +%s)"
+
+  bm_file_path > /dev/null
 }
 
 bm_file_path() {

--- a/share/github-backup-utils/bm.sh
+++ b/share/github-backup-utils/bm.sh
@@ -18,10 +18,10 @@ bm_start()
 {
   eval "$(bm_desc_to_varname $@)_start=$(date +%s)"
 
-  bm_file_path > /dev/null
+  bm_init > /dev/null
 }
 
-bm_file_path() {
+bm_init() {
   if [ -n "$BM_FILE_PATH" ]; then
     echo $BM_FILE_PATH
     return

--- a/share/github-backup-utils/bm.sh
+++ b/share/github-backup-utils/bm.sh
@@ -17,8 +17,6 @@ bm_desc_to_varname(){
 bm_start()
 {
   eval "$(bm_desc_to_varname $@)_start=$(date +%s)"
-
-  bm_file_path > /dev/null
 }
 
 bm_file_path() {


### PR DESCRIPTION
During a restore, the benchmarking functions are first used by [`ghe-backup-store-version`](https://github.com/github/backup-utils/blob/master/share/github-backup-utils/ghe-backup-store-version).

As `$GHE_RESTORE_SNAPSHOT_PATH`, which is not exported, is not available to `ghe-backup-store-version`, and therefore [`bm.sh`](https://github.com/github/backup-utils/blob/master/share/github-backup-utils/bm.sh), the benchmark output for this script is written to it's own file, in a new erroneous snapshot directory.

Exporting `$GHE_RESTORE_SNAPSHOT_PATH` doesn't fully resolve the issue either though, as `$BM_FILE_PATH`, which is set and exported by `bm.sh` and should be consistent across the backup or restore, isn't exported to the other scripts when run from `ghe-backup-store-version`, as it's initially being run within a child script. This then results in multiple benchmark files being written, as the timestamp changes.

This PR updates `ghe-backup` and `ghe-restore` to run `bm_file_path` directly from the parent script, allowing `$BM_FILE_PATH` to be set and exported for use by all benchmarking.

/cc @github/backup-utils for review