### PR TITLE
Support 2.11 audit log index naming for cluster backups and restores

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -38,16 +38,16 @@ if echo 'set -o pipefail; ! test -e /data/user/common/es-scan-complete && test -
   fi
 fi
 
-current_index=audit_log-$(ghe-ssh "$host" 'date +"%Y-%m"')
+current_index="audit_log(-[0-9]+)?-$(ghe-ssh "$host" 'date +"%Y-%m"')(-[0-9]+)?"
 
 for index in $indices; do
-  if [ -f $GHE_DATA_DIR/current/audit-log/$index.gz -a -f $GHE_DATA_DIR/current/audit-log/$index.gz.complete -a $index \< $current_index ]; then
+  if [[ -f $GHE_DATA_DIR/current/audit-log/$index.gz && -f $GHE_DATA_DIR/current/audit-log/$index.gz.complete && ! $index =~ $current_index ]]; then
     # Hard link any older indices that are complete, since these won't change
     ln $GHE_DATA_DIR/current/audit-log/$index.gz $GHE_SNAPSHOT_DIR/audit-log/$index.gz
     ln $GHE_DATA_DIR/current/audit-log/$index.gz.complete $GHE_SNAPSHOT_DIR/audit-log/$index.gz.complete
   else
     ghe-ssh "$host" "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:$es_port/$index\"" | gzip > $GHE_SNAPSHOT_DIR/audit-log/$index.gz
-    if [ $index \< $current_index ]; then
+    if [[ ! $index =~ $current_index ]]; then
       touch $GHE_SNAPSHOT_DIR/audit-log/$index.gz.complete
     fi
   fi

--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -19,12 +19,13 @@ GHE_HOSTNAME="$1"
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-last_index=$(ghe-ssh "$GHE_HOSTNAME" 'curl -s "localhost:9201/_cat/indices/audit_log*"' | cut -d ' ' -f 3 | sort | tail -2 | head -1)
-
 indices=$(ls -1 $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz 2>/dev/null | xargs -I{} -n1 basename {} .gz)
 
+last_month="audit_log(-[0-9]+)?-$(ghe-ssh "$GHE_HOSTNAME" 'date -d "1 month ago" +"%Y-%m"')(-[0-9]+)?"
+current_month="audit_log(-[0-9]+)?-$(ghe-ssh "$GHE_HOSTNAME" 'date +"%Y-%m"')(-[0-9]+)?"
+
 for index in $indices; do
-  if [ -z "$last_index" ] || ! [ $index \< $last_index ]; then
+  if ! ghe-ssh "$GHE_HOSTNAME" "curl -f -s -XGET http://localhost:9201/$index" || [[ $index =~ $last_month ]] || [[ $index =~ $current_month ]]; then
     ghe_verbose "* Restoring $index"
     gzip -dc $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/$index.gz | ghe-ssh "$GHE_HOSTNAME" "/usr/local/share/enterprise/ghe-es-load-json 'http://localhost:9201/$index'" 1>&3
   fi


### PR DESCRIPTION
Audit log indices are named a little differently in GitHub Enterprise 2.11, introducing a version number and slice number to the name.

As an example, the index for August 2017, which would have traditionally been named `audit_log-2017-08` is now named `audit_log-1-2017-08-1`, assuming an index version of 1 and slice number of 1.

This PR adds support for this new naming, while maintaining backwards compatibility with the old naming.

/cc @github/backup-utils for review