### PR TITLE
Use calculated routes when backing up storage data from a cluster

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -171,33 +171,36 @@ ghe-backup-pages-${GHE_BACKUP_STRATEGY} ||
 failures="$failures pages"
 
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
-    if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
-        echo "Backing up asset attachments ..."
-        ghe-backup-alambic-cluster ||
-        failures="$failures alambic_assets"
-
-        echo "Backing up custom Git hooks ..."
-        ghe-backup-git-hooks-cluster ||
-        failures="$failures git-hooks"
+  if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
+    echo "Backing up storage data ..."
+    if ghe-ssh "$GHE_HOSTNAME" test -f /data/github/current/bin/storage-cluster-backup-routes; then
+      ghe-backup-alambic-cluster-ng || failures="$failure alambic"
     else
-        echo "Backing up asset attachments ..."
-        ghe-backup-userdata alambic_assets ||
-        failures="$failures alambic_assets"
-
-        echo "Backing up storage data ..."
-        ghe-backup-userdata storage ||
-        failures="$failures storage"
-
-        echo "Backing up hook deliveries ..."
-        ghe-backup-userdata hookshot ||
-        failures="$failures hookshot"
-
-        echo "Backing up custom Git hooks ..."
-        ghe-backup-userdata git-hooks/environments/tarballs ||
-        failures="$failures git-hooks-environments"
-        ghe-backup-userdata git-hooks/repos ||
-        failures="$failures git-hooks-repos"
+      ghe-backup-alambic-cluster || failures="$failures alambic"
     fi
+
+    echo "Backing up custom Git hooks ..."
+    ghe-backup-git-hooks-cluster ||
+    failures="$failures git-hooks"
+  else
+    echo "Backing up asset attachments ..."
+    ghe-backup-userdata alambic_assets ||
+    failures="$failures alambic_assets"
+
+    echo "Backing up storage data ..."
+    ghe-backup-userdata storage ||
+    failures="$failures storage"
+
+    echo "Backing up hook deliveries ..."
+    ghe-backup-userdata hookshot ||
+    failures="$failures hookshot"
+
+    echo "Backing up custom Git hooks ..."
+    ghe-backup-userdata git-hooks/environments/tarballs ||
+    failures="$failures git-hooks-environments"
+    ghe-backup-userdata git-hooks/repos ||
+    failures="$failures git-hooks-repos"
+  fi
 fi
 
 if [ "$GHE_BACKUP_STRATEGY" != "cluster" ]; then

--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -60,7 +60,7 @@ mkdir -p "$backup_dir"
 cleanup() {
   # Enable remote maintenance operations
   for hostname in $hostnames; do
-    ghe-gc-enable -F $config_file $hostname:$port
+    ghe-gc-enable -F $ssh_config_file $hostname:$port
   done
 
   rm -f $config_file
@@ -69,7 +69,7 @@ trap 'cleanup' EXIT INT
 
 # Disable remote maintenance operations
 for hostname in $hostnames; do
-  ghe-gc-disable -F $config_file $hostname:$port
+  ghe-gc-disable -F $ssh_config_file $hostname:$port
 done
 
 # If we have a previous increment and it is not empty, avoid transferring existing files via rsync's

--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -83,6 +83,7 @@ for hostname in $hostnames; do
       -e "ssh -q $opts -p 122 -F $config_file -l $user" \
       --rsync-path='sudo -u git rsync' \
       $link_dest \
+      --size-only \
       "$hostname:$GHE_REMOTE_DATA_USER_DIR/storage/" \
       "$GHE_SNAPSHOT_DIR/storage" 1>&3
   bm_end "$(basename $0) - $hostname"

--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -36,7 +36,7 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-# git server hostnames
+# storage server hostnames
 hostnames=$(ghe_cluster_online_nodes "storage-server")
 
 for hostname in $hostnames; do
@@ -58,9 +58,19 @@ mkdir -p "$backup_dir"
 # Removes the remote sync-in-progress file on exit, re-enabling GC operations
 # on the remote instance.
 cleanup() {
+  # Enable remote maintenance operations
+  for hostname in $hostnames; do
+    ghe-gc-enable -F $config_file $hostname:$port
+  done
+
   rm -f $config_file
 }
 trap 'cleanup' EXIT INT
+
+# Disable remote maintenance operations
+for hostname in $hostnames; do
+  ghe-gc-disable -F $config_file $hostname:$port
+done
 
 # If we have a previous increment and it is not empty, avoid transferring existing files via rsync's
 # --link-dest support. This also decreases physical space usage considerably.

--- a/share/github-backup-utils/ghe-backup-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster-ng
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#/ Usage: ghe-backup-alambic-cluster-ng
+#/ Take an online, incremental snapshot of all Alambic Storage data using the
+#/ calulated routes method.
+#/
+#/ Note: This command typically isn't called directly. It's invoked by
+#/ ghe-backup when the cluster strategy is used.
+set -e
+
+# Bring in the backup configuration
+. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+
+bm_start "$(basename $0)"
+
+# Set up remote host and root backup snapshot directory based on config
+host="$GHE_HOSTNAME"
+backup_dir="$GHE_SNAPSHOT_DIR/storage"
+
+# Verify rsync is available.
+if ! rsync --version 1>/dev/null 2>&1; then
+    echo "Error: rsync not found." 1>&2
+    exit 1
+fi
+
+# Perform a host-check and establish GHE_REMOTE_XXX variables.
+ghe_remote_version_required "$host"
+
+# Split host:port into parts
+port=$(ssh_port_part "$GHE_HOSTNAME")
+host=$(ssh_host_part "$GHE_HOSTNAME")
+
+# Add user / -l option
+user="${host%@*}"
+[ "$user" = "$host" ] && user="admin"
+
+tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
+ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+ssh_config_file=$tempdir/ssh_config
+opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
+routes_list=$tempdir/routes_list
+
+for hostname in $(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server"); do
+  echo "
+Host $hostname
+  ServerAliveInterval 60
+  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p" >> $ssh_config_file
+done
+
+# Make sure root backup dir exists if this is the first run
+mkdir -p "$backup_dir"
+
+# Removes the remote sync-in-progress file on exit, re-enabling GC operations
+# on the remote instance.
+cleanup() {
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
+  rm -rf $tempdir
+}
+trap 'cleanup' EXIT INT
+
+# If we have a previous increment and it is not empty, avoid transferring existing files via rsync's
+# --link-dest support. This also decreases physical space usage considerably.
+if [ -d "$GHE_DATA_DIR/current/storage" ] && [ "$(ls -A $GHE_DATA_DIR/current/storage)" ]; then
+  link_dest="--link-dest=../../current/storage"
+fi
+
+bm_start "$(basename $0) - Generating routes"
+echo "github-env ./bin/storage-cluster-backup-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+bm_end "$(basename $0) - Generating routes"
+
+bm_start "$(basename $0) - Transferring routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
+bm_end "$(basename $0) - Transferring routes"
+
+bm_start "$(basename $0) - Processing routes"
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+bm_end "$(basename $0) - Processing routes"
+
+# rsync all the repositories
+bm_start "$(basename $0) - Storage object sync"
+for file_list in $tempdir/*.rsync; do
+  hostname=$(basename $file_list .rsync)
+
+  object_num=$(cat $file_list | wc -l)
+  echo "* Transferring $object_num objects from $hostname"
+
+  ghe-rsync -avr \
+  -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
+  $link_dest "$@" \
+  --rsync-path='sudo -u git rsync' \
+  --files-from="$file_list" \
+  "$hostname:$GHE_REMOTE_DATA_USER_DIR/storage/" \
+  "$backup_dir" 1>&3 &
+done
+
+for pid in $(jobs -p); do
+  wait $pid
+done
+bm_end "$(basename $0) - Storage object sync"
+
+bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-backup-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster-ng
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #/ Usage: ghe-backup-alambic-cluster-ng
 #/ Take an online, incremental snapshot of all Alambic Storage data using the
-#/ calulated routes method.
+#/ calculated routes method.
 #/
 #/ Note: This command typically isn't called directly. It's invoked by
 #/ ghe-backup when the cluster strategy is used.

--- a/share/github-backup-utils/ghe-backup-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster-ng
@@ -88,6 +88,7 @@ for file_list in $tempdir/*.rsync; do
   $link_dest "$@" \
   --rsync-path='sudo -u git rsync' \
   --files-from="$file_list" \
+  --size-only \
   "$hostname:$GHE_REMOTE_DATA_USER_DIR/storage/" \
   "$backup_dir" 1>&3 &
 done

--- a/share/github-backup-utils/ghe-backup-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster-ng
@@ -39,7 +39,10 @@ ssh_config_file=$tempdir/ssh_config
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 routes_list=$tempdir/routes_list
 
-for hostname in $(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server"); do
+# storage server hostnames
+hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server")
+
+for hostname in $hostnames; do
   echo "
 Host $hostname
   ServerAliveInterval 60
@@ -52,10 +55,20 @@ mkdir -p "$backup_dir"
 # Removes the remote sync-in-progress file on exit, re-enabling GC operations
 # on the remote instance.
 cleanup() {
+  # Enable remote maintenance operations
+  for hostname in $hostnames; do
+    ghe-gc-enable -F $ssh_config_file $hostname:$port
+  done
+
   ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
   rm -rf $tempdir
 }
 trap 'cleanup' EXIT INT
+
+# Disable remote maintenance operations
+for hostname in $hostnames; do
+  ghe-gc-disable -F $ssh_config_file $hostname:$port
+done
 
 # If we have a previous increment and it is not empty, avoid transferring existing files via rsync's
 # --link-dest support. This also decreases physical space usage considerably.

--- a/share/github-backup-utils/ghe-backup-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster-ng
@@ -33,21 +33,15 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
-ssh_config_file=$tempdir/ssh_config
-opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-routes_list=$tempdir/routes_list
-
 # storage server hostnames
 hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server")
 
-for hostname in $hostnames; do
-  echo "
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p" >> $ssh_config_file
-done
+tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
+ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+ssh_config_file=$tempdir/ssh_config
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
+opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
+routes_list=$tempdir/routes_list
 
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$backup_dir"


### PR DESCRIPTION
Use the more efficient calculated routes method to backup Alambic storage data from a GitHub Enterprise cluster where `bin/storage-cluster-backup-routes` is available on the cluster.

Alambic storage data includes release assets, avatars, LFS objects and issue attachments.

/cc @jatoben @michaeltwofish @github/backup-utils