### PR TITLE
More efficiently extract and quote environment variables when writing to config file on Docker

### DIFF
--- a/share/github-backup-utils/ghe-docker-init
+++ b/share/github-backup-utils/ghe-docker-init
@@ -6,12 +6,6 @@ mkdir -p /etc/github-backup-utils
 
 touch /etc/github-backup-utils/backup.config
 
-for VAR in $(env); do
-  if [[ $VAR =~ ^GHE_ ]]; then
-      backuputils_name=$(echo "$VAR" | sed -r "s/(.*)=.*/\1/g")
-      backuputils_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\1/g")
-      echo "${backuputils_name}=${backuputils_value}" >> /etc/github-backup-utils/backup.config
-  fi
-done
+env | grep ^GHE_ | sed -r "s/(.[^=]+)=(.*)/\1=\"\2\"/g" >> /etc/github-backup-utils/backup.config
 
 exec "$@"

--- a/test/test-docker-build.sh
+++ b/test/test-docker-build.sh
@@ -41,7 +41,15 @@ begin_test "GHE_ env variables set in backup.config"
 (
   set -e
 
-  docker run --rm -e "GHE_TEST_VAR=test" -t github/backup-utils:test cat /etc/github-backup-utils/backup.config | grep "GHE_TEST_VAR=test"
+  docker run --rm -e "GHE_TEST_VAR=test" -t github/backup-utils:test cat /etc/github-backup-utils/backup.config | grep "GHE_TEST_VAR=\"test\""
+)
+end_test
+
+begin_test "GHE_ env variables with spaces set in backup.config"
+(
+  set -e
+
+  docker run --rm -e "GHE_TEST_VAR=test with a space" -t github/backup-utils:test cat /etc/github-backup-utils/backup.config | grep "GHE_TEST_VAR=\"test with a space\""
 )
 end_test
 
@@ -49,6 +57,6 @@ begin_test "Non GHE_ env variables not set in backup.config"
 (
   set -e
 
-  docker run --rm -e "GHE_TEST_VAR=test" -e "NGHE_TEST_VAR=test" -t github/backup-utils:test grep -L "NGHE_TEST_VAR=test" /etc/github-backup-utils/backup.config | grep /etc/github-backup-utils/backup.config
+  docker run --rm -e "GHE_TEST_VAR=test" -e "NGHE_TEST_VAR=test" -t github/backup-utils:test grep -L "NGHE_TEST_VAR=\"test\"" /etc/github-backup-utils/backup.config | grep /etc/github-backup-utils/backup.config
 )
 end_test

--- a/test/test-docker-build.sh
+++ b/test/test-docker-build.sh
@@ -37,7 +37,7 @@ begin_test "docker run completes successfully"
 )
 end_test
 
-begin_test "GHE_ env variables set in backup.config"
+begin_test "docker GHE_ env variables set in backup.config"
 (
   set -e
 
@@ -45,7 +45,7 @@ begin_test "GHE_ env variables set in backup.config"
 )
 end_test
 
-begin_test "GHE_ env variables with spaces set in backup.config"
+begin_test "docker GHE_ env variables with spaces set in backup.config"
 (
   set -e
 
@@ -53,7 +53,7 @@ begin_test "GHE_ env variables with spaces set in backup.config"
 )
 end_test
 
-begin_test "Non GHE_ env variables not set in backup.config"
+begin_test "docker Non GHE_ env variables not set in backup.config"
 (
   set -e
 


### PR DESCRIPTION
I noticed yesterday that when using our instructions to pass the `GHE_EXTRA_SSH_OPTS` variable to a docker container, that the backup was failing:

```
$ docker run -it -e "GHE_HOSTNAME=10.0.1.64" \
-e "GHE_DATA_DIR=/data" \
-e "GHE_EXTRA_SSH_OPTS=-i /ghe-ssh/id_rsa -o UserKnownHostsFile=/ghe-ssh/known_hosts" \
-e "GHE_NUM_SNAPSHOTS=15" \
-v "ghe-backup-data:/data" \
-v "$HOME/.ssh/known_hosts:/ghe-ssh/known_hosts" \
-v "$HOME/.ssh/aws-lildude.pem:/ghe-ssh/id_rsa" \
-v "$(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK)" \
-e "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" \
--rm \
github/backup-utils ghe-backup
Starting backup of 10.0.1.64 in snapshot 20171213T154200
Warning: Identity file -o not accessible: No such file or directory.
ssh: Could not resolve hostname batchmode=no: Name or service not known
Error: ssh connection with '10.0.1.64' failed
Note that your SSH key needs to be setup on 10.0.1.64 as described in:
* https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access
$
```

Note...

```
Warning: Identity file -o not accessible: No such file or directory.
ssh: Could not resolve hostname batchmode=no: Name or service not known
```

Whoopsie 😮 

After a lot of digging, I worked out that this was happening because of the way `ghe-docker-init` was taking the environment variables and writing them to file. The problem is the current method doesn't take into account variable values with spaces. These aren't being quoted which means each "word" is being treated as a different option and silently dropped after the first.

This PR addresses this by simplifying the process of writing the environment variables to file and quoting them all, like we suggest they are in the `backup-utils.config-example` file, to ensure we don't end up with inadvertent option splitting.

/cc @djdefi as the original implementor. I'm not sure how I missed this or how this worked when I tested https://github.com/github/backup-utils/pull/346 as it _did_ work for me AFAICR. 🤔