### PR TITLE
Move check for git for ssh muxing into ghe-ssh

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -117,9 +117,6 @@ echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ../in-progress
 
 echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 
-# Warn if git is not installed, and set GHE_DISABLE_SSH_MUX=true
-command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed." && export GHE_DISABLE_SSH_MUX=true
-
 # Perform a host connection check and establish the remote appliance version.
 # The version is available in the GHE_REMOTE_VERSION variable and also written
 # to a version file in the snapshot directory itself.

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -64,8 +64,7 @@ fi
 
 # Warn if git is not installed, and set GHE_DISABLE_SSH_MUX=true
 if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
-  command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed."
-  export GHE_DISABLE_SSH_MUX=true
+  command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed." && export GHE_DISABLE_SSH_MUX=true
 fi
 
 if [ -z "$GHE_DISABLE_SSH_MUX" ]; then

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -62,6 +62,9 @@ if echo "$*" | grep "[|;]" >/dev/null || [ $(echo "$*" | wc -l) -gt 1 ]; then
     exit 1
 fi
 
+# Warn if git is not installed, and set GHE_DISABLE_SSH_MUX=true
+command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed." && export GHE_DISABLE_SSH_MUX=true
+
 if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
   controlpath="$TMPDIR/.ghe-sshmux-$(echo -n "$user@$host:$port" | git hash-object --stdin | cut -c 1-8)"
   opts="-o ControlMaster=auto -o ControlPath=\"$controlpath\" -o ControlPersist=10m -o ServerAliveInterval=10 $opts"

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -63,7 +63,10 @@ if echo "$*" | grep "[|;]" >/dev/null || [ $(echo "$*" | wc -l) -gt 1 ]; then
 fi
 
 # Warn if git is not installed, and set GHE_DISABLE_SSH_MUX=true
-command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed." && export GHE_DISABLE_SSH_MUX=true
+if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
+  command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed."
+  export GHE_DISABLE_SSH_MUX=true
+fi
 
 if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
   controlpath="$TMPDIR/.ghe-sshmux-$(echo -n "$user@$host:$port" | git hash-object --stdin | cut -c 1-8)"


### PR DESCRIPTION
Follow up to #362 -- If a backup was transferred to a different backup host that does not have `git`, `ghe-restore` could fail with:

```
git: command not found 
```

This moves the check and automatic disabling of muxing to `ghe-ssh` directly, rather than just being part of `ghe-backup`

  cc: @jatoben 