### PR TITLE
Add skip_test functionality

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -60,7 +60,9 @@ if script/package-deb 1>package-deb-out.txt 2>package-deb-err.txt; then
     pkg_files="$pkg_files $(cat package-deb-out.txt)"
 else
     echo "Package build failed:"
-    cat package-deb-out.txt package-deb-err.txt 1>&2
+    cat package-deb-out.txt package-deb-err.txt >&2
+    echo >&2
+    cat dist/debuild/github-backup-utils*.build >&2
     exit 1
 fi
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -60,7 +60,7 @@ if script/package-deb 1>package-deb-out.txt 2>package-deb-err.txt; then
     pkg_files="$pkg_files $(cat package-deb-out.txt)"
 else
     echo "Package build failed:"
-    cat package-tarball.txt | sed 's/^/    /' 1>&2
+    cat package-deb-out.txt package-deb-err.txt 1>&2
     exit 1
 fi
 

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -648,7 +648,7 @@ begin_test "ghe-restore fails when restore to an active HA pair"
 
     if [ "$GHE_VERSION_MAJOR" -le 1 ]; then
       # noop GHE < 2.0, does not support replication
-      exit 0
+      skip_test
     fi
 
     rm -rf "$GHE_REMOTE_ROOT_DIR"
@@ -691,7 +691,7 @@ begin_test "ghe-restore fails when restore 2.9/2.10 snapshot without audit log m
 
   # noop if not testing against 2.11
   if [ "$GHE_VERSION_MAJOR" -le 1 ] || [ "$GHE_VERSION_MINOR" -ne 11 ]; then
-    exit 0
+    skip_test
   fi
 
   rm -rf "$GHE_REMOTE_ROOT_DIR"
@@ -718,7 +718,7 @@ begin_test "ghe-restore force restore of 2.9/2.10 snapshot without audit log mig
 
   # noop if not testing against 2.11
   if [ "$GHE_VERSION_MAJOR" -le 1 ] || [ "$GHE_VERSION_MINOR" -ne 11 ]; then
-    exit 0
+    skip_test
   fi
 
   rm -rf "$GHE_REMOTE_ROOT_DIR"

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -158,8 +158,15 @@ end_test () {
 
     if [ "$test_status" -eq 0 ]; then
       printf "test: %-60s OK\n" "$test_description ..."
+    elif [ "$test_status" -eq 254 ]; then
+      printf "test: %-60s SKIPPED\n" "$test_description ..."
     else
       report_failure "FAILED" "$test_description ..."
     fi
+
     unset test_description
+}
+
+skip_test() {
+  exit 254
 }


### PR DESCRIPTION
Being able to see which tests have been skipped is crucial to confirming your desired tests have been skipped when skimming down the list of tests that have passed.

This PR implements `skip_test` that can be used to skip a test and show the test has been skipped in the output:

```
[...]
test: ghe-restore with current backup leaked key detection ...     OK
test: ghe-restore fails when restore to an active HA pair ...      SKIPPED
test: ghe-restore honours --version flag ...                       OK
[...]
```

Update: I've just discovered that when there's a failure building the Debian pkg, we display the results of building the tarball and not the Debian pkg. This PR fixes that too.

/cc @github/backup-utils 
  