### PR TITLE
move host check so that ES dump scripts can run standalone

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -11,11 +11,11 @@ set -e
 
 bm_start "$(basename $0)"
 
-# Set up remote host and root elastic backup directory based on config
-host="$GHE_HOSTNAME"
-
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"
+
+# Set up remote host and root elastic backup directory based on config
+host="$GHE_HOSTNAME"
 
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/audit-log"

--- a/share/github-backup-utils/ghe-backup-es-hookshot
+++ b/share/github-backup-utils/ghe-backup-es-hookshot
@@ -11,11 +11,11 @@ set -e
 
 bm_start "$(basename $0)"
 
-# Set up remote host and root elastic backup directory based on config
-host="$GHE_HOSTNAME"
-
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$host"
+
+# Set up remote host and root elastic backup directory based on config
+host="$GHE_HOSTNAME"
 
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/hookshot"


### PR DESCRIPTION
we need to give `ghe_remote_version_required` a chance to rewrite `$GHE_HOSTNAME` to include port 122 before using it in later `ghe-ssh` calls, otherwise either script fails with

```
++ ghe-ssh ghefusion.michaelrenner.at 'curl -s "localhost:9201/_cat/indices/audit_log*?h=index"'
This port is reserved for git operations.
To administer the host over SSH, use port 122 with `ssh -p 122`.
```