### PR TITLE
Solaris 11 fixes and new configuration documentation

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -43,3 +43,9 @@ GHE_NUM_SNAPSHOTS=10
 #
 # WARNING: do not enable this, only useful for debugging/development
 #GHE_BACKUP_FSCK=no
+
+# In some operatingsystems various tools such as gnu are located elsewhere
+# Modify you path here.
+#
+# Set this path on Solaris 11
+#PATH="/usr/gnu/bin:$PATH:/usr/sbin"

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -65,7 +65,7 @@ if [ -f ../in-progress ]; then
   progress=$(cat ../in-progress)
   snapshot=$(echo "$progress" | cut -d ' ' -f 1)
   pid=$(echo "$progress" | cut -d ' ' -f 2)
-  if ! ps -p $pid -o command= | grep ghe-backup; then
+  if ! ps -p $pid -o comm= | grep ghe-backup; then
     # We can safely remove in-progress, ghe-prune-snapshots
     # will clean up the failed backup.
     unlink ../in-progress


### PR DESCRIPTION
I have made two changes to make backup-utils work on Solaris 11.
First change ps command= to ps comm= which is posix compliant.

Second I change the PATH if backup-utils is run on Solaris 11.
We add a path to GNU utils first and /usr/sbin due to unlink residing in /usr/sbin.