### PR TITLE
Switch to TMPDIR when working around OpenSSH bug

### DIFF
--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -61,7 +61,10 @@ if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
   controlpath="$TMPDIR/.ghe-sshmux-$(echo -n "$user@$host:$port" | git hash-object --stdin | cut -c 1-8)"
   opts="-o ControlMaster=auto -o ControlPath=\"$controlpath\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
   # Workaround for https://bugzilla.mindrot.org/show_bug.cgi?id=1988
-  [ -S $controlpath ] || ssh -f -p $port $opts -o BatchMode=yes "$host" -- /bin/true 1>/dev/null 2>&1 || true
+  if ! [ -S $controlpath ]; then
+    cd "$TMPDIR"
+    ssh -f -p $port $opts -o BatchMode=yes "$host" -- /bin/true 1>/dev/null 2>&1 || true
+  fi
 fi
 
 # Turn on verbose SSH logging if needed

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -62,8 +62,7 @@ if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
   opts="-o ControlMaster=auto -o ControlPath=\"$controlpath\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"
   # Workaround for https://bugzilla.mindrot.org/show_bug.cgi?id=1988
   if ! [ -S $controlpath ]; then
-    cd "$TMPDIR"
-    ssh -f -p $port $opts -o BatchMode=yes "$host" -- /bin/true 1>/dev/null 2>&1 || true
+    ( cd "$TMPDIR" && ssh -f -p $port $opts -o BatchMode=yes "$host" -- /bin/true 1>/dev/null 2>&1 || true )
   fi
 fi
 


### PR DESCRIPTION
As identified in https://github.com/github/backup-utils/issues/345, if we don't switch to `$TMPDIR` before working around the OpenSSH bug, we end up holding a file handle open on the backup directory until such time as the master connection timeout has been reached (10mins).  This poses a problem if the backup directory is an NFS mount that needs to be umounted when the backup has finished.

Fixes https://github.com/github/backup-utils/issues/345

🎩  tip to @zmedico for the fix.

/cc @github/backup-utils 