### PR TITLE
Remove indices created with ES 1.x

### DIFF
--- a/share/github-backup-utils/ghe-restore-es-rsync
+++ b/share/github-backup-utils/ghe-restore-es-rsync
@@ -55,6 +55,11 @@ elif [ "$GHE_VERSION_MAJOR" -gt 1 ]; then
         "$snapshot_dir/elasticsearch/" \
         "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore" 1>&3
 
+    # restoring in 2.14 will remove incompatible indices created with 1.x.
+    if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -eq 14 ]; then
+        ghe-ssh "$GHE_HOSTNAME" -- "sudo /usr/local/share/enterprise/ghe-es-remove-1x-indices"
+    fi
+
 # restoring v11.10.x ES snapshot into a v11.10.x appliance
 else
     # Use GNU tar on BSDs.

--- a/share/github-backup-utils/ghe-restore-es-rsync
+++ b/share/github-backup-utils/ghe-restore-es-rsync
@@ -55,8 +55,8 @@ elif [ "$GHE_VERSION_MAJOR" -gt 1 ]; then
         "$snapshot_dir/elasticsearch/" \
         "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore" 1>&3
 
-    # restoring in 2.14 will remove incompatible indices created with 1.x.
-    if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -eq 14 ]; then
+    # restoring in >=2.14 will remove incompatible indices created with 1.x.
+    if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 14 ]; then
         ghe-ssh "$GHE_HOSTNAME" -- "sudo /usr/local/share/enterprise/ghe-es-remove-1x-indices"
     fi
 


### PR DESCRIPTION
For `GHE >= 2.14` which is expected to ship ES 5.x.

This means that there may be snapshots from 2.13 or 2.12 whose indices are created with ES 1.x instead of ES 2.x. If that's the case, ES 5.x won't be able to start.

Instead of triggering a hard fail of the appliance, this PR makes use of a script that is introduced in here to remove the indices that are not compatible. This removal happens after the snapshot indices have been synced into the appliance and before ES is started.

