### PR TITLE
Use the rsync backup strategy to backup all ha configurations

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -85,33 +85,13 @@ echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 ghe_remote_version_required
 echo "$GHE_REMOTE_VERSION" > version
 
-# Figure out if we're restoring into cluster
-cluster=false
-if ghe-ssh "$GHE_HOSTNAME" -- \
-  "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/cluster' ]"; then
-  cluster=true
-fi
-
 # Log backup start message in /var/log/syslog on remote instance
 ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
 
-# Determine whether to use the rsync or tarball backup strategy based on the
-# remote appliance version. The tarball strategy must be used with GitHub
-# Enterprise versions prior to 11.10.340 since rsync is not available.
-# The tarball strategy may be forced for newer versions by setting
-# GHE_BACKUP_STRATEGY=tarball in backup.config but this is not recommended.
-: ${GHE_BACKUP_STRATEGY:=rsync}
-if [ $GHE_VERSION_MAJOR -eq 1 -a $GHE_VERSION_PATCH -lt 340 ]; then
-    GHE_BACKUP_STRATEGY="tarball"
-fi
-
-if $cluster; then
-  GHE_BACKUP_STRATEGY="cluster"
-fi
+export GHE_BACKUP_STRATEGY=${GHE_BACKUP_STRATEGY:-$(ghe-backup-strategy)}
 
 # Record the strategy with the snapshot so we will know how to restore.
 echo "$GHE_BACKUP_STRATEGY" > strategy
-export GHE_BACKUP_STRATEGY
 
 # If we're using the tarball backup strategy, put the appliance in maintenance
 # mode and wait for all writing processes to bleed out.
@@ -150,7 +130,7 @@ failures="$failures mysql"
 bm_end "ghe-export-mysql"
 
 echo "Backing up Redis database ..."
-if $cluster; then
+if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
   ghe-backup-redis-cluster > redis.rdb ||
     failures="$failures redis"
 else
@@ -187,7 +167,7 @@ ghe-backup-pages-${GHE_BACKUP_STRATEGY} ||
 failures="$failures pages"
 
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
-    if $cluster; then
+    if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
         echo "Backing up asset attachments ..."
         ghe-backup-alambic-cluster ||
         failures="$failures alambic_assets"
@@ -216,7 +196,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     fi
 fi
 
-if ! $cluster; then
+if [ "$GHE_BACKUP_STRATEGY" != "cluster" ]; then
   echo "Backing up Elasticsearch indices ..."
   ghe-backup-es-${GHE_BACKUP_STRATEGY} ||
   failures="$failures elasticsearch"

--- a/share/github-backup-utils/ghe-backup-strategy
+++ b/share/github-backup-utils/ghe-backup-strategy
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#/ Usage: ghe-backup-strategy
+#/
+#/ Determine the backup strategy that will be used.
+#/
+#/ The tarball strategy must be used with GitHub Enterprise versions prior to
+#/ 11.10.340 since rsync is not available.
+#/
+#/ The rsync strategy should be used for single VMs and all HA configurations.
+#/
+#/ The cluster strategy should be used to backup GHE clusters.
+set -e
+
+# Bring in the backup configuration
+. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+
+if [ $GHE_VERSION_MAJOR -eq 1 -a $GHE_VERSION_PATCH -lt 340 ]; then
+  echo "tarball"
+elif ghe-ssh "$GHE_HOSTNAME" -- \
+  "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/repl-state' ]"; then
+  echo "rsync"
+elif ghe-ssh "$GHE_HOSTNAME" -- \
+  "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/cluster' ]"; then
+  echo "cluster"
+else
+  echo "rsync"
+fi


### PR DESCRIPTION
Ensures that all HA configurations of GitHub Enterprise use the `rsync` backup strategy.

/cc @github/backup-utils 