### PR TITLE
Include the user data directory in the benchmark name

### DIFF
--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -45,4 +45,4 @@ if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/$dirname" ]; then
       "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/$dirname" 1>&3
 fi
 
-bm_start "$(basename $0) - $1"
+bm_end "$(basename $0) - $1"

--- a/share/github-backup-utils/ghe-restore-userdata
+++ b/share/github-backup-utils/ghe-restore-userdata
@@ -11,7 +11,7 @@ set -e
 # Show usage and bail with no arguments
 [ $# -lt 2 ] && print_usage
 
-bm_start "$(basename $0)"
+bm_start "$(basename $0) - $1"
 
 # Grab userdata directory name and host args
 dirname="$1"
@@ -37,7 +37,7 @@ if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/$dirname" ]; then
   if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "sudo -u git mkdir -p $GHE_REMOTE_DATA_USER_DIR/$dirname"
   fi
-  
+
   ghe-rsync -avz --delete \
       -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
       --rsync-path="sudo -u git rsync" \
@@ -45,4 +45,4 @@ if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/$dirname" ]; then
       "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/$dirname" 1>&3
 fi
 
-bm_end "$(basename $0)"
+bm_start "$(basename $0) - $1"


### PR DESCRIPTION
This was added to the backup side some time ago in https://github.com/github/backup-utils/commit/79a1299e21b7c516156807e4f751b5377a896ddc, but was missed on the restore side:

```
ghe-backup-store-version took 2s
ghe-import-mysql took 4s
ghe-import-redis took 2s
ghe-restore-repositories-rsync took 3s
ghe-restore-userdata took 3s
ghe-restore-pages-rsync took 3s
ghe-restore-userdata took 3s
ghe-restore-userdata took 3s
ghe-restore-userdata took 3s
ghe-restore-userdata took 0s
ghe-restore-userdata took 2s
ghe-restore-es-rsync took 27s
```

Adding this will allow us to identify which user data directory a particular benchmark relates to.

/cc @github/backup-utils for review