### PR TITLE
Determine if audit log migration needs to take place as part of backup

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -31,6 +31,13 @@ if ! indices=$(ghe-ssh "$host" "curl -s \"localhost:$es_port/_cat/indices/audit_
   exit 1
 fi
 
+# Determine if the audit log migration has occurred or is needed.
+if echo 'set -o pipefail; ! test -e /data/user/common/es-scan-complete && test -f /usr/local/share/enterprise/run-audit-log-transitions.sh' | ghe-ssh "$host" /bin/bash; then
+  if echo 'set -o pipefail; echo n | /usr/local/share/enterprise/run-audit-log-transitions.sh > /dev/null 2>&1 && touch /data/user/common/es-scan-complete' | ghe-ssh "$host" /bin/bash; then
+    touch $GHE_SNAPSHOT_DIR/es-scan-complete
+  fi
+fi
+
 current_index=audit_log-$(ghe-ssh "$host" 'date +"%Y-%m"')
 
 for index in $indices; do


### PR DESCRIPTION
Whilst working on https://github.com/github/backup-utils/pull/329, I completely missed the fact the `es-scan-complete` file we check when restoring is only created when an instance is upgraded. 

This missed fact means compatible 2.9 and 2.10 snapshots can _not_ be restored to 2.11 instances as the file doesn't exist in the snapshot.

This PR resolves this problem by checking if the audit log transition needs to take place, and if not, drops the `es-scan-complete` file onto the host and stores it within the backup.



The side effect is admins will need to take a new backup using the latest version of backup-utils (once this has been merged) before they can restore a 2.9 or 2.10 backup to a 2.11 host.

/cc @github/backup-utils 