### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ site setup or recovery, please contact our [Enterprise support team][7] instead.
 
 [1]: https://enterprise.github.com
 [2]: https://github.com/github/enterprise-backup-site/blob/master/backup.config-example
-[3]: https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access
+[3]: https://help.github.com/articles/connecting-to-github-with-ssh/
 [4]: http://rsync.samba.org/
 [5]: https://enterprise.github.com/download
 [6]: https://enterprise.github.com/help/articles/upgrading-to-a-newer-release


### PR DESCRIPTION
Modify link for `Adding an SSH key for shell access`. The currently listed link (https://help.github.com/enterprise/2.9/admin/guides/installation/administrative-shell-ssh-access/) does little to explain how to generate/find the SSH key. I propose using: https://help.github.com/articles/connecting-to-github-with-ssh/