### PR TITLE
Fix flaky ghe-detect-leaked-ssh-keys tests

### DIFF
--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -45,9 +45,10 @@ if (ssh-keygen -E 2>&1 | head -1 |  grep -q 'option requires an argument'); then
 fi
 
 # Bring in the backup configuration
-. $( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config
+# shellcheck source=share/github-backup-utils/ghe-backup-config
+. "$( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config"
 
-fingerprint_blacklist=$(cat "$GHE_BACKUP_ROOT/share/github-backup-utils/ghe-ssh-leaked-host-keys-list.txt")
+FINGERPRINT_BLACKLIST="${FINGERPRINT_BLACKLIST:-$(cat "$GHE_BACKUP_ROOT/share/github-backup-utils/ghe-ssh-leaked-host-keys-list.txt")}"
 
 keys="ssh_host_dsa_key.pub ssh_host_ecdsa_key.pub ssh_host_ed25519_key.pub ssh_host_rsa_key.pub"
 
@@ -71,16 +72,16 @@ leaked_keys_found=false
 current_bkup=false
 for tar_file in $ssh_tars; do
   for key in $keys; do
-    if $(tar -tvf "$tar_file" $key &>/dev/null); then
+    if tar -tvf "$tar_file" $key &>/dev/null; then
       tar -C $TEMPDIR -xvf "$tar_file" $key &>/dev/null
       if $sshkeygen_multiple_hash_formats; then
         fingerprint=$(ssh-keygen -l -E md5 -f $TEMPDIR/$key | cut -d ' ' -f 2 | cut -f2- -d':')
       else
         fingerprint=$(ssh-keygen -lf $TEMPDIR/$key | cut -d ' ' -f 2)
       fi
-      if echo "$fingerprint_blacklist" | grep -q "$fingerprint"; then
+      if echo "$FINGERPRINT_BLACKLIST" | grep -q "$fingerprint"; then
         leaked_keys_found=true
-        if [ "$current_dir" == $(dirname "$tar_file") ]; then
+        if [ "$current_dir" == "$(dirname "$tar_file")" ]; then
           current_bkup=true
           echo "* Leaked key found in current backup snapshot."
         else
@@ -124,8 +125,8 @@ if $leaked_keys_found; then
     echo "* (An upgrade may be required)"
     echo
   fi
-else 
-  echo "* No leaked keys found"  
+else
+  echo "* No leaked keys found"
 fi
 
 # Cleanup temp dir


### PR DESCRIPTION
Whilst working on https://github.com/github/backup-utils/pull/363 and https://github.com/github/backup-utils/pull/364 I noticed that the "ghe-detect-leaked-ssh-keys leaked keys in [old|current] snapshot" tests are very very flaky on our CI as of https://github.com/github/backup-utils/pull/361, but not Travis. 

That PR didn't introduce any changes that would directly affect the test, but it did add a new test which seems to have increased the likelihood of these tests overlapping with each other and with others that modify the `ghe-ssh-leaked-host-keys-list.txt` file used in testing. 

I think the problem is these changes aren't atomic under testing, so I've changed the script and test to use an environment variable, if set, or the contents of the original file.  The env var is only pre-set under testing.

I've also implemented a few more ShellCheck recommendations whilst I'm at it.

/cc @github/backup-utils 