### PR TITLE
test/test-ghe-backup.sh: skip test if not in a git checkout

### DIFF
--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -475,14 +475,20 @@ begin_test "ghe-backup stores version when not run from a clone"
   # Make sure this doesn't exist
   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
 
-  tmpdir=$(mktemp -d $TRASHDIR/foo.XXXXXX)
-  git clone $ROOTDIR $tmpdir/backup-utils
-  cd $tmpdir/backup-utils
-  rm -rf .git
-  ./bin/ghe-backup
+  tmpdir=$(mktemp -d "$TRASHDIR/foo.XXXXXX")
 
-  # verify that ghe-backup wrote its version information to the host
-  [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]
+  # If user is running the tests extracted from a release tarball, git clone will fail.
+  if GIT_DIR="$ROOTDIR/.git" git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+      git clone "$ROOTDIR" "$tmpdir/backup-utils"
+      cd "$tmpdir/backup-utils"
+      rm -rf .git
+      ./bin/ghe-backup
+
+      # Verify that ghe-backup wrote its version information to the host
+      [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]
+  else
+      echo ".git directory not found, skipping ghe-backup not from a clone test"
+  fi
 )
 end_test
 


### PR DESCRIPTION
See https://bugs.gentoo.org/629628 for the background. In short, the test always assumed it was a git repo, and so git clone would always be available. If someone runs the tests from a tarball release, that's not true. The file is still there, just need to skip the clone.