### PR TITLE
Check backup-utils are not being run on GitHub Enterprise host

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -83,6 +83,18 @@ if [ ${GHE_DATA_DIR:0:1} != "/" ]; then
   GHE_DATA_DIR="$( cd "$GHE_BACKUP_ROOT" && readlink -m "$GHE_DATA_DIR" 2> /dev/null || echo "$GHE_BACKUP_ROOT/$GHE_DATA_DIR" )"
 fi
 
+# Assign the Release File path if it hasn't been provided (eg: by test suite)
+: ${GHE_RELEASE_FILE:="/etc/github/enterprise-release"}
+
+# Check that utils are not being run directly on GHE appliance.
+if [ -f "$GHE_RELEASE_FILE" ]; then
+  echo "Error: Backup Utils cannot be run on the GitHub Enterprise host." 1>&2
+  echo "       The backup utilities should be run on a host dedicated to" 1>&2
+  echo "       long-term permanent storage and must have network connectivity" 1>&2
+  echo "       with the GitHub Enterprise appliance." 1>&2
+  exit 1
+fi
+
 GHE_CREATE_DATA_DIR=${GHE_CREATE_DATA_DIR:-yes}
 
 # Check that the data directory is set and create it if it doesn't exist.

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -41,6 +41,26 @@ begin_test "ghe-backup-config GHE_CREATE_DATA_DIR disabled"
 )
 end_test
 
+begin_test "ghe-backup-config run on GHE appliance"
+(
+    set -e
+
+    export GHE_RELEASE_FILE="$TRASHDIR/enterprise-release"
+    touch "$GHE_RELEASE_FILE"
+    set +e
+    error=$(. share/github-backup-utils/ghe-backup-config 2>&1)
+    # should exit 1
+    if [ $? != 1 ]; then
+      exit 1
+    fi
+    set -e
+    echo "$error" | grep -q "Error: Backup Utils cannot be run on the GitHub Enterprise host."
+
+    test -f "$GHE_RELEASE_FILE"
+    rm -rf "$GHE_RELEASE_FILE"
+)
+end_test
+
 begin_test "ghe-backup-config ssh_host_part"
 (
     set -e
@@ -50,7 +70,6 @@ begin_test "ghe-backup-config ssh_host_part"
     [ $(ssh_host_part "git@github.example.com:5000") = "git@github.example.com" ]
 )
 end_test
-
 
 begin_test "ghe-backup-config ssh_port_part"
 (


### PR DESCRIPTION
Customers occasionally configure backup-utils to run on the GitHub Enterprise
host or HA replica. Apart from losing their backup if the appliance is lost,
it leads to running out of disk space issues.

This PR adds a check for this case and returns an informative error to guide the user.

/cc @kathodos @github/backup-utils