### PR TITLE
Remove Precise Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,6 @@
 ---
 matrix:
   include:
-    - os: osx
-      before_install:
-        - brew update
-        - brew install gnu-tar
-        - brew install moreutils
-      script: make test
-    - os: linux
-      dist: precise
-      sudo: required
-      addons:
-        apt:
-          packages:
-            - devscripts
-            - debhelper
-            - moreutils
-            - fakeroot
-      before_script: git fetch --unshallow
-      script: debuild -uc -us
     - os: linux
       dist: trusty
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 ---
 matrix:
   include:
+    - os: osx
+      before_install:
+        - brew update
+        - brew install gnu-tar
+        - brew install moreutils
+      script: make test
     - os: linux
       dist: trusty
       sudo: required


### PR DESCRIPTION
Updated: After taking on feedback, this PR only removes the obsolete Ubuntu Precise builds.

---
Originally:

macOS is not officially supported and waiting for Travis to run our tests can take many many hours queuing alone. Local dev should be sufficient testing.

Precise is dead and no longer receiving security updates except for those with deep pockets paying Canonical lots of money for "Extended security maintenance for advanced customers" so we probably don't need to keep testing on it either.

So what's the impact? The build one before this one took:

![screen shot 2018-01-15 at 17 27 04](https://user-images.githubusercontent.com/627280/34954730-751c590e-fa19-11e7-9131-504498701c56.png)

The one before this one is still running:

![screen shot 2018-01-15 at 17 27 43](https://user-images.githubusercontent.com/627280/34954739-7b0f5334-fa19-11e7-89be-c375fc9b8b92.png)

This one: 

![screen shot 2018-01-15 at 17 29 01](https://user-images.githubusercontent.com/627280/34954775-9b455ed2-fa19-11e7-81f3-b42e567731ce.png)

The big times are almost exclusively waiting in the macOS queue.

/cc @github/backup-utils 