### PR TITLE
Explicitly state OpenSSH in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ storage and must have network connectivity with the GitHub Enterprise appliance.
 ##### Backup host requirements
 
 Backup host software requirements are modest: Linux or other modern Unix
-operating system with [bash][13], [git][14], [OpenSSH][15] and [rsync][4] v2.6.4 or newer.
+operating system with [bash][13], [git][14], [OpenSSH][15], and [rsync][4] v2.6.4 or newer.
 
 The backup host must be able to establish network connections outbound to the
 GitHub appliance over SSH. TCP port 122 is used to backup GitHub Enterprise 2.0

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ storage and must have network connectivity with the GitHub Enterprise appliance.
 ##### Backup host requirements
 
 Backup host software requirements are modest: Linux or other modern Unix
-operating system with [bash][13], [git][14], and [rsync][4] v2.6.4 or newer.
+operating system with [bash][13], [git][14], [OpenSSH][15] and [rsync][4] v2.6.4 or newer.
 
 The backup host must be able to establish network connections outbound to the
 GitHub appliance over SSH. TCP port 122 is used to backup GitHub Enterprise 2.0
@@ -287,3 +287,4 @@ site setup or recovery, please contact our [Enterprise support team][7] instead.
 [12]: https://en.wikipedia.org/wiki/Hard_link
 [13]: https://www.gnu.org/software/bash/
 [14]: https://git-scm.com/
+[15]: https://www.openssh.com/


### PR DESCRIPTION
Updating the requirements section to explicitly state [OpenSSH](https://www.openssh.com/), as this is what is tested against.