### PR TITLE
Cleanup SSH multiplexing on exit

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -38,7 +38,8 @@ while true; do
 done
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+# shellcheck source=share/github-backup-utils/ghe-backup-config
+. "$( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config"
 
 # Used to record failed backup steps
 failures=
@@ -74,7 +75,7 @@ cleanup () {
     progress=$(cat ../in-progress)
     snapshot=$(echo "$progress" | cut -d ' ' -f 1)
     pid=$(echo "$progress" | cut -d ' ' -f 2)
-    if [ "$snapshot" = "$GHE_SNAPSHOT_TIMESTAMP" -a "$$" = $pid ]; then
+    if [ "$snapshot" = "$GHE_SNAPSHOT_TIMESTAMP" ] && [ "$$" = $pid ]; then
       unlink ../in-progress
     fi
   fi

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -82,6 +82,9 @@ cleanup () {
   if $GHE_MAINTENANCE_MODE_ENABLED; then
     ghe-maintenance-mode-disable "$GHE_HOSTNAME"
   fi
+
+  # Cleanup SSH multiplexing
+  ghe-ssh --clean "$GHE_HOSTNAME"
 }
 
 # Setup exit traps

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -77,7 +77,8 @@ cleanup () {
 }
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
+# shellcheck source=share/github-backup-utils/ghe-backup-config
+. "$( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config"
 
 # Grab the host arg
 GHE_HOSTNAME="${1:-$GHE_RESTORE_HOST}"

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -67,6 +67,15 @@ while true; do
   esac
 done
 
+cleanup () {
+  if [ -n "$1" ]; then
+    update_restore_status "$1"
+  fi
+
+  # Cleanup SSH multiplexing
+  ghe-ssh --clean "$GHE_HOSTNAME"
+}
+
 # Bring in the backup configuration
 . $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
 
@@ -205,7 +214,7 @@ update_restore_status () {
 }
 
 # Update remote restore state file and setup failure trap
-trap "update_restore_status failed" EXIT
+trap "cleanup failed" EXIT
 update_restore_status "restoring"
 
 # Verify the host has been fully configured at least once if when running
@@ -414,7 +423,7 @@ fi
 # Update the remote status to "complete". This has to happen before importing
 # ssh host keys because subsequent commands will fail due to the host key
 # changing otherwise.
-trap "" EXIT
+trap "cleanup" EXIT
 update_restore_status "complete"
 
 # Log restore complete message in /var/log/syslog on remote instance

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -7,7 +7,8 @@
 set -e
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+# shellcheck source=share/github-backup-utils/ghe-backup-config
+. "$( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config"
 
 opts="$GHE_EXTRA_SSH_OPTS"
 while true; do

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -78,10 +78,8 @@ $GHE_VERBOSE_SSH && set -x
 if [ -z "$cleanup_mux" ]; then
   # Exec ssh command with modified host / port args and add nice to command.
   exec ssh -p $port $opts -o BatchMode=yes "$host" -- $GHE_NICE $GHE_IONICE "$@"
-else
-  if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
-    while ssh -O check -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1; do
-      ssh -O stop -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1
-    done
-  fi
+elif [ -z "$GHE_DISABLE_SSH_MUX" ]; then
+  while ssh -O check -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1; do
+    ssh -O stop -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1
+  done
 fi

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -20,6 +20,10 @@ while true; do
             opts="$opts $1 $2"
             shift 2
             ;;
+        -c|--clean)
+            cleanup_mux=1
+            shift
+            ;;
         --)
             echo "Error: illegal '--' in ssh invocation"
             exit 1
@@ -70,4 +74,13 @@ fi
 $GHE_VERBOSE_SSH && set -x
 
 # Exec ssh command with modified host / port args and add nice to command.
-exec ssh -p $port $opts -o BatchMode=yes "$host" -- $GHE_NICE $GHE_IONICE "$@"
+if [ -z "$cleanup_mux" ]; then
+  # Exec ssh command with modified host / port args and add nice to command.
+  exec ssh -p $port $opts -o BatchMode=yes "$host" -- $GHE_NICE $GHE_IONICE "$@"
+else
+  if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
+    while ssh -O check -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1; do
+      ssh -O stop -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1
+    done
+  fi
+fi


### PR DESCRIPTION
Whilst experimenting with other changes, I encountered problems with an old SSH multiplexing session still running for the node in question and needed to manually clean it up so I could continue. The problems were my own fault but it did highlight that we aren't being good citizens and aren't cleaning up after ourselves.

This PR corrects this and automatically cleans up the SSH multiplexing when `ghe-backup` and `ghe-restore` exit rather than leaving it hanging around to naturally time out after 10mins.

I've also taken the opportunity to start implementing some of the simpler ShellCheck recommendations.

/cc @github/backup-utils 