### PR TITLE
test/bin/python: force python2.7 so it works on python3 systems

### DIFF
--- a/test/bin/python
+++ b/test/bin/python
@@ -18,7 +18,7 @@ cat >/dev/null
 # verify the python compiles at least. if this fails then the python code passed
 # to -c failed basic syntax checks.
 echo "$2" |
-/usr/bin/python -c "import sys; __import__('compiler').parse(sys.stdin.read())"
+/usr/bin/python2.7 -c "import sys; __import__('compiler').parse(sys.stdin.read())"
 
 # pretend we found zero processes.
 echo 0


### PR DESCRIPTION
compiler was deprecated in python2.6 and removed in python3+

https://docs.python.org/2/library/compiler.html