### PR TITLE
Remove other snapshot contents before removing the "incomplete" file

### DIFF
--- a/share/github-backup-utils/ghe-prune-snapshots
+++ b/share/github-backup-utils/ghe-prune-snapshots
@@ -14,7 +14,7 @@ prune_snapshot() {
   while read prune_dir; do
     [ -n "$prune_dir" ] || return
     touch "$prune_dir/incomplete"
-    find "$prune_dir" -mindepth 1 -maxdepth 1 -not -path "$prune_dir/incomplete" | xargs rm -rf
+    find "$prune_dir" -mindepth 1 -maxdepth 1 -not -path "$prune_dir/incomplete" -print0 | xargs -0 rm -rf
     rm -rf "$prune_dir"
   done
 }

--- a/share/github-backup-utils/ghe-prune-snapshots
+++ b/share/github-backup-utils/ghe-prune-snapshots
@@ -6,13 +6,26 @@ set -e
 # Bring in the backup configuration
 . $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
 
+# Once we start pruning, this backup will no longer be valid.
+# So create or preserve its `incomplete` file and remove the
+# `incomplete` file last.
+prune_snapshot() {
+  local prune_dir
+  while read prune_dir; do
+    [ -n $prune_dir ] || return
+    touch "$prune_dir/incomplete"
+    find "$prune_dir" -not -path "$prune_dir/incomplete" | xargs rm -rf
+    rm -rf "$prune_dir"
+  done
+}
+
 # First prune all incomplete / failed snapshot directories
 prune_dirs="$(ls -1 "$GHE_DATA_DIR"/[0-9]*/incomplete 2>/dev/null || true)"
 prune_num=$(echo "$prune_dirs" | grep -v '^$' | wc -l)
 
 if [ $prune_num -gt 0 ]; then
     echo Pruning $prune_num "failed snapshot(s) ..."
-    echo "$prune_dirs" | sed 's@/incomplete$@@' | xargs rm -rf
+    echo "$prune_dirs" | sed 's@/incomplete$@@' | prune_snapshot
 fi
 
 # Now prune all expired snapshots. Keep GHE_NUM_SNAPSHOTS around.
@@ -22,5 +35,5 @@ if [ "$snapshot_count" -gt "$GHE_NUM_SNAPSHOTS" ]; then
     prune_dirs="$(ls -1d "$GHE_DATA_DIR"/[0-9]* | sort -r | awk "NR>$GHE_NUM_SNAPSHOTS")"
     prune_num=$(echo "$prune_dirs" | grep -v '^$' | wc -l)
     echo Pruning $prune_num "expired snapshot(s) ..."
-    echo "$prune_dirs" | xargs rm -rf
+    echo "$prune_dirs" | prune_snapshot
 fi

--- a/share/github-backup-utils/ghe-prune-snapshots
+++ b/share/github-backup-utils/ghe-prune-snapshots
@@ -12,7 +12,7 @@ set -e
 prune_snapshot() {
   local prune_dir
   while read prune_dir; do
-    [ -n $prune_dir ] || return
+    [ -n "$prune_dir" ] || return
     touch "$prune_dir/incomplete"
     find "$prune_dir" -not -path "$prune_dir/incomplete" | xargs rm -rf
     rm -rf "$prune_dir"

--- a/share/github-backup-utils/ghe-prune-snapshots
+++ b/share/github-backup-utils/ghe-prune-snapshots
@@ -14,7 +14,7 @@ prune_snapshot() {
   while read prune_dir; do
     [ -n "$prune_dir" ] || return
     touch "$prune_dir/incomplete"
-    find "$prune_dir" -not -path "$prune_dir/incomplete" | xargs rm -rf
+    find "$prune_dir" -mindepth 1 -maxdepth 1 -not -path "$prune_dir/incomplete" | xargs rm -rf
     rm -rf "$prune_dir"
   done
 }


### PR DESCRIPTION
When [`ghe-prune-snapshots`](https://github.com/github/backup-utils/blob/675786c2b6b5ee003b1811911c3b66bc09b2cae0/share/github-backup-utils/ghe-prune-snapshots) is interrupted, it may leave a snapshot directory containing a partial backup snapshot - without an `incomplete` file.

If that happens while pruning failed or incomplete backups, the partial snapshot may be retained along with actually-completed snapshots.

This Pull Request modifies `ghe-prune-snapshots` to remove the `incomplete` file after other snapshot contents have been removed.

How do y'all feel about this approach? and specifically about adding an `incomplete` file to a snapshot we're about to prune?