### PR TITLE
Track completeness of Elasticsearch JSON dumps

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -34,11 +34,15 @@ fi
 current_index=audit_log-$(ghe-ssh "$host" 'date +"%Y-%m"')
 
 for index in $indices; do
-  if [ -f $GHE_DATA_DIR/current/audit-log/$index.gz -a $index \< $current_index ]; then
-    # Hard link any older indices since they are read only and won't change
+  if [ -f $GHE_DATA_DIR/current/audit-log/$index.gz -a -f $GHE_DATA_DIR/current/audit-log/$index.gz.complete -a $index \< $current_index ]; then
+    # Hard link any older indices that are complete, since these won't change
     ln $GHE_DATA_DIR/current/audit-log/$index.gz $GHE_SNAPSHOT_DIR/audit-log/$index.gz
+    ln $GHE_DATA_DIR/current/audit-log/$index.gz.complete $GHE_SNAPSHOT_DIR/audit-log/$index.gz.complete
   else
     ghe-ssh "$host" "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:$es_port/$index\"" | gzip > $GHE_SNAPSHOT_DIR/audit-log/$index.gz
+    if [ $index \< $current_index ]; then
+      touch $GHE_SNAPSHOT_DIR/audit-log/$index.gz.complete
+    fi
   fi
 done
 

--- a/share/github-backup-utils/ghe-backup-es-hookshot
+++ b/share/github-backup-utils/ghe-backup-es-hookshot
@@ -21,14 +21,19 @@ ghe_remote_version_required "$host"
 mkdir -p "$GHE_SNAPSHOT_DIR/hookshot"
 
 indices=$(ghe-ssh "$host" 'curl -s "localhost:9201/_cat/indices/hookshot-logs-*"' | cut -d ' ' -f 3)
+
 current_index=hookshot-logs-$(ghe-ssh "$host" 'date +"%Y-%m-%d"')
 
 for index in $indices; do
-  if [ -f $GHE_DATA_DIR/current/hookshot/$index.gz -a $index \< $current_index ]; then
-    # Hard link any older indices since they are read only and won't change
+  if [ -f $GHE_DATA_DIR/current/hookshot/$index.gz -a -f $GHE_DATA_DIR/current/hookshot/$index.gz.complete -a $index \< $current_index ]; then
+    # Hard link any older indices that are complete, since these won't change
     ln $GHE_DATA_DIR/current/hookshot/$index.gz $GHE_SNAPSHOT_DIR/hookshot/$index.gz
+    ln $GHE_DATA_DIR/current/hookshot/$index.gz.complete $GHE_SNAPSHOT_DIR/hookshot/$index.gz.complete
   else
-    ghe-ssh "$host" "/usr/local/share/enterprise/ghe-es-dump-json 'http://localhost:9201/$index'" | gzip > $GHE_SNAPSHOT_DIR/hookshot/$index.gz
+    ghe-ssh "$host" "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:9201/$index\"" | gzip > $GHE_SNAPSHOT_DIR/hookshot/$index.gz
+    if [ $index \< $current_index ]; then
+      touch $GHE_SNAPSHOT_DIR/hookshot/$index.gz.complete
+    fi
   fi
 done
 


### PR DESCRIPTION
Resolves an issue that can lead to incomplete JSON dumps of the `audit_log` and `hookshot-logs` Elasticsearch indices.

Take for example Audit Logs, which are stored in an index per month,

During a backup, existing dumps of indexes from previous months are reused by creating a hard-link to them if they exist in the previous snapshot, and not re-transferred. Only the current month is re-transferred on each backup run.

As the dumps for a previous month are likely to have been taken during that month, and not after the month had concluded, these dumps may be incomplete.

This PR updates this logic, so that we will reuse an existing monthly dump only if it was taken after that month has concluded, ensuring it is a complete and final snapshot of the month in question.

The same applies to Hookshot Logs, which are stored in an index per day.

As these dumps are only used when restoring to Cluster, this issue only impacts customers using GitHub Enterprise Cluster at this time. Restores to non-cluster appliances uses a raw Elasticsearch backup which is not impacted by this issue.

cc @github/backup-utils for review.