### PR TITLE
Prevent restores to an appliance in a HA pair

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -115,12 +115,12 @@ if $cluster; then
   fi
 fi
 
-# Figure out if this instance is in a replication pair
-if ghe-ssh "$GHE_HOSTNAME" -- "ghe-repl-status -r 2>/dev/null" \
-  | grep -Eq "replica|primary"; then
-  instance_configured=true
-  echo "WARNING: Restoring to a server with replication enabled interrupts replication."
-  echo "         You will need to reconfigure replication after the restore completes."
+# Figure out if this appliance is in a replication pair
+if ghe-ssh "$GHE_HOSTNAME" -- \
+  "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/repl-state' ]"; then
+  echo "Error: Restoring to an appliance with replication enabled is not supported." >&2
+  echo "       Please teardown replication before restoring." >&2
+  exit 1
 fi
 
 # Prompt to verify the restore host given is correct. Restoring overwrites

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -607,3 +607,24 @@ EOF
   echo $output | grep -q "The snapshot that is being restored contains a leaked SSH host key."
 )
 end_test
+
+begin_test "ghe-restore fails when restore to an active HA pair"
+(
+    set -e
+
+    if [ "$GHE_VERSION_MAJOR" -le 1 ]; then
+      # noop GHE < 2.0, does not support replication
+      exit 0
+    fi
+
+    rm -rf "$GHE_REMOTE_ROOT_DIR"
+    setup_remote_metadata
+
+    echo "rsync" > "$GHE_DATA_DIR/current/strategy"
+    touch "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
+
+    ! output=$(ghe-restore -v -f localhost 2>&1)
+
+    echo $output | grep -q "Error: Restoring to an appliance with replication enabled is not supported."
+)
+end_test


### PR DESCRIPTION
As restoring to an appliance with replication enabled interrupts replication, and can lead to further replication issues, replication should be torn down before restoring.

/cc @github/backup-utils 