### PR TITLE
Prepare backup-utils for the Elasticsearch upgrade coming in GHE 2.11.0

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -123,6 +123,16 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
   exit 1
 fi
 
+# Only allow restores of 2.9 and 2.10 to 2.11 and above, after running the audit log migration
+if ! test -f $GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete && \
+   ! echo $snapshot_instance_version | grep -Eq "v2\.[1-9][1-9]" && \
+   echo $GHE_REMOTE_VERSION | grep -Eq "v2\.[1-9][1-9]"; then
+      echo "Error: Snapshot must be from GitHub Enterprise v2.9 or v.2.10 after running the" >&2
+      echo "       audit log migration, or from 2.11.0 or above." >&2
+      echo "Please see https://git.io/v5rCE for the audit log migration procedure." >&2
+      exit 1
+fi
+
 # Prompt to verify the restore host given is correct. Restoring overwrites
 # important data on the destination appliance that cannot be recovered. This is
 # mostly to prevent accidents where the backup host is given to restore instead

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -349,6 +349,11 @@ else
   ghe-restore-es-${GHE_BACKUP_STRATEGY} "$GHE_HOSTNAME" 1>&3
 fi
 
+# Restore the audit log migration sentinel file, if it exists in the snapshot
+if test -f $GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete; then
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo touch $GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete"
+fi
+
 # Restart an already running memcached to reset the cache after restore
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     echo "Restarting memcached ..." 1>&3

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -123,14 +123,19 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
   exit 1
 fi
 
-# Only allow restores of 2.9 and 2.10 to 2.11 and above, after running the audit log migration
-if ! test -f $GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete && \
-   ! echo $snapshot_instance_version | grep -Eq "v2\.[1-9][1-9]" && \
-   echo $GHE_REMOTE_VERSION | grep -Eq "v2\.[1-9][1-9]"; then
-      echo "Error: Snapshot must be from GitHub Enterprise v2.9 or v.2.10 after running the" >&2
-      echo "       audit log migration, or from 2.11.0 or above." >&2
-      echo "Please see https://git.io/v5rCE for the audit log migration procedure." >&2
-      exit 1
+# Only allow restores of 2.9 and 2.10 snapshots that have run the audit log migration to 2.11 and above
+if ! $force; then
+  snapshot_instance_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)
+  snapshot_version_major=$(echo "${snapshot_instance_version#v}" | cut -f 1 -d .)
+  snapshot_version_minor=$(echo "$snapshot_instance_version"     | cut -f 2 -d .)
+  if ! test -f $GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete && \
+     [ "$snapshot_version_major" -eq 2 ] && [ "$snapshot_version_minor" -lt 11 ] && \
+     [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 11 ]; then
+        echo "Error: Snapshot must be from GitHub Enterprise v2.9 or v2.10 after running the" >&2
+        echo "       audit log migration, or from v2.11.0 or above." >&2
+        echo "Please see https://git.io/v5rCE for the audit log migration procedure." >&2
+        exit 1
+  fi
 fi
 
 # Prompt to verify the restore host given is correct. Restoring overwrites

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -109,7 +109,7 @@ if $cluster; then
   snapshot_instance_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)
   if ! echo $snapshot_instance_version | \
     grep -Eq "v2\.[5-9]|v2\.[1-9][0-9]|v[3-9]|v[1-9][0-9]"; then
-    echo "Error: Snapshot must be from GitHub Enterprise v2.5.0 or above to be restored"
+    echo "Error: Snapshot must be from GitHub Enterprise v2.5.0 or above to be restored" >&2
     echo "       into a cluster (detected $snapshot_instance_version).  Aborting." >&2
     exit 1
   fi

--- a/script/cibuild
+++ b/script/cibuild
@@ -11,6 +11,7 @@ REMOTE_VERSIONS="
   2.0.0
   2.2.0
   2.5.0
+  2.11.0
 "
 
 # Enable verbose logging of ssh commands

--- a/share/github-backup-utils/ghe-backup-es-rsync
+++ b/share/github-backup-utils/ghe-backup-es-rsync
@@ -96,4 +96,9 @@ ghe-rsync -avz \
     "$(ssh_host_part "$host"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch/" \
     "$GHE_SNAPSHOT_DIR/elasticsearch" 1>&3
 
+# "Backup" audit log migration sentinel file
+if ghe-ssh "$host" -- "test -f $GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete"; then
+  touch $GHE_SNAPSHOT_DIR/es-scan-complete
+fi
+
 bm_end "$(basename $0)"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -49,6 +49,9 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
 
     # Create a fake UUID
     echo "fake uuid" > "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
+
+    # Create fake audit log migration sentinel file
+    touch "$GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete"
 fi
 
 # Create some fake elasticsearch data in the remote data directory
@@ -154,6 +157,9 @@ begin_test "ghe-backup first snapshot"
 
         # check that ca certificates were backed up
         [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]
+
+        # verify the audit log migration sentinel file has been created
+        [ -f "$GHE_DATA_DIR/current/es-scan-complete" ]
     fi
 
     # verify that ghe-backup wrote its version information to the host
@@ -241,6 +247,9 @@ begin_test "ghe-backup subsequent snapshot"
 
         # check that ca certificates were backed up
         [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]
+
+        # verify the audit log migration sentinel file has been created
+        [ -f "$GHE_DATA_DIR/current/es-scan-complete" ]
     fi
 )
 end_test
@@ -344,6 +353,9 @@ begin_test "ghe-backup with relative data dir path"
 
         # check that ca certificates were backed up
         [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]
+
+        # verify the audit log migration sentinel file has been created
+        [ -f "$GHE_DATA_DIR/current/es-scan-complete" ]
     fi
 
     # verify that ghe-backup wrote its version information to the host

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -83,6 +83,9 @@ echo "fake ghe-export-ssl-ca-certificates data" > "$GHE_DATA_DIR/current/ssl-ca-
 echo "fake license data" > "$GHE_DATA_DIR/current/enterprise.ghl"
 echo "fake manage password hash data" > "$GHE_DATA_DIR/current/manage-password"
 echo "rsync" > "$GHE_DATA_DIR/current/strategy"
+if [ "$GHE_VERSION_MAJOR" -eq 2 ]; then
+  touch "$GHE_DATA_DIR/current/es-scan-complete"
+fi
 
 begin_test "ghe-restore into configured vm"
 (
@@ -152,6 +155,11 @@ begin_test "ghe-restore into configured vm"
 
         # verify the UUID was transferred
         diff -ru "$GHE_DATA_DIR/current/uuid" "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
+
+        # verify the audit log migration sentinel file has been created on 2.9 and above
+        if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 9 ]; then
+          [ -f "$GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete" ]
+        fi
     fi
 )
 end_test
@@ -292,6 +300,11 @@ begin_test "ghe-restore -c into unconfigured vm"
 
         # verify ghe-export-ssl-ca-certificates was run
         grep -q "fake ghe-export-ssl-ca-certificates data" "$TRASHDIR/restore-out"
+
+        # verify the audit log migration sentinel file has been created on 2.9 and above
+        if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 9 ]; then
+          [ -f "$GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete" ]
+        fi
     fi
 )
 end_test
@@ -365,6 +378,11 @@ begin_test "ghe-restore into unconfigured vm"
 
         # verify no config run after restore on unconfigured instance
         ! grep -q "ghe-config-apply OK" "$TRASHDIR/restore-out"
+
+        # verify the audit log migration sentinel file has been created on 2.9 and above
+        if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 9 ]; then
+          [ -f "$GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete" ]
+        fi
     fi
 )
 end_test
@@ -418,6 +436,11 @@ begin_test "ghe-restore with host arg"
 
         # verify the UUID was transferred
         diff -ru "$GHE_DATA_DIR/current/uuid" "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
+
+        # verify the audit log migration sentinel file has been created on 2.9 and above
+        if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 9 ]; then
+          [ -f "$GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete" ]
+        fi
     fi
 )
 end_test


### PR DESCRIPTION
This pull request prepares backup-utils to handle the restrictions and requirements around the Elasticsearch upgrade coming in GitHub Enterprise 2.11.0 as detailed https://help.github.com/enterprise/2.10/admin/guides/installation/migrating-audit-logs-to-github-enterprise-2-11/

This pull request ensure backup-utils...

- "backs up" the `/data/user/common/es-scan-complete` file on 2.9 and 2.10 appliances that have already followed the migration preparation process,
- "restores" the `/data/user/common/es-scan-complete` to 2.9 and 2.10 appliances, if included in the snapshot being restored, to indicate that the restored indices have already been through the migration procress,
- prevents restoring of 2.9 and 2.10 snapshots that have not gone through the migration process to 2.11,
- adds 2.11.0 to the list of versions CI runs against, 
- and adds tests for all of the above.

I also snuck in a little missing redirect I noticed.

/cc @github/backup-utils 