### PR TITLE
SSH multiplexing support

### DIFF
--- a/share/github-backup-utils/ghe-backup-alambic-cluster
+++ b/share/github-backup-utils/ghe-backup-alambic-cluster
@@ -24,10 +24,6 @@ fi
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -36,19 +32,11 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-# git server hostnames
+# Alambic server hostnames
 hostnames=$(ghe_cluster_online_nodes "storage-server")
 
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
-
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -58,7 +46,7 @@ mkdir -p "$backup_dir"
 # Removes the remote sync-in-progress file on exit, re-enabling GC operations
 # on the remote instance.
 cleanup() {
-  rm -f $config_file
+  rm -f $ssh_config_file
 }
 trap 'cleanup' EXIT INT
 
@@ -80,7 +68,7 @@ for hostname in $hostnames; do
 
   # Transfer all data from the user data directory using rsync.
   ghe-rsync -avz \
-      -e "ssh -q $opts -p 122 -F $config_file -l $user" \
+      -e "ssh -q $opts -p 122 -F $ssh_config_file -l $user" \
       --rsync-path='sudo -u git rsync' \
       $link_dest \
       "$hostname:$GHE_REMOTE_DATA_USER_DIR/storage/" \

--- a/share/github-backup-utils/ghe-backup-git-hooks-cluster
+++ b/share/github-backup-utils/ghe-backup-git-hooks-cluster
@@ -34,28 +34,18 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-# Generate SSH config for forwarding
-config=""
-
 # git server hostnames
 hostnames=$(ghe_cluster_online_nodes "git-server")
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
 # Removes the remote sync-in-progress file on exit, re-enabling GC operations
 # on the remote instance.
 cleanup() {
-  rm -f $config_file
+  rm -f $ssh_config_file
 }
 trap 'cleanup' EXIT
 trap 'exit $?' INT # ^C always terminate
@@ -97,20 +87,20 @@ rsync_git_hooks_data () {
     mkdir -p "$backup_dir/$subpath"
 
     ghe-rsync -av \
-        -e "ssh -q $opts -p $port -F $config_file -l $user" $link_dest \
+        -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" $link_dest \
         --rsync-path='sudo -u git rsync' \
         "$host:$GHE_REMOTE_DATA_USER_DIR/git-hooks/$subpath/" \
         "$backup_dir/$subpath" 1>&3
 }
 
 hostname=$(echo $hostnames | awk '{ print $1; }')
-if ghe-ssh -F $config_file "$hostname:122" -- "sudo -u git [ -d '$GHE_REMOTE_DATA_USER_DIR/git-hooks/environments/tarballs' ]"; then
+if ghe-ssh -F $ssh_config_file "$hostname:122" -- "sudo -u git [ -d '$GHE_REMOTE_DATA_USER_DIR/git-hooks/environments/tarballs' ]"; then
   rsync_git_hooks_data $hostname:122 environments/tarballs
 else
   ghe_verbose "git-hooks environment tarballs not found. Skipping ..."
 fi
 
-if ghe-ssh -F $config_file "$hostname:122" -- "sudo -u git [ -d '$GHE_REMOTE_DATA_USER_DIR/git-hooks/repos' ]"; then
+if ghe-ssh -F $ssh_config_file "$hostname:122" -- "sudo -u git [ -d '$GHE_REMOTE_DATA_USER_DIR/git-hooks/repos' ]"; then
   rsync_git_hooks_data $hostname:122 repos
 else
   ghe_verbose "git-hooks repositories not found. Skipping ..."

--- a/share/github-backup-utils/ghe-backup-pages-cluster
+++ b/share/github-backup-utils/ghe-backup-pages-cluster
@@ -24,10 +24,6 @@ fi
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -36,19 +32,11 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-# git server hostnames
+# Pages server hostnames
 hostnames=$(ghe_cluster_online_nodes "pages-server")
 
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
-
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -58,7 +46,7 @@ mkdir -p "$backup_dir"
 # Removes the remote sync-in-progress file on exit, re-enabling GC operations
 # on the remote instance.
 cleanup() {
-  rm -f $config_file
+  rm -f $ssh_config_file
 }
 trap 'cleanup' EXIT INT
 
@@ -80,7 +68,7 @@ for hostname in $hostnames; do
 
   # Transfer all data from the user data directory using rsync.
   ghe-rsync -avz \
-      -e "ssh -q $opts -p 122 -F $config_file -l $user" \
+      -e "ssh -q $opts -p 122 -F $ssh_config_file -l $user" \
       --rsync-path='sudo -u git rsync' \
       $link_dest \
       "$hostname:$GHE_REMOTE_DATA_USER_DIR/pages/" \

--- a/share/github-backup-utils/ghe-backup-repositories-cluster
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster
@@ -58,10 +58,6 @@ fi
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -72,16 +68,9 @@ user="${host%@*}"
 
 # git server hostnames
 hostnames=$(ghe_cluster_online_nodes "git-server")
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -93,16 +82,16 @@ mkdir -p "$backup_dir"
 cleanup() {
   # Enable remote GC operations
   for hostname in $hostnames; do
-    ghe-gc-enable -F $config_file $hostname:$port
+    ghe-gc-enable -F $ssh_config_file $hostname:$port
   done
-  rm -f $config_file
+  rm -f $ssh_config_file
 }
 trap 'cleanup' EXIT
 trap 'exit $?' INT # ^C always terminate
 
 # Disable remote GC operations
 for hostname in $hostnames; do
-  ghe-gc-disable -F $config_file $hostname:$port
+  ghe-gc-disable -F $ssh_config_file $hostname:$port
 done
 
 # If we have a previous increment, avoid transferring existing files via rsync's
@@ -121,7 +110,7 @@ rsync_repository_data () {
 
   shift
   ghe-rsync -av \
-    -e "ssh -q $opts -p $port -F $config_file -l $user" \
+    -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     $link_dest "$@" \
     --rsync-path='sudo -u git rsync' \
     --include-from=- --exclude=\* \

--- a/share/github-backup-utils/ghe-backup-repositories-cluster-ng
+++ b/share/github-backup-utils/ghe-backup-repositories-cluster-ng
@@ -61,10 +61,6 @@ fi
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -75,16 +71,9 @@ user="${host%@*}"
 
 # git server hostnames
 hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server")
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -100,10 +89,10 @@ cleanup() {
 
   # Enable remote GC operations
   for hostname in $hostnames; do
-    ghe-gc-enable -F $config_file $hostname:$port
+    ghe-gc-enable -F $ssh_config_file $hostname:$port
   done
 
-  rm -f $config_file
+  rm -f $ssh_config_file
   rm -rf $tempdir
 }
 trap 'cleanup' EXIT
@@ -111,7 +100,7 @@ trap 'exit $?' INT # ^C always terminate
 
 # Disable remote GC operations
 for hostname in $hostnames; do
-  ghe-gc-disable -F $config_file $hostname:$port
+  ghe-gc-disable -F $ssh_config_file $hostname:$port
 done
 
 # If we have a previous increment, avoid transferring existing files via rsync's
@@ -159,7 +148,7 @@ rsync_repository_data () {
     shift
     shift
     ghe-rsync -avr \
-      -e "ssh -q $opts -p $port -F $config_file -l $user" \
+      -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       $link_dest "$@" \
       --rsync-path='sudo -u git rsync' \
       --include-from=- --exclude=\* \
@@ -169,7 +158,7 @@ rsync_repository_data () {
   else
     shift
     ghe-rsync -avr \
-      -e "ssh -q $opts -p $port -F $config_file -l $user" \
+      -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       $link_dest "$@" \
       --rsync-path='sudo -u git rsync' \
       --include-from=- --exclude=\* \

--- a/share/github-backup-utils/ghe-restore-alambic-cluster
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster
@@ -33,9 +33,6 @@ if [ -z "$storage_paths" ]; then
   exit 0
 fi
 
-# Generate SSH config for forwarding
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -45,15 +42,9 @@ user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
 hostnames=$(ghe-ssh "$GHE_HOSTNAME" ghe-config --get-regexp cluster.*.hostname | cut -d ' ' -f 2)
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -61,7 +52,7 @@ cleanup() {
   for pid in $(jobs -p); do
     kill -KILL $pid > /dev/null 1>&2 || true
   done
-  rm -rf $config_file ssh_routes_in ssh_routes_out ssh_finalize_out
+  rm -rf $ssh_config_file ssh_routes_in ssh_routes_out ssh_finalize_out
 }
 
 trap 'cleanup' INT TERM EXIT
@@ -86,7 +77,7 @@ for storage_path in $storage_paths; do
 
   for route in $routes; do
     ghe-rsync -aHR --delete \
-      -e "ssh -q $opts -p $port -F $config_file -l $user" \
+      -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       --rsync-path="sudo -u git rsync" \
       "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/storage/./$storage_path" \
       "$route:$GHE_REMOTE_DATA_USER_DIR/storage" &

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -42,17 +42,10 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-# Generate SSH config for forwarding
-config=""
-for hostname in $(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server"); do
-  config="$config
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p"
-done
+hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server")
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 # Stores a list of "oid size" tuples.
 tmp_list=$(mktemp -t cluster-backup-restore-XXXXXX)
@@ -62,7 +55,7 @@ opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecki
 tempdir=$(mktemp -d)
 
 cleanup() {
-  rm -rf $tempdir $config_file $tmp_list $to_restore
+  rm -rf $tempdir $ssh_config_file $tmp_list $to_restore
   true
 }
 
@@ -112,7 +105,7 @@ done
 for route in $tempdir/*.rsync; do
   ghe_verbose "* rsync data to $(basename $route .rsync) ..."
   ghe-rsync -arHR --delete \
-    -e "ssh -q $opts -p $port -F $config_file -l $user" \
+    -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
     --files-from=$route \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/storage/./" \

--- a/share/github-backup-utils/ghe-restore-git-hooks-cluster
+++ b/share/github-backup-utils/ghe-restore-git-hooks-cluster
@@ -24,9 +24,6 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # us run this script directly.
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
-# Generate SSH config for forwarding
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -36,17 +33,9 @@ user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
 hostnames=$(ghe_cluster_online_nodes "git-server")
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -54,7 +43,7 @@ cleanup() {
   for pid in $(jobs -p); do
     kill -KILL $pid > /dev/null 2>&1 || true
   done
-  rm -f $config_file
+  rm -f $ssh_config_file
 }
 trap 'cleanup' INT TERM EXIT
 
@@ -64,14 +53,14 @@ if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks/environments/tarballs" ];
 
   if [ -n "$hostname" ]; then
     ghe-rsync -avH --delete \
-    -e "ssh -q $opts -p $port -F $config_file -l $user" \
+    -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks/environments/tarballs/" \
     "$hostname:$GHE_REMOTE_DATA_USER_DIR/git-hooks/environments/tarballs" 1>&3
 
     for tarball in $tarballs; do
       env_id=$(echo $tarball | cut -d '/' -f 2)
-      ssh -q $opts -p $port -F $config_file -l $user $hostname "/bin/bash -c 'export PATH=\$PATH:/usr/local/share/enterprise && ghe-hook-env-update $env_id $GHE_REMOTE_DATA_USER_DIR/git-hooks/environments/tarballs/$tarball'" 1>&3 2>&3
+      ssh -q $opts -p $port -F $ssh_config_file -l $user $hostname "/bin/bash -c 'export PATH=\$PATH:/usr/local/share/enterprise && ghe-hook-env-update $env_id $GHE_REMOTE_DATA_USER_DIR/git-hooks/environments/tarballs/$tarball'" 1>&3 2>&3
     done
   fi
 fi
@@ -79,7 +68,7 @@ fi
 if [ -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks/repos" ]; then
   for hostname in $hostnames; do
     ghe-rsync -avH --delete \
-    -e "ssh -q $opts -p $port -F $config_file -l $user" \
+    -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/git-hooks/repos/" \
     "$hostname:$GHE_REMOTE_DATA_USER_DIR/git-hooks/repos" 1>&3 &

--- a/share/github-backup-utils/ghe-restore-pages-dpages
+++ b/share/github-backup-utils/ghe-restore-pages-dpages
@@ -33,10 +33,6 @@ fi
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -45,15 +41,10 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-for hostname in $(ghe-cluster-hostnames "$GHE_HOSTNAME" "pages-server"); do
-  config="$config
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p"
-done
+hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "pages-server")
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -61,7 +52,7 @@ cleanup() {
   for pid in $(jobs -p); do
     kill -KILL $pid > /dev/null 2>&1 || true
   done
-  rm -rf $config_file ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
+  rm -rf $ssh_config_file ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
 }
 
 trap 'cleanup' INT TERM EXIT
@@ -92,7 +83,7 @@ for pages_path in $pages_paths; do
 
   for route in $routes; do
     ghe-rsync -aHR --delete \
-      -e "ssh -q $opts -p $port -F $config_file -l $user" \
+      -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       --rsync-path="sudo -u git rsync" \
       "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/pages/./$pages_path" \
       "$route:$GHE_REMOTE_DATA_USER_DIR/pages" &

--- a/share/github-backup-utils/ghe-restore-repositories-dgit
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit
@@ -31,10 +31,6 @@ if [ -z "$network_paths" ]; then
   exit 0
 fi
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -44,17 +40,9 @@ user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
 hostnames=$(ghe_cluster_online_nodes "git-server")
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -64,16 +52,16 @@ cleanup() {
   done
   # Enable remote GC operations
   for hostname in $hostnames; do
-    ghe-gc-enable -F $config_file $hostname:$port
+    ghe-gc-enable -F $ssh_config_file $hostname:$port
   done
-  rm -rf $config_file ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
+  rm -rf $ssh_config_file ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
 }
 
 trap 'cleanup' INT TERM EXIT
 
 # Disable remote GC operations
 for hostname in $hostnames; do
-  ghe-gc-disable -F $config_file $hostname:$port
+  ghe-gc-disable -F $ssh_config_file $hostname:$port
 done
 
 rm -rf ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
@@ -98,7 +86,7 @@ for network_path in $network_paths; do
   for route in $routes; do
     ghe-rsync -aHR --delete \
       --exclude ".sync_in_progress" \
-      -e "ssh -q $opts -p $port -F $config_file -l $user" \
+      -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       --rsync-path="sudo -u git rsync" \
       "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/./$network_path" \
       "$route:$GHE_REMOTE_DATA_USER_DIR/repositories" &
@@ -133,7 +121,7 @@ wait $ssh_finalize_pid > /dev/null 2>&1 || true
 if [ -d $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/info ]; then
   for route in `ghe-ssh "$GHE_HOSTNAME" ghe-cluster-each -r git -p`; do
     if ! ghe-rsync -a --delete \
-        -e "ssh -q $opts -p $port -F $config_file -l $user" \
+        -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
         --rsync-path="sudo -u git rsync" \
         "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/info/" \
         "$route:$GHE_REMOTE_DATA_USER_DIR/repositories/info"; then

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -73,13 +73,8 @@ tmp_list=$tempdir/tmp_list
 to_restore=$tempdir/to_restore
 
 hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server")
-for hostname in $hostnames; do
-  echo "
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no" >> $ssh_config_file
-done
+
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 cleanup() {
   for hostname in $hostnames; do

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -33,10 +33,6 @@ fi
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-# Generate SSH config for forwarding
-
-config=""
-
 # Split host:port into parts
 port=$(ssh_port_part "$GHE_HOSTNAME")
 host=$(ssh_host_part "$GHE_HOSTNAME")
@@ -46,17 +42,9 @@ user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
 hostnames=$(ghe_cluster_online_nodes "git-server")
-for hostname in $hostnames; do
-  config="$config
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p
-  StrictHostKeyChecking=no
-"
-done
 
-config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
-echo "$config" > "$config_file"
+ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 
@@ -66,16 +54,16 @@ cleanup() {
   done
   # Enable remote GC operations
   for hostname in $hostnames; do
-    ghe-gc-enable -F $config_file $hostname:$port
+    ghe-gc-enable -F $ssh_config_file $hostname:$port
   done
-  rm -rf $config_file ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
+  rm -rf $ssh_config_file ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
 }
 
 trap 'cleanup' INT TERM EXIT
 
 # Disable remote GC operations
 for hostname in $hostnames; do
-  ghe-gc-disable -F $config_file $hostname:$port
+  ghe-gc-disable -F $ssh_config_file $hostname:$port
 done
 
 rm -rf ssh_routes_in ssh_routes_out ssh_finalize_in ssh_finalize_out
@@ -105,7 +93,7 @@ for gist_path in $gist_paths; do
   for route in $routes; do
     ghe-rsync -aHR --delete \
       --exclude ".sync_in_progress" \
-      -e "ssh -q $opts -p $port -F $config_file -l $user" \
+      -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       --rsync-path="sudo -u git rsync" \
       "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/./$gist_path" \
       "$route:$GHE_REMOTE_DATA_USER_DIR/repositories" &

--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -46,12 +46,9 @@ opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecki
 tmp_list=$tempdir/tmp_list
 to_restore=$tempdir/to_restore
 
-for hostname in $(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server"); do
-  echo "
-Host $hostname
-  ServerAliveInterval 60
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $port $user@$host nc.openbsd %h %p" >> $ssh_config_file
-done
+hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server")
+
+ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 cleanup() {
   rm -rf $tempdir

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -53,6 +53,9 @@ if echo "$*" | grep "[|;]" >/dev/null || [ $(echo "$*" | wc -l) -gt 1 ]; then
     exit 1
 fi
 
+
+[ -z "$GHE_DISABLE_SSH_MUX" ] && opts="-o ControlMaster=auto -o ControlPath=\"$GHE_DATA_DIR/.sshmux-$(echo -n "$user@$host:$port" | sha256sum | cut -c 1-8)\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
+
 # Turn on verbose SSH logging if needed
 $GHE_VERBOSE_SSH && set -x
 

--- a/share/github-backup-utils/ghe-ssh-config
+++ b/share/github-backup-utils/ghe-ssh-config
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#/ Usage: ghe-ssh-config <proxy_host> [<host>...]
+#/
+#/ Returns a SSH configuration file.
+#/
+#/ Note: This script typically isn't called directly. It's invoked by the
+#/ ghe-[backup|restore]-* commands.
+set -e
+
+# Bring in the backup configuration
+. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+
+# Show usage and bail with no arguments
+[ -z "$*" ] && print_usage
+
+GHE_HOSTNAME="$1"
+shift
+
+hosts="$@"
+
+proxy_host=$(ssh_host_part "$GHE_HOSTNAME")
+proxy_port=$(ssh_port_part "$GHE_HOSTNAME")
+proxy_user="${host%@*}"
+[ "$proxy_user" = "$proxy_host" ] && proxy_user="admin"
+
+for host in $hosts; do
+  cat <<EOF
+Host $hostname
+  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $proxy_port $proxy_user@$proxy_host nc.openbsd %h %p
+  StrictHostKeyChecking=no
+EOF
+done

--- a/share/github-backup-utils/ghe-ssh-config
+++ b/share/github-backup-utils/ghe-ssh-config
@@ -20,13 +20,17 @@ hosts="$@"
 
 proxy_host=$(ssh_host_part "$GHE_HOSTNAME")
 proxy_port=$(ssh_port_part "$GHE_HOSTNAME")
-proxy_user="${host%@*}"
+proxy_user="${proxy_host%@*}"
 [ "$proxy_user" = "$proxy_host" ] && proxy_user="admin"
+
+opts="$GHE_EXTRA_SSH_OPTS"
+
+[ -z "$GHE_DISABLE_SSH_MUX" ] && opts="-o ControlMaster=auto -o ControlPath=\"$GHE_DATA_DIR/.sshmux-$(echo -n "$proxy_user@$proxy_host:$proxy_port" | sha256sum | cut -c 1-8)\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
 
 for host in $hosts; do
   cat <<EOF
-Host $hostname
-  ProxyCommand ssh -q $GHE_EXTRA_SSH_OPTS -p $proxy_port $proxy_user@$proxy_host nc.openbsd %h %p
+Host $host
+  ProxyCommand ssh -q $opts -p $proxy_port $proxy_user@$proxy_host nc.openbsd %h %p
   StrictHostKeyChecking=no
 EOF
 done


### PR DESCRIPTION
Multiplexing will cut down on the latency involved in opening and closing the many SSH connections used by the backup utilities, and more importantly ensures that connections to a cluster always land on the same node, which will facilitate PRs such as https://github.com/github/backup-utils/pull/318.

A seperate mux is created per username, hostname and IP combination, resulting in a single multiplexed connection to each host. Each control master will persist in the background until it has been idle for 10 minutes, which allows the backup utilities to cope with brief periods when there are no active SSH connections during a backup or restore while local processing is happening.

A short sha of sorts is used as part of the name of mux control socket to work around socket path length limitations. These sockets are placed in `GHE_DATA_DIR` as hidden files.

Multiplexing can be disabled by setting the environment variable `GHE_DISABLE_SSH_MUX`.

I also took the opportunity to refactor the code used to generate the SSH configurations.

/cc @github/backup-utils @github/enterprise-on-prem