### PR TITLE
Do not remove the working copy's .git dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       addons:
         apt:
           packages: devscripts
+      before_script: git fetch --unshallow
       script: debuild -uc -us
     - os: linux
       dist: trusty

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -463,7 +463,7 @@ begin_test "ghe-backup stores version when not run from a clone"
   # Make sure this doesn't exist
   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
 
-  tmpdir=(mktemp -d $TRASHDIR/foo.XXXXXX)
+  tmpdir=$(mktemp -d $TRASHDIR/foo.XXXXXX)
   git clone $ROOTDIR $tmpdir/backup-utils
   cd $tmpdir/backup-utils
   rm -rf .git

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -463,9 +463,12 @@ begin_test "ghe-backup stores version when not run from a clone"
   # Make sure this doesn't exist
   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
 
-  mv "$ROOTDIR/.git" "$ROOTDIR/.gittmp"
-  ghe-backup
-  mv "$ROOTDIR/.gittmp" "$ROOTDIR/.git"
+  tmpdir=$TRASHDIR/ghe-backup-stores-version
+  mkdir $tmpdir
+  git clone $ROOTDIR $tmpdir/backup-utils
+  cd $tmpdir/backup-utils
+  rm -rf .git
+  ./bin/ghe-backup
 
   # verify that ghe-backup wrote its version information to the host
   [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -463,8 +463,7 @@ begin_test "ghe-backup stores version when not run from a clone"
   # Make sure this doesn't exist
   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
 
-  tmpdir=$TRASHDIR/ghe-backup-stores-version-$RANDOM
-  mkdir $tmpdir
+  tmpdir=(mktemp -d $TRASHDIR/foo.XXXXXX)
   git clone $ROOTDIR $tmpdir/backup-utils
   cd $tmpdir/backup-utils
   rm -rf .git

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -463,7 +463,7 @@ begin_test "ghe-backup stores version when not run from a clone"
   # Make sure this doesn't exist
   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
 
-  tmpdir=$TRASHDIR/ghe-backup-stores-version
+  tmpdir=$TRASHDIR/ghe-backup-stores-version-$RANDOM
   mkdir $tmpdir
   git clone $ROOTDIR $tmpdir/backup-utils
   cd $tmpdir/backup-utils


### PR DESCRIPTION
Safer to work on a throw-away dir inside TRASHDIR.

Fixes some test issues we've seen introduced by ebca53e441dbbfef6c63d7ea6f93c971cf68a431.

/cc @github/backup-utils @jatoben 