### PR TITLE
Optimise route generation and finalisation during cluster restores

### DIFF
--- a/share/github-backup-utils/ghe-restore-alambic-cluster
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster
@@ -79,6 +79,7 @@ for storage_path in $storage_paths; do
     ghe-rsync -aHR --delete \
       -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
       --rsync-path="sudo -u git rsync" \
+      --size-only \
       "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/storage/./$storage_path" \
       "$route:$GHE_REMOTE_DATA_USER_DIR/storage" &
   done

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -44,19 +44,20 @@ user="${host%@*}"
 
 hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "storage-server")
 
-ssh_config_file=$(mktemp -t cluster-backup-restore-XXXXXX)
+tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
+ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+ssh_config_file=$tempdir/ssh_config
 ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
-
-# Stores a list of "oid size" tuples.
-tmp_list=$(mktemp -t cluster-backup-restore-XXXXXX)
-routes_list=$(mktemp -t cluster-backup-restore-XXXXXX)
-to_restore=$(mktemp -t cluster-backup-restore-XXXXXX)
-
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-tempdir=$(mktemp -d)
+tmp_list=$tempdir/tmp_list
+routes_list=$tempdir/routes_list
+to_restore=$tempdir/to_restore
+
+echo "$config" > "$config_file"
 
 cleanup() {
   rm -rf $tempdir $ssh_config_file $tmp_list $to_restore
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
   true
 }
 
@@ -83,19 +84,20 @@ ghe_verbose "* Sending the object list to the server..."
 # # OID SERVER1 SERVER2 SERVER2
 # b8a48b6b122b4ef8175348d1d6fbd846d3b3ccc8fd7552b79f91125c4958e43b server1 server2 server3
 # bc4cdd292e6b5387df2a42a907fcd5f3b6804a5d5ab427184faea5ef118d635e server1 server2 server3
-bm_start "$(basename $0) - Obtaining routes"
-ghe-rsync -avz --delete \
-    -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
-    "$tmp_list" \
-    "$(ssh_host_part "$GHE_HOSTNAME"):$(basename $tmp_list)" 1>&3
 
-echo "cat $(basename $tmp_list) | github-env ./bin/storage-cluster-restore-routes > $(basename $routes_list)" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+bm_start "$(basename $0) - Transferring object list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+bm_end "$(basename $0) - Transferring object list"
 
-ghe-rsync -avz --delete \
-    -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
-    "$(ssh_host_part "$GHE_HOSTNAME"):$(basename $routes_list)" \
-    "$routes_list" 1>&3
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/storage-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+bm_end "$(basename $0) - Generating routes"
 
+bm_start "$(basename $0) - Transferring routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
+bm_end "$(basename $0) - Transferring routes"
+
+bm_start "$(basename $0) - Processing routes"
 cat $routes_list | while read obj; do
   ghe_verbose "Received route: $obj"
   oid=$(echo $obj | cut -d ' ' -f1)
@@ -108,7 +110,7 @@ cat $routes_list | while read obj; do
   done
   echo "$obj" >> $to_restore
 done
-bm_end "$(basename $0) - Obtaining routes"
+bm_end "$(basename $0) - Processing routes"
 
 # rsync all the objects to the storage server where they belong.
 # One rsync invocation per server available.
@@ -125,13 +127,11 @@ done
 bm_end "$(basename $0) - Restoring objects"
 
 bm_start "$(basename $0) - Finalizing routes"
-ghe_verbose "* Update storage database after the restore ..."
-ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
-  tempdir=\$(mktemp -d)
-  echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
-  chunks=\$(find \$tempdir/ -name chunk\*)
+cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
+  split -l 1000 -d $to_restore $tempdir/chunk
+  chunks=\$(find $tempdir/ -name chunk\*)
   parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
-  rm -rf \$tempdir
 EOF
 bm_end "$(basename $0) - Finalizing routes"
 

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -114,11 +114,11 @@ done
 
 ghe_verbose "* Update storage database after the restore ..."
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
-	tempdir=\$(mktemp -d)
-	echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
-	chunks=\$(find \$tempdir/ -name chunk\*)
-	parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
-	rm -rf \$tempdir
+  tempdir=\$(mktemp -d)
+  echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
+  chunks=\$(find \$tempdir/ -name chunk\*)
+  parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
+  rm -rf \$tempdir
 EOF
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -72,13 +72,7 @@ trap 'cleanup' EXIT
 # b63c30f6f885e59282c2aa22cfca846516b5e72621c10a58140fb04d133e2c17 5592492
 # ...
 bm_start "$(basename $0) - Building object list"
-OLDIFS=$IFS; IFS=$'\n'
-for path in $storage_paths; do
-  oid=$(echo $path | awk -F/ '{print $(NF)}')
-  size=$(echo $path | awk '{print $1}')
-  echo $oid $size
-done > $tmp_list
-IFS=$OLDIFS
+echo "$storage_paths" | awk '{print $2 " " $1}' | awk -F/ '{print $NF }' > $tmp_list
 bm_end "$(basename $0) - Building object list"
 
 ghe_verbose "* Sending the object list to the server..."

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -51,7 +51,6 @@ ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 tmp_list=$tempdir/tmp_list
 routes_list=$tempdir/routes_list
-to_restore=$tempdir/to_restore
 
 echo "$config" > "$config_file"
 
@@ -98,18 +97,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
 bm_end "$(basename $0) - Transferring routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $routes_list | while read obj; do
-  ghe_verbose "Received route: $obj"
-  oid=$(echo $obj | cut -d ' ' -f1)
-  oid_c1=$(echo $oid | cut -c1)
-  oid_c2=$(echo $oid | cut -c1-2)
-  oid_c3=$(echo $oid | cut -c3-4)
-  for server in $(echo $obj | cut -d ' ' -f2-); do
-    ghe_verbose "Adding $oid_c1/$oid_c2/$oid_c3/$oid to $tempdir/$server.rsync"
-    echo "$oid_c1/$oid_c2/$oid_c3/$oid" >> $tempdir/$server.rsync
-  done
-  echo "$obj" >> $to_restore
-done
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
 bm_end "$(basename $0) - Processing routes"
 
 # rsync all the objects to the storage server where they belong.
@@ -128,9 +116,8 @@ done
 bm_end "$(basename $0) - Restoring objects"
 
 bm_start "$(basename $0) - Finalizing routes"
-cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
 ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-  split -l 1000 -d $to_restore $tempdir/chunk
+  split -l 1000 -d $routes_list $tempdir/chunk
   chunks=\$(find $tempdir/ -name chunk\*)
   parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
 EOF

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -52,8 +52,6 @@ opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecki
 tmp_list=$tempdir/tmp_list
 routes_list=$tempdir/routes_list
 
-echo "$config" > "$config_file"
-
 cleanup() {
   rm -rf $tempdir
   ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -56,7 +56,7 @@ to_restore=$tempdir/to_restore
 echo "$config" > "$config_file"
 
 cleanup() {
-  rm -rf $tempdir $ssh_config_file $tmp_list $to_restore
+  rm -rf $tempdir
   ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
   true
 }

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -121,6 +121,7 @@ for route in $tempdir/*.rsync; do
     -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
     --files-from=$route \
+    --size-only \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/storage/./" \
     "$(basename $route .rsync):$GHE_REMOTE_DATA_USER_DIR/storage/"
 done

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -49,6 +49,7 @@ ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 # Stores a list of "oid size" tuples.
 tmp_list=$(mktemp -t cluster-backup-restore-XXXXXX)
+routes_list=$(mktemp -t cluster-backup-restore-XXXXXX)
 to_restore=$(mktemp -t cluster-backup-restore-XXXXXX)
 
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
@@ -89,8 +90,20 @@ ghe_verbose "* Sending the object list to the server..."
 # b8a48b6b122b4ef8175348d1d6fbd846d3b3ccc8fd7552b79f91125c4958e43b server1 server2 server3
 # bc4cdd292e6b5387df2a42a907fcd5f3b6804a5d5ab427184faea5ef118d635e server1 server2 server3
 bm_start "$(basename $0) - Obtaining routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/storage-cluster-restore-routes \
- | while read obj; do
+ghe-rsync -avz --delete \
+    -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
+    "$tmp_list" \
+    "$(ssh_host_part "$GHE_HOSTNAME"):$(basename $tmp_list)" 1>&3
+
+
+echo "cat $(basename $tmp_list) | github-env ./bin/storage-cluster-restore-routes > $(basename $routes_list)" | ghe-ssh "$GHE_HOSTNAME"
+
+ghe-rsync -avz --delete \
+    -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
+    "$(ssh_host_part "$GHE_HOSTNAME"):$(basename $routes_list)" \
+    "$routes_list" 1>&3
+
+cat $routes_list | while read obj; do
   ghe_verbose "Received route: $obj"
   oid=$(echo $obj | cut -d ' ' -f1)
   oid_c1=$(echo $oid | cut -c1)

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -113,6 +113,12 @@ for route in $tempdir/*.rsync; do
 done
 
 ghe_verbose "* Update storage database after the restore ..."
-cat $to_restore | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/storage-cluster-restore-finalize
+ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
+	tempdir=\$(mktemp -d)
+	echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
+	chunks=\$(find \$tempdir/ -name chunk\*)
+	parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
+	rm -rf \$tempdir
+EOF
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -95,8 +95,7 @@ ghe-rsync -avz --delete \
     "$tmp_list" \
     "$(ssh_host_part "$GHE_HOSTNAME"):$(basename $tmp_list)" 1>&3
 
-
-echo "cat $(basename $tmp_list) | github-env ./bin/storage-cluster-restore-routes > $(basename $routes_list)" | ghe-ssh "$GHE_HOSTNAME"
+echo "cat $(basename $tmp_list) | github-env ./bin/storage-cluster-restore-routes > $(basename $routes_list)" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
 
 ghe-rsync -avz --delete \
     -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \

--- a/share/github-backup-utils/ghe-restore-alambic-cluster-ng
+++ b/share/github-backup-utils/ghe-restore-alambic-cluster-ng
@@ -70,6 +70,7 @@ trap 'cleanup' EXIT
 # b65f657194ca6202c17b5062e4afc11843fc892a3f2febef8ac10971db7689a8 5591634
 # b63c30f6f885e59282c2aa22cfca846516b5e72621c10a58140fb04d133e2c17 5592492
 # ...
+bm_start "$(basename $0) - Building object list"
 OLDIFS=$IFS; IFS=$'\n'
 for path in $storage_paths; do
   oid=$(echo $path | awk -F/ '{print $(NF)}')
@@ -77,6 +78,7 @@ for path in $storage_paths; do
   echo $oid $size
 done > $tmp_list
 IFS=$OLDIFS
+bm_end "$(basename $0) - Building object list"
 
 ghe_verbose "* Sending the object list to the server..."
 
@@ -86,6 +88,7 @@ ghe_verbose "* Sending the object list to the server..."
 # # OID SERVER1 SERVER2 SERVER2
 # b8a48b6b122b4ef8175348d1d6fbd846d3b3ccc8fd7552b79f91125c4958e43b server1 server2 server3
 # bc4cdd292e6b5387df2a42a907fcd5f3b6804a5d5ab427184faea5ef118d635e server1 server2 server3
+bm_start "$(basename $0) - Obtaining routes"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/storage-cluster-restore-routes \
  | while read obj; do
   ghe_verbose "Received route: $obj"
@@ -99,9 +102,11 @@ cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/storage-cluster-restore
   done
   echo "$obj" >> $to_restore
 done
+bm_end "$(basename $0) - Obtaining routes"
 
 # rsync all the objects to the storage server where they belong.
 # One rsync invocation per server available.
+bm_start "$(basename $0) - Restoring objects"
 for route in $tempdir/*.rsync; do
   ghe_verbose "* rsync data to $(basename $route .rsync) ..."
   ghe-rsync -arHR --delete \
@@ -111,7 +116,9 @@ for route in $tempdir/*.rsync; do
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/storage/./" \
     "$(basename $route .rsync):$GHE_REMOTE_DATA_USER_DIR/storage/"
 done
+bm_end "$(basename $0) - Restoring objects"
 
+bm_start "$(basename $0) - Finalizing routes"
 ghe_verbose "* Update storage database after the restore ..."
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
   tempdir=\$(mktemp -d)
@@ -120,5 +127,6 @@ ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
   parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
   rm -rf \$tempdir
 EOF
+bm_end "$(basename $0) - Finalizing routes"
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -147,11 +147,11 @@ done
 
 # Tell dgit about the repositories restored
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
-	tempdir=\$(mktemp -d)
-	echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
-	chunks=\$(find \$tempdir/ -name chunk\*)
-	parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
-	rm -rf \$tempdir
+  tempdir=\$(mktemp -d)
+  echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
+  chunks=\$(find \$tempdir/ -name chunk\*)
+  parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
+  rm -rf \$tempdir
 EOF
 
 if [ -d $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/info ]; then

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -146,7 +146,13 @@ for file_list in $tempdir/*.rsync; do
 done
 
 # Tell dgit about the repositories restored
-cat $to_restore | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/dgit-cluster-restore-finalize >&3
+ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
+	tempdir=\$(mktemp -d)
+	echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
+	chunks=\$(find \$tempdir/ -name chunk\*)
+	parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
+	rm -rf \$tempdir
+EOF
 
 if [ -d $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/info ]; then
   ghe_verbose "* Transferring repository info data"

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -156,12 +156,11 @@ bm_end "$(basename $0) - Restoring repository networks"
 
 # Tell dgit about the repositories restored
 bm_start "$(basename $0) - Finalizing routes"
-ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
-  tempdir=\$(mktemp -d)
-  echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
-  chunks=\$(find \$tempdir/ -name chunk\*)
+cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
+  split -l 1000 -d $to_restore $tempdir/chunk
+  chunks=\$(find $tempdir/ -name chunk\*)
   parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
-  rm -rf \$tempdir
 EOF
 bm_end "$(basename $0) - Finalizing routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -136,7 +136,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
 bm_end "$(basename $0) - Transferring routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $routes_list | awk -vtempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
 cat $routes_list | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' > $to_restore
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -100,6 +100,7 @@ done
 # ...
 #
 # One network path per line.
+bm_start "$(basename $0) - Building network list"
 OLDIFS=$IFS; IFS=$'\n'
 for path in $network_paths; do
    # Get the network ID
@@ -109,6 +110,7 @@ for path in $network_paths; do
    echo $path
 done > $tmp_list
 IFS=$OLDIFS
+bm_end "$(basename $0) - Building network list"
 
 # The server returns a list of routes:
 #
@@ -118,6 +120,7 @@ IFS=$OLDIFS
 # ...
 #
 # One route per line.
+bm_start "$(basename $0) - Obtaining routes"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/dgit-cluster-restore-routes \
  | while read route; do
   ghe_verbose "Received route $route"
@@ -132,11 +135,13 @@ cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/dgit-cluster-restore-ro
   ghe_verbose "Route: $network_id /data/repositories/$network_path $servers"
   echo "$network_id /data/repositories/$network_path $servers" >> $to_restore
 done
+bm_end "$(basename $0) - Obtaining routes"
 
+bm_start "$(basename $0) - Restoring repository networks"
 # rsync all the repositories
 for file_list in $tempdir/*.rsync; do
   server=$(basename $file_list .rsync)
-  ghe_verbose "* Transferring repositories to $server"
+  ghe_verbose "* Transferring repository networks to $server"
   ghe-rsync -avrHR --delete \
     -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
     --rsync-path="sudo -u git rsync" \
@@ -144,8 +149,10 @@ for file_list in $tempdir/*.rsync; do
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/./" \
     "$server:$GHE_REMOTE_DATA_USER_DIR/repositories/" 1>&3
 done
+bm_end "$(basename $0) - Restoring repository networks"
 
 # Tell dgit about the repositories restored
+bm_start "$(basename $0) - Finalizing routes"
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
   tempdir=\$(mktemp -d)
   echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
@@ -153,7 +160,9 @@ ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
   parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
   rm -rf \$tempdir
 EOF
+bm_end "$(basename $0) - Finalizing routes"
 
+bm_start "$(basename $0) - Updating repository info data"
 if [ -d $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/info ]; then
   ghe_verbose "* Transferring repository info data"
   sync_repo_info
@@ -161,5 +170,6 @@ else
   ghe_verbose "* Removing repository info data"
   ghe-ssh "$GHE_HOSTNAME" ghe-cluster-each -r git -- rm -f /data/repositories/info/*
 fi
+bm_end "$(basename $0) - Updating repository info data"
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-repositories-dgit-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-dgit-ng
@@ -66,10 +66,12 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-tempdir=$(mktemp -d)
+tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
+ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
 ssh_config_file=$tempdir/ssh_config
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 tmp_list=$tempdir/tmp_list
+routes_list=$tempdir/routes_list
 to_restore=$tempdir/to_restore
 
 hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server")
@@ -80,6 +82,7 @@ cleanup() {
   for hostname in $hostnames; do
     ghe-gc-enable -F $ssh_config_file $hostname:$port
   done
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
   rm -rf $tempdir
 }
 trap cleanup EXIT
@@ -112,6 +115,10 @@ done > $tmp_list
 IFS=$OLDIFS
 bm_end "$(basename $0) - Building network list"
 
+bm_start "$(basename $0) - Transferring network list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+bm_end "$(basename $0) - Transferring network list"
+
 # The server returns a list of routes:
 #
 # a/nw/a8/3f/02/100000855 dgit-node1 dgit-node2 dgit-node3
@@ -120,22 +127,18 @@ bm_end "$(basename $0) - Building network list"
 # ...
 #
 # One route per line.
-bm_start "$(basename $0) - Obtaining routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/dgit-cluster-restore-routes \
- | while read route; do
-  ghe_verbose "Received route $route"
-  servers=$(echo $route | cut -d ' ' -f2-)
-  for server in $servers; do
-    network_path=$(echo $route | cut -d ' ' -f1)
-    ghe_verbose "Adding $network_path to $tempdir/$server.rsync"
-    echo "$network_path" >> $tempdir/$server.rsync
-  done
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/dgit-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+bm_end "$(basename $0) - Generating routes"
 
-  network_id=$(echo $network_path | awk -F/ '{print $(NF)}')
-  ghe_verbose "Route: $network_id /data/repositories/$network_path $servers"
-  echo "$network_id /data/repositories/$network_path $servers" >> $to_restore
-done
-bm_end "$(basename $0) - Obtaining routes"
+bm_start "$(basename $0) - Transferring routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
+bm_end "$(basename $0) - Transferring routes"
+
+bm_start "$(basename $0) - Processing routes"
+cat $routes_list | awk -vtempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' > $to_restore
+bm_end "$(basename $0) - Processing routes"
 
 bm_start "$(basename $0) - Restoring repository networks"
 # rsync all the repositories

--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -87,9 +87,9 @@ for route in $tempdir/*.rsync; do
 done
 
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
-	tempdir=\$(mktemp -d)
-	echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
-	chunks=\$(find \$tempdir/ -name chunk\*)
-	parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
-	rm -rf \$tempdir
+  tempdir=\$(mktemp -d)
+  echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
+  chunks=\$(find \$tempdir/ -name chunk\*)
+  parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
+  rm -rf \$tempdir
 EOF

--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -82,18 +82,8 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
 bm_end "$(basename $0) - Transferring routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $routes_list | while read route; do
-  servers=$(echo $route | cut -d ' ' -f2-)
-  for server in $servers; do
-    gist=$(echo $route | cut -d ' ' -f1)
-    ghe_verbose "Adding $gist to $tempdir/$server.rsync"
-    echo "$gist" >> $tempdir/$server.rsync
-  done
-
-  gist_id=$(basename $(echo $route | cut -d ' ' -f 1) .git)
-  ghe_verbose "Route: $gist_id /data/repositories/$gist $servers"
-  echo "$gist_id /data/repositories/$gist $servers" >> $to_restore
-done
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk '{ n = split($1, p, "/"); i = p[n]; sub(/\.git/, "", i); printf i " /data/repositories/" $1; $1=""; print $0}' > $to_restore
 bm_end "$(basename $0) - Processing routes"
 
 # rsync all the gist repositories

--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -86,4 +86,10 @@ for route in $tempdir/*.rsync; do
     "$(basename $route .rsync):$GHE_REMOTE_DATA_USER_DIR/repositories/" 1>&3
 done
 
-cat $to_restore | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/gist-cluster-restore-finalize
+ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
+	tempdir=\$(mktemp -d)
+	echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
+	chunks=\$(find \$tempdir/ -name chunk\*)
+	parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
+	rm -rf \$tempdir
+EOF

--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -12,6 +12,8 @@ set -e
 # Show usage and bail with no arguments
 [ -z "$*" ] && print_usage
 
+bm_start "$(basename $0)"
+
 # Grab host arg
 GHE_HOSTNAME="$1"
 
@@ -56,12 +58,15 @@ cleanup() {
 trap cleanup EXIT
 
 # Find the routes (servers) for each gist available locally
+bm_start "$(basename $0) - Building gist list"
 OLDIFS=$IFS; IFS=$'\n'
 for path in $gist_paths; do
    echo $path
 done > $tmp_list
 IFS=$OLDIFS
+bm_end "$(basename $0) - Building gist list"
 
+bm_start "$(basename $0) - Obtaining routes"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/gist-cluster-restore-routes \
  | while read route; do
   servers=$(echo $route | cut -d ' ' -f2-)
@@ -75,8 +80,10 @@ cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/gist-cluster-restore-ro
  ghe_verbose "Route: $gist_id /data/repositories/$gist $servers"
  echo "$gist_id /data/repositories/$gist $servers" >> $to_restore
 done
+bm_end "$(basename $0) - Obtaining routes"
 
 # rsync all the gist repositories
+bm_start "$(basename $0) - Restoring gists"
 for route in $tempdir/*.rsync; do
   ghe-rsync -avrHR --delete \
     -e "ssh -q $opts -p $port -F $ssh_config_file -l $user" \
@@ -85,7 +92,9 @@ for route in $tempdir/*.rsync; do
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/repositories/./" \
     "$(basename $route .rsync):$GHE_REMOTE_DATA_USER_DIR/repositories/" 1>&3
 done
+bm_end "$(basename $0) - Restoring gists"
 
+bm_start "$(basename $0) - Finalizing routes"
 ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
   tempdir=\$(mktemp -d)
   echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
@@ -93,3 +102,6 @@ ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
   parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
   rm -rf \$tempdir
 EOF
+bm_end "$(basename $0) - Finalizing routes"
+
+bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-repositories-gist-ng
+++ b/share/github-backup-utils/ghe-restore-repositories-gist-ng
@@ -42,10 +42,12 @@ host=$(ssh_host_part "$GHE_HOSTNAME")
 user="${host%@*}"
 [ "$user" = "$host" ] && user="admin"
 
-tempdir=$(mktemp -d)
+tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
+ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
 ssh_config_file=$tempdir/ssh_config
 opts="$GHE_EXTRA_SSH_OPTS -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
 tmp_list=$tempdir/tmp_list
+routes_list=$tempdir/routes_list
 to_restore=$tempdir/to_restore
 
 hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server")
@@ -53,6 +55,7 @@ hostnames=$(ghe-cluster-hostnames "$GHE_HOSTNAME" "git-server")
 ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 
 cleanup() {
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
   rm -rf $tempdir
 }
 trap cleanup EXIT
@@ -66,21 +69,32 @@ done > $tmp_list
 IFS=$OLDIFS
 bm_end "$(basename $0) - Building gist list"
 
-bm_start "$(basename $0) - Obtaining routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" github-env ./bin/gist-cluster-restore-routes \
- | while read route; do
+bm_start "$(basename $0) - Transferring gist list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+bm_end "$(basename $0) - Transferring gist list"
+
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/gist-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+bm_end "$(basename $0) - Generating routes"
+
+bm_start "$(basename $0) - Transferring routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $routes_list
+bm_end "$(basename $0) - Transferring routes"
+
+bm_start "$(basename $0) - Processing routes"
+cat $routes_list | while read route; do
   servers=$(echo $route | cut -d ' ' -f2-)
   for server in $servers; do
     gist=$(echo $route | cut -d ' ' -f1)
     ghe_verbose "Adding $gist to $tempdir/$server.rsync"
     echo "$gist" >> $tempdir/$server.rsync
- done
+  done
 
- gist_id=$(basename $(echo $route | cut -d ' ' -f 1) .git)
- ghe_verbose "Route: $gist_id /data/repositories/$gist $servers"
- echo "$gist_id /data/repositories/$gist $servers" >> $to_restore
+  gist_id=$(basename $(echo $route | cut -d ' ' -f 1) .git)
+  ghe_verbose "Route: $gist_id /data/repositories/$gist $servers"
+  echo "$gist_id /data/repositories/$gist $servers" >> $to_restore
 done
-bm_end "$(basename $0) - Obtaining routes"
+bm_end "$(basename $0) - Processing routes"
 
 # rsync all the gist repositories
 bm_start "$(basename $0) - Restoring gists"
@@ -95,12 +109,11 @@ done
 bm_end "$(basename $0) - Restoring gists"
 
 bm_start "$(basename $0) - Finalizing routes"
-ghe-ssh "$GHE_HOSTNAME" -- /bin/sh >&3 <<EOF
-  tempdir=\$(mktemp -d)
-  echo "$(cat $to_restore)" | split -l 1000 -d - \$tempdir/chunk
-  chunks=\$(find \$tempdir/ -name chunk\*)
+cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
+  split -l 1000 -d $to_restore $tempdir/chunk
+  chunks=\$(find $tempdir/ -name chunk\*)
   parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
-  rm -rf \$tempdir
 EOF
 bm_end "$(basename $0) - Finalizing routes"
 


### PR DESCRIPTION
This PR implements a couple of new concepts, being the parallelisation of the finalisation processes, and the use of intermediary files for the route transfer.

Take for example repository backups:

Old method:

```
ghe-restore-repositories-dgit-ng - Obtaining routes took 1815s
```

Earlier version of this new method (with more granular benchmarking):

```
ghe-restore-repositories-dgit-ng - Transferring network list took 1s
ghe-restore-repositories-dgit-ng - Generating routes took 127s
ghe-restore-repositories-dgit-ng - Transferring routes took 1s
ghe-restore-repositories-dgit-ng - Processing routes took 0s
```

/cc @github/backup-utils @github/enterprise-on-prem @dbussink @jatoben @terrorobe  