### PR TITLE
Fix custom options being overridden on execution

### DIFF
--- a/share/github-backup-utils/ghe-rsync
+++ b/share/github-backup-utils/ghe-rsync
@@ -14,7 +14,7 @@ set -o pipefail
 # stderr (rsync versions >= 3.x). The complex redirections are necessary to
 # filter stderr while also keeping stdout and stderr separated.
 IGNOREOUT='^(file has vanished: |rsync warning: some files vanished before they could be transferred)'
-(rsync $GHE_EXTRA_RSYNC_OPTS "${@}" 3>&1 1>&2 2>&3 3>&- |
+(rsync "${@}" $GHE_EXTRA_RSYNC_OPTS 3>&1 1>&2 2>&3 3>&- |
   (egrep -v "$IGNOREOUT" || true)) 3>&1 1>&2 2>&3 3>&- |
   (egrep -v "$IGNOREOUT" || true)
 res=$?


### PR DESCRIPTION
If one sets an option that will be later overriden by `-a` (for instance `--no-p` ), the current behaviour dismiss that option.
Since the options manually added to the configuration file are meant to be overrides, this change adds them after the defaults instead of before.