### PR TITLE
Allow the restoration of configuration to Cluster

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -94,7 +94,6 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
   "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/cluster' ]"; then
   cluster=true
   instance_configured=true
-  restore_settings=false
 fi
 
 # Restoring a cluster backup to a standalone appliance is not supported

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -93,7 +93,6 @@ cluster=false
 if ghe-ssh "$GHE_HOSTNAME" -- \
   "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/cluster' ]"; then
   cluster=true
-  instance_configured=true
 fi
 
 # Restoring a cluster backup to a standalone appliance is not supported


### PR DESCRIPTION
The recent introduction of SSH multiplexing support removed the last remaining roadblock to enabling the optional restoration of appliance configuration settings for customers running GitHub Enterprise Cluster.

This PR allows the `-c` flag to be used with `ghe-restore` when restoring to a Cluster, enabling the restoration of `github.conf`, which includes settings such as the instance hostname, SSL certificate and authentication options.

/cc @github/backup-utils for review