### PR TITLE
Use default niceness for restores

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -13,6 +13,10 @@ set -e
 # Used to record failed backup steps
 failures=
 
+# CPU and IO throttling to keep backups from thrashing around.
+export GHE_NICE=${GHE_NICE:-"nice -n 19"}
+export GHE_IONICE=${GHE_IONICE:-"ionice -c 3"}
+
 # Create the timestamped snapshot directory where files for this run will live,
 # change into it, and mark the snapshot as incomplete by touching the
 # 'incomplete' file. If the backup succeeds, this file will be removed

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -160,10 +160,6 @@ GHE_SNAPSHOT_DIR="$GHE_DATA_DIR"/"$GHE_SNAPSHOT_TIMESTAMP"
 # allows the location to be overridden in tests.
 : ${GHE_REMOTE_METADATA_FILE:="$GHE_REMOTE_DATA_DIR/enterprise/chef_metadata.json"}
 
-# CPU and IO throttling to keep backups and restores from thrashing around.
-: ${GHE_NICE:="nice -n 19"}
-: ${GHE_IONICE:="ionice -c 3"}
-
 # The number of seconds to wait for in progress git-gc processes to complete
 # before starting the sync of git data. See share/github-backup-utils/ghe-backup-repositories-rsync
 # for more information. Default: 10 minutes.


### PR DESCRIPTION
Fixes #307

As restores occur against an appliance in maintenance mode, there is no need to reduce the `nice` and `ionice` priority on processes run on the appliance.

Should these still be needed for a restore, such as to reduce the impact on the backup host during a restore, `GHE_IONICE` and `GHE_NICE` can be defined at the command-line for restores:

```
GHE_NICE="nice -n 19" GHE_IONICE="ionice -c 3" bin/ghe-restore
```

or in `backup.config` for both backups and restores:

```
GHE_NICE="nice -n 19"
GHE_IONICE="ionice -c 3"
```

/cc @github/backup-utils @OptimusAl