### PR TITLE
Output backup utils version on backup and restore

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -106,7 +106,7 @@ fi
 
 echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ../in-progress
 
-echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
+echo "Starting backup of $GHE_HOSTNAME with backup-utils v$BACKUP_UTILS_VERSION in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 
 # Perform a host connection check and establish the remote appliance version.
 # The version is available in the GHE_REMOTE_VERSION variable and also written
@@ -115,7 +115,7 @@ ghe_remote_version_required
 echo "$GHE_REMOTE_VERSION" > version
 
 # Log backup start message in /var/log/syslog on remote instance
-ghe_remote_logger "Starting backup from $(hostname) in snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
+ghe_remote_logger "Starting backup from $(hostname) with backup-utils v$BACKUP_UTILS_VERSION in snapshot $GHE_SNAPSHOT_TIMESTAMP ..."
 
 export GHE_BACKUP_STRATEGY=${GHE_BACKUP_STRATEGY:-$(ghe-backup-strategy)}
 

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -181,8 +181,8 @@ if $instance_configured && ! $force; then
 fi
 
 # Log restore start message locally and in /var/log/syslog on remote instance
-echo "Starting restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT"
-ghe_remote_logger "Starting restore from $(hostname) / snapshot $GHE_RESTORE_SNAPSHOT ..."
+echo "Starting restore of $GHE_HOSTNAME with backup-utils v$BACKUP_UTILS_VERSION from snapshot $GHE_RESTORE_SNAPSHOT"
+ghe_remote_logger "Starting restore from $(hostname) with backup-utils v$BACKUP_UTILS_VERSION / snapshot $GHE_RESTORE_SNAPSHOT ..."
 
 # Keep other processes on the VM or cluster in the loop about the restore status.
 #


### PR DESCRIPTION
While we output / log the GitHub Enterprise version, the version of backup-utils is not present in the `ghe-backup` and `ghe-restore` output.

This PR adds the backup-utils version to the starting backup / restore messages:

__After:__

```
$ bin/ghe-backup 
Starting backup of hostname with backup-utils v2.13.0 in snapshot 20180328T104804
Connect hostname:122 OK (v2.13.0)
Backing up GitHub settings ...
...
```

__Before:__

```
$ bin/ghe-backup 
Starting backup of hostname in snapshot 20180328T105119
Connect hostname:122 OK (v2.13.0)
Backing up GitHub settings ...
...
```

This will make it easier to determine the backup-utils release when we only have the backup or restore output.

cc: @github/enterprise-support 