### PR TITLE
Prefer ssh port specified at command line

### DIFF
--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -12,7 +12,11 @@ set -e
 opts="$GHE_EXTRA_SSH_OPTS"
 while true; do
     case "$1" in
-        -p|-l|-o|-F)
+        -p)
+            port="$2"
+            shift 2
+            ;;
+        -l|-o|-F)
             opts="$opts $1 $2"
             shift 2
             ;;
@@ -37,7 +41,7 @@ if [ "$1" = "--" ]; then
 fi
 
 # Split host:port into parts
-port=$(ssh_port_part "$host")
+port=${port:-$(ssh_port_part "$host")}
 host=$(ssh_host_part "$host")
 
 # Add user / -l option

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -40,7 +40,7 @@ if [ "$1" = "--" ]; then
     shift
 fi
 
-# Split host:port into parts
+# Split host:port into parts. The port is only used if not specified earlier.
 port=${port:-$(ssh_port_part "$host")}
 host=$(ssh_host_part "$host")
 


### PR DESCRIPTION
This PR fixes a bug with the new SSH multiplexing implementation that would see the wrong port used for the control socket name if a port was specified using `-p` and not as part of the hostname:

```
$ ./share/github-backup-utils/ghe-ssh test-host:122 -- hostname
test-host
$ ./share/github-backup-utils/ghe-ssh -p 122 test-host -- hostname
This port is reserved for git operations.
To administer the host over SSH, use port 122 with `ssh -p 122`.
```

This bug is triggered in a number of the `rsync` calls used during the backup of a standalone appliance.

/cc @github/backup-utils @jatoben for review