### PR TITLE
Backup and restore the management console password

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -28,15 +28,11 @@ ghe-ssh "$host" -- "$comm" > enterprise.ghl
 
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     echo "* Transferring management console password ..." 1>&3
-    manage_password_file="$GHE_REMOTE_DATA_USER_DIR/common/manage-password"
-    if echo "sudo cat '$manage_password_file' 2>/dev/null || true" |
-       ghe-ssh "$host" -- /bin/sh > manage-password+
-    then
-        if [ -n "$(cat manage-password+)" ]; then
-            mv manage-password+ manage-password
-        fi
+    ghe-ssh "$host" -- ghe-config secrets.manage > manage-password+
+    if [ -n "$(cat manage-password+)" ]; then
+      mv manage-password+ manage-password
     else
-        unlink manage-password+
+      unlink manage-password+
     fi
 
     if ghe-ssh "$host" -- "test -f $GHE_REMOTE_DATA_USER_DIR/common/idp.crt"; then

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -47,8 +47,8 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-license' < "$GHE_RESTORE_SNAPSHOT_PATH/en
 # Restore management console password hash if present.
 if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/manage-password" ]; then
     echo "Restoring management console password ..."
-    cat "$GHE_RESTORE_SNAPSHOT_PATH/manage-password" |
-    ghe-ssh "$GHE_HOSTNAME" -- "ghe-import-passwords"
+    echo "ghe-config secrets.manage '$(cat "$GHE_RESTORE_SNAPSHOT_PATH/manage-password")'" |
+    ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
 fi
 
 # Restore SAML keys if present.

--- a/test/bin/ghe-config
+++ b/test/bin/ghe-config
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Usage: ghe-config
+# Emulates the remote GitHub ghe-config secrets.manage command. Tests use this
+# to assert that the command was executed.
+set -e
+if [ $# -eq 1 ]; then
+  git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" "$1"
+else
+  git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" "$1" "$2"
+fi

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -15,7 +15,7 @@ touch alice/index.html bob/index.html
 
 # Create a fake manage password file
 mkdir -p "$GHE_REMOTE_DATA_USER_DIR/common"
-echo "fake password hash data" > "$GHE_REMOTE_DATA_USER_DIR/common/manage-password"
+git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage "fake password hash data"
 
 if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
     # Create some fake data in the remote data directory
@@ -416,11 +416,11 @@ begin_test "ghe-backup cleans up stale in-progress file"
 )
 end_test
 
-begin_test "ghe-backup without manage-password file"
+begin_test "ghe-backup without management console password"
 (
     set -e
 
-    unlink "$GHE_REMOTE_DATA_USER_DIR/common/manage-password"
+    git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage ""
     ghe-backup
 
     [ ! -f "$GHE_DATA_DIR/current/manage-password" ]


### PR DESCRIPTION
The management console password hasn't been backed up for all releases since GitHub Enterprise 2.6.0 due to a change I introduced and forgot to make the equivalent update to backup-utils. 😊

This isn't a major problem, it just meant admins needed to browse to the management console and set a new password even when restoring the settings.

This PR brings back backing up and restoring of the management console password.

Fixes https://github.com/github/enterprise2/issues/6221

/cc @github/backup-utils 