### PR TITLE
Use existing Elasticsearch indices to speed up transfer during a restore

### DIFF
--- a/share/github-backup-utils/ghe-restore-es-rsync
+++ b/share/github-backup-utils/ghe-restore-es-rsync
@@ -51,6 +51,7 @@ elif [ "$GHE_VERSION_MAJOR" -gt 1 ]; then
     ghe-rsync -avz --delete \
         -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
         --rsync-path="sudo -u elasticsearch rsync" \
+        --copy-dest="$GHE_REMOTE_DATA_USER_DIR/elasticsearch" \
         "$snapshot_dir/elasticsearch/" \
         "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore" 1>&3
 


### PR DESCRIPTION
When restoring Elasticsearch indices, leverage the `--copy-dest=` `rsync` option so that any existing indices on the target appliance are used as a base.

While `rsync` would typically do this without needing this additional option, our use of a temporary staging directory - `/data/user/elasticsearch-restore` - necessitates the addition of this flag.

This will help minimise unnecessary re-transfers of data during incremental restores, with the aim of only transferring data that has changed.

Testing has shown this brings improvements in various scenarios, and as yet no downside has been identified.

/cc @github/backup-utils 