### PR TITLE
Update travis.yml distributions and packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
         - brew install moreutils
       script: make test
     - os: linux
-      sudo: false
+      dist: precise
+      sudo: required
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
           packages:
             - devscripts
             - moreutils
+            - fakeroot
       before_script: git fetch --unshallow
       script: debuild -uc -us
     - os: linux
@@ -25,4 +26,5 @@ matrix:
             - devscripts
             - debhelper
             - moreutils
+            - fakeroot
       script: debuild -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         apt:
           packages:
             - devscripts
+            - debhelper
             - moreutils
             - fakeroot
       before_script: git fetch --unshallow


### PR DESCRIPTION
debuild now complains that fakeroot is missing for some reason.

See https://travis-ci.org/github/backup-utils/jobs/259352688

/cc @github/backup-utils @brntbeer 