### PR TITLE
Improve detection of failures in cluster backup rsync threads

### DIFF
--- a/share/github-backup-utils/ghe-backup-repositories-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster-ng
@@ -95,14 +95,14 @@ mkdir -p "$backup_dir"
 # on the remote instance.
 cleanup() {
   for pid in $(jobs -p); do
-    wait $pid
+    kill -KILL $pid > /dev/null 2>&1 || true
   done
 
   # Enable remote GC operations
   for hostname in $hostnames; do
     ghe-gc-enable -F $config_file $hostname:$port
   done
-  
+
   rm -f $config_file
   rm -rf $tempdir
 }

--- a/share/github-backup-utils/ghe-backup-repositories-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster-ng
@@ -94,10 +94,15 @@ mkdir -p "$backup_dir"
 # Removes the remote sync-in-progress file on exit, re-enabling GC operations
 # on the remote instance.
 cleanup() {
+  for pid in $(jobs -p); do
+    wait $pid
+  done
+
   # Enable remote GC operations
   for hostname in $hostnames; do
     ghe-gc-enable -F $config_file $hostname:$port
   done
+  
   rm -f $config_file
   rm -rf $tempdir
 }
@@ -322,7 +327,10 @@ for file_list in $tempdir/*.rsync; do
 
   sync_data $hostname $file_list &
 done
-wait
+
+for pid in $(jobs -p); do
+  wait $pid
+done
 bm_end "$(basename $0) - Repo sync"
 
 # Since there are no routes for special data directories


### PR DESCRIPTION
When performing a repositories backup from a cluster, only the exit code of the last `rsync` thread to exit was being inspected. As a result, if one of the other threads exited non-zero, this was not detected, which could lead to undetected backup failures, and a backup being incorrectly considered successful.

This change ensures that all threads return zero on exit, rather than just the last thread to exit.

/cc @github/backup-utils