### PR TITLE
Remove use of --literally when computing arbitrary shasum

### DIFF
--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -58,7 +58,7 @@ if echo "$*" | grep "[|;]" >/dev/null || [ $(echo "$*" | wc -l) -gt 1 ]; then
 fi
 
 if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
-  controlpath="$TMPDIR/.ghe-sshmux-$(echo -n "$user@$host:$port" | git hash-object --stdin --literally | cut -c 1-8)"
+  controlpath="$TMPDIR/.ghe-sshmux-$(echo -n "$user@$host:$port" | git hash-object --stdin | cut -c 1-8)"
   opts="-o ControlMaster=auto -o ControlPath=\"$controlpath\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
   # Workaround for https://bugzilla.mindrot.org/show_bug.cgi?id=1988
   [ -S $controlpath ] || ssh -f -p $port $opts -o BatchMode=yes "$host" -- /bin/true 1>/dev/null 2>&1 || true

--- a/share/github-backup-utils/ghe-ssh-config
+++ b/share/github-backup-utils/ghe-ssh-config
@@ -25,7 +25,7 @@ proxy_user="${proxy_host%@*}"
 
 opts="$GHE_EXTRA_SSH_OPTS"
 
-[ -z "$GHE_DISABLE_SSH_MUX" ] && opts="-o ControlMaster=auto -o ControlPath=\"$TMPDIR/.ghe-sshmux-$(echo -n "$proxy_user@$proxy_host:$proxy_port" | git hash-object --stdin --literally | cut -c 1-8)\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
+[ -z "$GHE_DISABLE_SSH_MUX" ] && opts="-o ControlMaster=auto -o ControlPath=\"$TMPDIR/.ghe-sshmux-$(echo -n "$proxy_user@$proxy_host:$proxy_port" | git hash-object --stdin | cut -c 1-8)\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
 
 for host in $hosts; do
   cat <<EOF


### PR DESCRIPTION
As `git hash-object` defaults to a type of `blob`, and what we feed in is considered a valid `blob`, the `--literally` flag isn't required.

This removes the need for a newer version of `git` as the updated invocation of the command is backwards compatible all the way back to `git` 1.0.0.

Fixes #337.

/cc @github/backup-utils for review