### PR TITLE
Check for git before allowing SSH multiplex

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -113,6 +113,9 @@ echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ../in-progress
 
 echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 
+# Warn if git is not installed, and set GHE_DISABLE_SSH_MUX=true
+command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed." && export GHE_DISABLE_SSH_MUX=true
+
 # Perform a host connection check and establish the remote appliance version.
 # The version is available in the GHE_REMOTE_VERSION variable and also written
 # to a version file in the snapshot directory itself.


### PR DESCRIPTION
Without `git` being installed, `ghe-backup` will fail will a rather unuseful error message:

```
ghe-ssh: line 61: git: command not found 
```
This PR adds a simple check to see if `git` is available in our PATH, and if it isn't, we disable multiplexing and log a Warning message. This should make things a little more friendly. Here is what the warning looks like:

```
$ bin/ghe-backup 
Starting backup of hostname in snapshot 20180105T235729
Warning: SSH multiplexing requires git but it's not installed.
Connect hostname:122 OK (v2.12.1)
Backing up GitHub settings ...
...
```

Open to any suggestions on adding a test case for this, if one is warranted (or possible).

----

Background on the `git` dependency for future readers: 

<details>

Git is now used by the [Backup Utilities](https://github.com/github/backup-utils) instead of `sha256sum` to generate an object hash—this change was made due to a cross platform compatibility issue several users were experiencing. 

> Use git to generate short name for SSH multiplex control path [#335](https://github.com/github/backup-utils/pull/335)

Git has been listed as a [dependency of the Backup Utilities](https://github.com/github/backup-utils#backup-host-requirements) since mid 2016, however up until recently it was only used for a few tasks when GitHub Enterprise is deployed in a cluster configuration. It is now also required for standalone backups when the SSH multiplexing feature is enabled.

SSH multiplexing was [added in the 2.11.0 release](https://github.com/github/backup-utils/pull/321) in order to improve backup performance and is enabled by default. If you experience problems with SSH multiplexing, the feature can be disabled by adding `GHE_DISABLE_SSH_MUX=true` to your *backup.config* file.

</details>

cc: @github/backup-utils @taz  