### PR TITLE
:fire: some cluster backup noise

### DIFF
--- a/share/github-backup-utils/ghe-backup-repositories-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster-ng
@@ -135,7 +135,7 @@ ghe-ssh "$GHE_HOSTNAME" github-env ./bin/dgit-cluster-backup-routes \
 done
 bm_end "$(basename $0) - Calculating Sync Routes"
 
-if ! ls $tempdir/*.rsync 2>/dev/null; then
+if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   echo "Warning: no routes found, skipping repositories backup ..."
   exit 0
 fi


### PR DESCRIPTION
Harmless but noisy.

```
Backing up Git repositories ...
* Using calculated routes method...
/tmp/tmp.2HLa5AiPQV/git-server-1df34f8a-95dd-11e6-9f0e-060d3255d03f.rsync  /tmp/tmp.2HLa5AiPQV/git-server-ba5589aa-95de-11e6-8fe1-023b382555e3.rsync
/tmp/tmp.2HLa5AiPQV/git-server-a43bc744-95dc-11e6-b197-063e1f683c47.rsync
```

Introduced by https://github.com/github/backup-utils/commit/ea61b4e6c3214a832f202d747dcc635e5ba305db

/cc @github/backup-utils