### PR TITLE
Switch back to optimised route restores

### DIFF
--- a/share/github-backup-utils/bm.sh
+++ b/share/github-backup-utils/bm.sh
@@ -17,7 +17,9 @@ bm_desc_to_varname(){
 bm_start()
 {
   eval "$(bm_desc_to_varname $@)_start=$(date +%s)"
-
+  if [ -n "$GHE_DEBUG" ]; then
+    echo "Debug: $1 (bm_start)"
+  fi
   bm_init > /dev/null
 }
 
@@ -48,4 +50,7 @@ bm_end() {
   local tstart=$(eval "echo \$$(bm_desc_to_varname $@)_start")
 
   echo "$1 took $(($tend - $tstart))s" >> $BM_FILE_PATH
+  if [ -n "$GHE_DEBUG" ]; then
+    echo "Debug: $1 took $(($tend - $tstart))s (bm_end)"
+  fi
 }

--- a/share/github-backup-utils/bm.sh
+++ b/share/github-backup-utils/bm.sh
@@ -48,9 +48,10 @@ bm_end() {
 
   local tend=$(date +%s)
   local tstart=$(eval "echo \$$(bm_desc_to_varname $@)_start")
+  local total=$(($tend - $tstart))
 
-  echo "$1 took $(($tend - $tstart))s" >> $BM_FILE_PATH
+  echo "$1 took ${total}s" >> $BM_FILE_PATH
   if [ -n "$GHE_DEBUG" ]; then
-    echo "Debug: $1 took $(($tend - $tstart))s (bm_end)"
+    echo "Debug: $1 took ${total}s (bm_end)"
   fi
 }

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -288,7 +288,7 @@ ghe_verbose() {
 # Log if debug mode is enabled (GHE_DEBUG).
 ghe_debug() {
   if [ -n "$GHE_DEBUG" ]; then
-    echo "Debug: $*" 1>&3
+    echo -e "Debug: $*" 1>&3
   fi
 }
 

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -127,7 +127,11 @@ fi
 
 bm_start "$(basename $0) - Restoring pages"
 for file_list in $tempdir/*.rsync; do
-  server=$(basename $file_list .rsync)
+  if $CLUSTER; then
+    server=$(basename $file_list .rsync)
+  else
+    server=$host
+  fi
   ghe_verbose "* Transferring Pages to $server"
   ghe-rsync -avrHR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -102,22 +102,22 @@ bm_end "$(basename $0) - Building pages list"
 #
 bm_start "$(basename $0) - Transferring pages list"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
-ghe_debug "Transferring object list:\n$(cat $tmp_list)"
+ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring pages list"
 
 bm_start "$(basename $0) - Generating routes"
 echo "cat $tmp_list | github-env ./bin/dpages-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
-ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
 ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+ghe_debug "\n$(cat $local_routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
 cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
-ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync)"
+ghe_debug "\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -47,7 +47,8 @@ ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
 opts="$GHE_EXTRA_SSH_OPTS"
 ssh_config_file_opt=
 tmp_list=$tempdir/tmp_list
-to_restore=$tempdir/to_restore
+routes_list=$tempdir/routes_list
+local_routes_list=$tempdir/local_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -96,23 +97,28 @@ bm_end "$(basename $0) - Building pages list"
 #
 # One route per line.
 #
-bm_start "$(basename $0) - Calculating sync routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- github-env ./bin/dpages-cluster-restore-routes \
-  | while read route; do
-  ghe_debug "Got restore route $route"
-  if $CLUSTER; then
-    servers=$(echo $route | cut -d ' ' -f2-)
-  else
-    servers=$host
-  fi
-  page=$(echo $route | cut -d ' ' -f1)
-  for server in $servers; do
-    ghe_debug "Adding $page to $tempdir/$server.rsync"
-    echo "$page" >> $tempdir/$server.rsync
-    echo "$route" >> $to_restore
-  done
-done
-bm_end "$(basename $0) - Calculating sync routes"
+# NOTE: The route generation is performed on the appliance as it is considerably
+# more performant than performing over an SSH pipe.
+#
+bm_start "$(basename $0) - Transferring pages list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+ghe_debug "Transferring object list:\n$(cat $tmp_list)"
+bm_end "$(basename $0) - Transferring pages list"
+
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/dpages-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+bm_end "$(basename $0) - Generating routes"
+
+bm_start "$(basename $0) - Fetching routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
+ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+bm_end "$(basename $0) - Fetching routes"
+
+bm_start "$(basename $0) - Processing routes"
+cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync)"
+bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   echo "Warning: no routes found, skipping pages restore ..."
@@ -135,9 +141,8 @@ bm_end "$(basename $0) - Restoring pages"
 if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
-  cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $to_restore $tempdir/chunk
+    split -l 1000 $routes_list $tempdir/chunk
     chunks=\$(find $tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/dpages-cluster-restore-finalize" -- \$chunks
 EOF

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -47,6 +47,8 @@ ssh_config_file_opt=
 opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
 to_restore=$tempdir/to_restore
+routes_list=$tempdir/routes_list
+local_routes_list=$tempdir/local_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -102,33 +104,44 @@ bm_end "$(basename $0) - Building network list"
 #
 # One route per line.
 #
-bm_start "$(basename $0) - Calculating sync routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- github-env ./bin/dgit-cluster-restore-routes \
-  | while read route; do
-  ghe_debug "Got restore route $route"
-  if $CLUSTER; then
-    servers=$(echo $route | cut -d ' ' -f2-)
-  else
-    servers=$host
-  fi
-  network_path=$(echo $route | cut -d ' ' -f1)
-  for server in $servers; do
-    ghe_debug "Adding $network_path to $tempdir/$server.rsync"
-    echo "$network_path" >> $tempdir/$server.rsync
-    echo "$route" | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' >> $to_restore
-  done
-done
-bm_end "$(basename $0) - Calculating sync routes"
+# NOTE: The route generation is performed on the appliance as it is considerably
+# more performant than performing over an SSH pipe.
+#
+bm_start "$(basename $0) - Transferring network list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+ghe_debug "Transferring network list:\n$(cat $tmp_list)"
+bm_end "$(basename $0) - Transferring network list"
+
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/dgit-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+bm_end "$(basename $0) - Generating routes"
+
+bm_start "$(basename $0) - Fetching routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
+ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+bm_end "$(basename $0) - Fetching routes"
+
+bm_start "$(basename $0) - Processing routes"
+cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $local_routes_list | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' > $to_restore
+ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
+bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   echo "Warning: no routes found, skipping repositories restore ..."
   exit 0
 fi
 
+# rsync all the repository networks to the git server where they belong.
+# One rsync invocation per server available.
 bm_start "$(basename $0) - Restoring repository networks"
-# rsync all the repositories
 for file_list in $tempdir/*.rsync; do
-  server=$(basename $file_list .rsync)
+  if $CLUSTER; then
+    server=$(basename $file_list .rsync)
+  else
+    server=$host
+  fi
   ghe_verbose "* Transferring repository networks to $server ..."
   ghe-rsync -avrHR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -109,23 +109,23 @@ bm_end "$(basename $0) - Building network list"
 #
 bm_start "$(basename $0) - Transferring network list"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
-ghe_debug "Transferring network list:\n$(cat $tmp_list)"
+ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring network list"
 
 bm_start "$(basename $0) - Generating routes"
 echo "cat $tmp_list | github-env ./bin/dgit-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
-ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
 ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+ghe_debug "\n$(cat $local_routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
 cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
 cat $local_routes_list | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' > $to_restore
-ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
+ghe_debug "\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
 bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -102,23 +102,23 @@ bm_end "$(basename $0) - Building gist list"
 #
 bm_start "$(basename $0) - Transferring gist list"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
-ghe_debug "Transferring gist list:\n$(cat $tmp_list)"
+ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring gist list"
 
 bm_start "$(basename $0) - Generating routes"
 echo "cat $tmp_list | github-env ./bin/gist-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
-ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Transferring routes"
 ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+ghe_debug "\n$(cat $local_routes_list)"
 bm_end "$(basename $0) - Transferring routes"
 
 bm_start "$(basename $0) - Processing routes"
 cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
 cat $local_routes_list | awk '{ n = split($1, p, "/"); i = p[n]; sub(/\.git/, "", i); printf i " /data/repositories/" $1; $1=""; print $0}' > $to_restore
-ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
+ghe_debug "\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
 bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -49,6 +49,8 @@ ssh_config_file_opt=
 opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
 to_restore=$tempdir/to_restore
+routes_list=$tempdir/routes_list
+local_routes_list=$tempdir/local_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -95,26 +97,29 @@ bm_end "$(basename $0) - Building gist list"
 #
 # One route per line.
 #
-bm_start "$(basename $0) - Calculating Sync Routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- github-env ./bin/gist-cluster-restore-routes \
-  | while read route; do
-  ghe_debug "Got restore route $route"
-  if $CLUSTER; then
-    servers=$(echo $route | cut -d ' ' -f2-)
-  else
-    servers=$host
-  fi
-  network_path=$(echo $route | cut -d ' ' -f1)
-  for server in $servers; do
-    ghe_debug "Adding $network_path to $tempdir/$server.rsync"
-    echo "$network_path" >> $tempdir/$server.rsync
-  done
-  # Add entries to the to_restore in the form:
-  #
-  # gist_id /data/repositories/a/a8/3f/02/gist/gist_id.git dgit-node3 dgit-node2 dgit-node4
-  echo "$route" | awk '{ n = split($1, p, "/"); i = p[n]; sub(/\.git/, "", i); printf i " /data/repositories/" $1; $1=""; print $0}' >> $to_restore
-done
-bm_end "$(basename $0) - Calculating Sync Routes"
+# NOTE: The route generation is performed on the appliance as it is considerably
+# more performant than performing over an SSH pipe.
+#
+bm_start "$(basename $0) - Transferring gist list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+ghe_debug "Transferring gist list:\n$(cat $tmp_list)"
+bm_end "$(basename $0) - Transferring gist list"
+
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/gist-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+bm_end "$(basename $0) - Generating routes"
+
+bm_start "$(basename $0) - Transferring routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
+ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+bm_end "$(basename $0) - Transferring routes"
+
+bm_start "$(basename $0) - Processing routes"
+cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $local_routes_list | awk '{ n = split($1, p, "/"); i = p[n]; sub(/\.git/, "", i); printf i " /data/repositories/" $1; $1=""; print $0}' > $to_restore
+ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
+bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   echo "Warning: no routes found, skipping gists restore ..."
@@ -124,7 +129,11 @@ fi
 # rsync all the gist repositories
 bm_start "$(basename $0) - Restoring gists"
 for file_list in $tempdir/*.rsync; do
-  server=$(basename $file_list .rsync)
+  if $CLUSTER; then
+    server=$(basename $file_list .rsync)
+  else
+    server=$host
+  fi
   ghe_verbose "* Transferring gists to $server"
   ghe-rsync -avrHR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -94,22 +94,22 @@ bm_end "$(basename $0) - Building object list"
 #
 bm_start "$(basename $0) - Transferring object list"
 cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
-ghe_debug "Transferring object list:\n$(cat $tmp_list)"
+ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring object list"
 
 bm_start "$(basename $0) - Generating routes"
 echo "cat $tmp_list | github-env ./bin/storage-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
-ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
 ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+ghe_debug "\n$(cat $local_routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
 cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
-ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync)"
+ghe_debug "\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -108,7 +108,7 @@ ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
+cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
 ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -48,7 +48,8 @@ ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
 ssh_config_file_opt=
 opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
-to_restore=$tempdir/to_restore
+routes_list=$tempdir/routes_list
+local_routes_list=$tempdir/local_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -88,23 +89,28 @@ bm_end "$(basename $0) - Building object list"
 #
 # One route per line.
 #
-bm_start "$(basename $0) - Calculating sync routes"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- github-env ./bin/storage-cluster-restore-routes \
-  | while read route; do
-  ghe_debug "Got restore route $route"
-  if $CLUSTER; then
-    servers=$(echo $route | cut -d ' ' -f2-)
-  else
-    servers=$host
-  fi
-  object=$(echo $route | cut -d ' ' -f1)
-  for server in $servers; do
-    ghe_debug "Adding $object to $tempdir/$server.rsync"
-    echo "$object" | awk '{ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1}' >> $tempdir/$server.rsync
-    echo "$route" >> $to_restore
-  done
-done
-bm_end "$(basename $0) - Calculating sync routes"
+# NOTE: The route generation is performed on the appliance as it is considerably
+# more performant than performing over an SSH pipe.
+#
+bm_start "$(basename $0) - Transferring object list"
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+ghe_debug "Transferring object list:\n$(cat $tmp_list)"
+bm_end "$(basename $0) - Transferring object list"
+
+bm_start "$(basename $0) - Generating routes"
+echo "cat $tmp_list | github-env ./bin/storage-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+ghe_debug "Generating routes:\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+bm_end "$(basename $0) - Generating routes"
+
+bm_start "$(basename $0) - Fetching routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
+ghe_debug "Fetching routes:\n$(cat $local_routes_list)"
+bm_end "$(basename $0) - Fetching routes"
+
+bm_start "$(basename $0) - Processing routes"
+ghe-ssh "$GHE_HOSTNAME" -- cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
+ghe_debug "Processing routes:\n$(ls -l $tempdir/*.rsync)"
+bm_end "$(basename $0) - Processing routes"
 
 if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   echo "Warning: no routes found, skipping storage restore ..."
@@ -115,7 +121,11 @@ fi
 # One rsync invocation per server available.
 bm_start "$(basename $0) - Restoring objects"
 for file_list in $tempdir/*.rsync; do
-  server=$(basename $file_list .rsync)
+  if $CLUSTER; then
+    server=$(basename $file_list .rsync)
+  else
+    server=$host
+  fi
   ghe_verbose "* Transferring data to $server ..."
   ghe-rsync -arvHR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \
@@ -130,9 +140,8 @@ bm_end "$(basename $0) - Restoring objects"
 if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
-  cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $to_restore $tempdir/chunk
+    split -l 1000 $routes_list $tempdir/chunk
     chunks=\$(find $tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
 EOF

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -23,7 +23,7 @@ begin_test "ghe-restore into configured vm"
     export GHE_RESTORE_HOST
 
     # run ghe-restore and write output to file for asserting against
-    if ! ghe-restore -v -f > "$TRASHDIR/restore-out" 2>&1; then
+    if ! GHE_DEBUG=1 ghe-restore -v -f > "$TRASHDIR/restore-out" 2>&1; then
         cat "$TRASHDIR/restore-out"
         : ghe-restore should have exited successfully
         false


### PR DESCRIPTION
When unifying the backup and restore process as part of https://github.com/github/backup-utils/pull/375, I unified all restores to use the same approach, but this happened to be the unoptimised of the two. This PR switches everything back to using the optimised method.

It also adds more output that can be used to debug the behaviour and performance.