### PR TITLE
Check for missing GHE_DATA_DIR variable in config

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -76,6 +76,12 @@ if [ -z "$GHE_HOSTNAME" ]; then
     exit 2
 fi
 
+# Check that the GHE data directory is set.
+if [ -z "$GHE_DATA_DIR" ]; then
+    echo "Error: GHE_DATA_DIR not set in config file." 1>&2
+    exit 2
+fi
+
 # Convert the data directory path to an absolute path, basing any relative
 # paths on the backup-utils root, and using readlink, if available, to
 # canonicalize the path.

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -15,6 +15,19 @@ export GHE_DATA_DIR GHE_REMOTE_DATA_DIR
 cd "$ROOTDIR"
 . "share/github-backup-utils/ghe-backup-config"
 
+begin_test "ghe-backup-config GHE_DATA_DIR defined"
+(
+    set +e
+    GHE_DATA_DIR= error=$(. share/github-backup-utils/ghe-backup-config 2>&1)
+    # should exit 2
+    if [ $? != 2 ]; then
+      exit 1
+    fi
+    set -e
+    echo $error | grep -q "Error: GHE_DATA_DIR not set in config file."
+)
+end_test
+
 begin_test "ghe-backup-config GHE_CREATE_DATA_DIR disabled"
 (
     set -e


### PR DESCRIPTION
```
$ ./bin/ghe-backup
./bin/../share/github-backup-utils/ghe-backup-config: line 82: [: !=: unary operator expected
mkdir: : No such file or directory
```

These errors occur because `GHE_DATA_DIR` is not defined before running`ghe-backup-config`, causing it to throw errors.

```
$ ./share/github-backup-utils/ghe-backup-config
./share/github-backup-utils/ghe-backup-config: line 82: [: !=: unary operator expected
mkdir: : No such file or directory
Error: GHE_DATA_DIR  does not exist.
```

This change adds a test to ensure `GHE_DATA_DIR` is defined, else return an appropriate error.

```
$ ./bin/ghe-backup
Error: GHE_DATA_DIR not set in config file.
$ ./share/github-backup-utils/ghe-backup-config
Error: GHE_DATA_DIR not set in config file.
```