### PR TITLE
Docker image variable tests

### DIFF
--- a/share/github-backup-utils/ghe-docker-init
+++ b/share/github-backup-utils/ghe-docker-init
@@ -8,7 +8,7 @@ touch /etc/github-backup-utils/backup.config
 
 for VAR in $(env); do
   if [[ $VAR =~ ^GHE_ ]]; then
-      backuputils_name=$(echo "$VAR" | sed -r "s/GHE_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]')
+      backuputils_name=$(echo "$VAR" | sed -r "s/(.*)=.*/\1/g")
       backuputils_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\1/g")
       echo "${backuputils_name}=${backuputils_value}" >> /etc/github-backup-utils/backup.config
   fi

--- a/test/test-docker-build.sh
+++ b/test/test-docker-build.sh
@@ -41,7 +41,7 @@ begin_test "GHE_ env variables set in backup.config"
 (
   set -e
 
-  docker run --rm -e "GHE_TEST_VAR=test" -t github/backup-utils:test grep "GHE_TEST_VAR=test" /etc/github-backup-utils/backup.config
+  docker run --rm -e "GHE_TEST_VAR=test" -t github/backup-utils:test cat /etc/github-backup-utils/backup.config | grep "GHE_TEST_VAR=test"
 )
 end_test
 

--- a/test/test-docker-build.sh
+++ b/test/test-docker-build.sh
@@ -28,3 +28,27 @@ begin_test "docker build completes successfully"
   docker build -q -t github/backup-utils:test . | grep "sha256:"
 )
 end_test
+
+begin_test "docker run completes successfully"
+(
+  set -e
+
+  docker run --rm -t github/backup-utils:test ghe-host-check --version | grep "GitHub backup-utils "
+)
+end_test
+
+begin_test "GHE_ env variables set in backup.config"
+(
+  set -e
+
+  docker run --rm -e "GHE_TEST_VAR=test" -t github/backup-utils:test grep "GHE_TEST_VAR=test" /etc/github-backup-utils/backup.config
+)
+end_test
+
+begin_test "Non GHE_ env variables not set in backup.config"
+(
+  set -e
+
+  docker run --rm -e "GHE_TEST_VAR=test" -e "NGHE_TEST_VAR=test" -t github/backup-utils:test grep -L "NGHE_TEST_VAR=test" /etc/github-backup-utils/backup.config | grep /etc/github-backup-utils/backup.config
+)
+end_test


### PR DESCRIPTION
Adds a few additional test items to the Docker build tests.

In adding a test to validate the correct ENV variables being set in `/etc/github-backup-utils/backup.config` , I realized I was using a bad `sed` and `tr` statement in the init script, which was leading to an invalid formatted / useless config within container.

This wasn't causing the backups to fail,as backup-utils was just reading the correctly formatted env `GHE_` variables set at runtime in the container.

I suppose this exposes the possibility of just removing `/etc/github-backup-utils/backup.config` and related function for writing the env variables there completely, but maybe it is good to have the fallback?