### PR TITLE
Retry loop for redis-cli BGSAVE

### DIFF
--- a/script/package-deb
+++ b/script/package-deb
@@ -24,7 +24,7 @@ git clone -q . "$distdir"
 cd "$distdir"
 git checkout -q "$PKG_HEAD"
 
-debuild -uc -us 1>&2
+DEB_BUILD_OPTIONS=nocheck debuild -uc -us 1>&2
 cd ..
 files=$(ls -1 *.deb *.tar.gz *.dsc *.changes)
 mv $files ../

--- a/script/package-deb
+++ b/script/package-deb
@@ -24,7 +24,7 @@ git clone -q . "$distdir"
 cd "$distdir"
 git checkout -q "$PKG_HEAD"
 
-DEB_BUILD_OPTIONS=nocheck debuild -uc -us 1>&2
+debuild -uc -us 1>&2
 cd ..
 files=$(ls -1 *.deb *.tar.gz *.dsc *.changes)
 mv $files ../

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -22,13 +22,13 @@ sudo=
 ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
     set -e
     timestamp=\$(redis-cli LASTSAVE)
-    for i in $(seq 10); do
+    for i in \$(seq 10); do
       if ! redis-cli BGSAVE | grep -q ERR; then
         break
       fi
       sleep 15
     done
-    for n in $(seq 240); do
+    for n in \$(seq 240); do
       if [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ]; then
         break
       fi

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -19,12 +19,25 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # Force a redis BGSAVE, and wait for it to complete.
 sudo=
 [ "$GHE_VERSION_MAJOR" -ge 2 ] && sudo="sudo"
-ghe-ssh "$GHE_HOSTNAME" /bin/sh <<EOF
+ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
     set -e
     timestamp=\$(redis-cli LASTSAVE)
-    redis-cli BGSAVE 1>/dev/null
-    while [ \$(redis-cli LASTSAVE) -eq \$timestamp ]; do
-        sleep 1
+    for ((n=0; n<10; n++)); do
+      if redis-cli BGSAVE | grep -q ERR; then
+        sleep 15
+      else
+        break
+      fi
+    done
+    for ((n=0; n<240; n++)); do
+      if [ \$(redis-cli LASTSAVE) -eq \$timestamp ]; then
+          sleep 15
+      else
+        break
+      fi
+      if [ \$n -eq 239 ]; then
+        exit 1
+      fi
     done
     $sudo cat '$GHE_REMOTE_DATA_USER_DIR/redis/dump.rdb'
 EOF

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -22,23 +22,19 @@ sudo=
 ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
     set -e
     timestamp=\$(redis-cli LASTSAVE)
-    for ((n=0; n<10; n++)); do
-      if redis-cli BGSAVE | grep -q ERR; then
-        sleep 15
-      else
+    for i in $(seq 10); do
+      if ! redis-cli BGSAVE | grep -q ERR; then
         break
       fi
+      sleep 15
     done
-    for ((n=0; n<240; n++)); do
-      if [ \$(redis-cli LASTSAVE) -eq \$timestamp ]; then
-          sleep 15
-      else
+    for n in $(seq 240); do
+      if [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ]; then
         break
       fi
-      if [ \$n -eq 239 ]; then
-        exit 1
-      fi
+      sleep 15
     done
+    [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ] # exits 1 if bgsave didn't work
     $sudo cat '$GHE_REMOTE_DATA_USER_DIR/redis/dump.rdb'
 EOF
 

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -29,10 +29,11 @@ ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
       sleep 15
     done
     for n in \$(seq 240); do
+      sleep 1
       if [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ]; then
         break
       fi
-      sleep 15
+      sleep 14
     done
     [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ] # exits 1 if bgsave didn't work
     $sudo cat '$GHE_REMOTE_DATA_USER_DIR/redis/dump.rdb'

--- a/share/github-backup-utils/ghe-backup-redis
+++ b/share/github-backup-utils/ghe-backup-redis
@@ -28,12 +28,11 @@ ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
       fi
       sleep 15
     done
-    for n in \$(seq 240); do
-      sleep 1
+    for n in \$(seq 3600); do
       if [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ]; then
         break
       fi
-      sleep 14
+      sleep 1
     done
     [ "\$(redis-cli LASTSAVE)" != "\$timestamp" ] # exits 1 if bgsave didn't work
     $sudo cat '$GHE_REMOTE_DATA_USER_DIR/redis/dump.rdb'

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -32,10 +32,11 @@ ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
       sleep 15
     done
     for n in \$(seq 240); do
+      sleep 1
       if [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ]; then
         break
       fi
-      sleep 15
+      sleep 14
     done
     [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ] # exits 1 if bgsave didn't work
 

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -31,12 +31,11 @@ ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
       fi
       sleep 15
     done
-    for n in \$(seq 240); do
-      sleep 1
+    for n in \$(seq 3600); do
       if [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ]; then
         break
       fi
-      sleep 14
+      sleep 1
     done
     [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ] # exits 1 if bgsave didn't work
 

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -25,23 +25,19 @@ ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
     redis_host=\$(ghe-config cluster.redis-master 2>/dev/null || echo "localhost")
     timestamp=\$(redis-cli -h \$redis_host LASTSAVE)
 
-    for ((n=0; n<10; n++)); do
-      if redis-cli -h \$redis_host BGSAVE | grep -q ERR; then
-        sleep 15
-      else
+    for i in $(seq 10); do
+      if ! redis-cli -h \$redis_host BGSAVE | grep -q ERR; then
         break
       fi
+      sleep 15
     done
-    for ((n=0; n<240; n++)); do
-      if [ \$(redis-cli -h \$redis_host LASTSAVE) -eq \$timestamp ]; then
-          sleep 15
-      else
+    for n in $(seq 240); do
+      if [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ]; then
         break
       fi
-      if [ \$n -eq 239 ]; then
-        exit 1
-      fi
+      sleep 15
     done
+    [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ] # exits 1 if bgsave didn't work
 
     if [ "\$redis_host" != "localhost" ]; then
       ssh \$redis_host $sudo cat '$GHE_REMOTE_DATA_USER_DIR/redis/dump.rdb'

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -25,13 +25,13 @@ ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
     redis_host=\$(ghe-config cluster.redis-master 2>/dev/null || echo "localhost")
     timestamp=\$(redis-cli -h \$redis_host LASTSAVE)
 
-    for i in $(seq 10); do
+    for i in \$(seq 10); do
       if ! redis-cli -h \$redis_host BGSAVE | grep -q ERR; then
         break
       fi
       sleep 15
     done
-    for n in $(seq 240); do
+    for n in \$(seq 240); do
       if [ "\$(redis-cli -h \$redis_host LASTSAVE)" != "\$timestamp" ]; then
         break
       fi

--- a/share/github-backup-utils/ghe-backup-redis-cluster
+++ b/share/github-backup-utils/ghe-backup-redis-cluster
@@ -19,15 +19,28 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # Force a redis BGSAVE, and wait for it to complete.
 sudo=
 [ "$GHE_VERSION_MAJOR" -ge 2 ] && sudo="sudo"
-ghe-ssh "$GHE_HOSTNAME" /bin/sh <<EOF
+ghe-ssh "$GHE_HOSTNAME" /bin/bash <<EOF
     set -e
 
     redis_host=\$(ghe-config cluster.redis-master 2>/dev/null || echo "localhost")
     timestamp=\$(redis-cli -h \$redis_host LASTSAVE)
-    redis-cli -h \$redis_host BGSAVE 1>/dev/null
 
-    while [ \$(redis-cli -h \$redis_host LASTSAVE) -eq \$timestamp ]; do
-        sleep 1
+    for ((n=0; n<10; n++)); do
+      if redis-cli -h \$redis_host BGSAVE | grep -q ERR; then
+        sleep 15
+      else
+        break
+      fi
+    done
+    for ((n=0; n<240; n++)); do
+      if [ \$(redis-cli -h \$redis_host LASTSAVE) -eq \$timestamp ]; then
+          sleep 15
+      else
+        break
+      fi
+      if [ \$n -eq 239 ]; then
+        exit 1
+      fi
     done
 
     if [ "\$redis_host" != "localhost" ]; then


### PR DESCRIPTION
`ghe-backup-redis` dumps can fail and hang indefinitely if BGSAVE is called while Redis "background rewriting" is happening. In these cases BGSAVE will report an error, but still exit 0. 

This PR adds a `for` loop around the `redis-cli BGSAVE` to retry if BGSAVE reports an `ERR`. I also put the `LASTSAVE` check in a `for` loop that times out after 60 minutes. 

I'm not certain how long the `for` loop `sleep`s should be, but I think 60 minutes is more than enough.