### PR TITLE
Optionally log verbose output to a file instead of stdout

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -23,6 +23,11 @@ GHE_NUM_SNAPSHOTS=10
 #
 #GHE_RESTORE_HOST="github-standby.example.com"
 
+# When verbose output is enabled with `-v`, it's written to stdout by default. If
+# you'd prefer it to be written to a separate file, set this option.
+#
+# GHE_VERBOSE_LOG="/var/log/backup-verbose.log"
+
 # Any extra options passed to the SSH command.
 # In a single instance environment, nothing is required by default.
 # In a clustering environment, "-i abs-path-to-ssh-private-key" is required.

--- a/backup.config-example
+++ b/backup.config-example
@@ -26,7 +26,7 @@ GHE_NUM_SNAPSHOTS=10
 # When verbose output is enabled with `-v`, it's written to stdout by default. If
 # you'd prefer it to be written to a separate file, set this option.
 #
-# GHE_VERBOSE_LOG="/var/log/backup-verbose.log"
+#GHE_VERBOSE_LOG="/var/log/backup-verbose.log"
 
 # Any extra options passed to the SSH command.
 # In a single instance environment, nothing is required by default.

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -85,7 +85,7 @@ if [ -n "$GHE_VERBOSE" ]; then
     exec 3>&1
   fi
 else
-    exec 3>/dev/null
+  exec 3>/dev/null
 fi
 
 # Restore saved off hostname.

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -26,12 +26,16 @@ if [ -n "$GHE_SHOW_VERSION" ]; then
   exit 0
 fi
 
-# If verbose logging is enabled, redirect fd 3 to stdout; otherwise, redirect it
-# to /dev/null. Write verbose output to fd 3.
+# If verbose logging is enabled, redirect fd 3 to stdout or the specified log file;
+# otherwise, redirect it to /dev/null. Write verbose output to fd 3.
 if [ -n "$GHE_VERBOSE" ]; then
-  exec 3>&1
+  if [ -n "$GHE_VERBOSE_LOG" ]; then
+    exec 3<> "$GHE_VERBOSE_LOG"
+  else
+    exec 3>&1
+  fi
 else
-  exec 3>/dev/null
+    exec 3>/dev/null
 fi
 
 # Check for "--help|-h" in args or GHE_SHOW_HELP=true and show usage

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -26,18 +26,6 @@ if [ -n "$GHE_SHOW_VERSION" ]; then
   exit 0
 fi
 
-# If verbose logging is enabled, redirect fd 3 to stdout or the specified log file;
-# otherwise, redirect it to /dev/null. Write verbose output to fd 3.
-if [ -n "$GHE_VERBOSE" ]; then
-  if [ -n "$GHE_VERBOSE_LOG" ]; then
-    exec 3<> "$GHE_VERBOSE_LOG"
-  else
-    exec 3>&1
-  fi
-else
-    exec 3>/dev/null
-fi
-
 # Check for "--help|-h" in args or GHE_SHOW_HELP=true and show usage
 # shellcheck disable=SC2120 # the script name is always referenced
 print_usage () {
@@ -86,6 +74,18 @@ if ! $config_found; then
   echo " - $HOME/.github-backup-utils/backup.config" 1>&2
   echo " - /etc/github-backup-utils/backup.config" 1>&2
   exit 2
+fi
+
+# If verbose logging is enabled, redirect fd 3 to stdout or the specified log file;
+# otherwise, redirect it to /dev/null. Write verbose output to fd 3.
+if [ -n "$GHE_VERBOSE" ]; then
+  if [ -n "$GHE_VERBOSE_LOG" ]; then
+    exec 3<> "$GHE_VERBOSE_LOG"
+  else
+    exec 3>&1
+  fi
+else
+    exec 3>/dev/null
 fi
 
 # Restore saved off hostname.

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -126,3 +126,17 @@ begin_test "ghe-backup-config ghe_parse_remote_version v2.x series"
   [ "$GHE_VERSION_PATCH" = "5" ]
 )
 end_test
+
+begin_test "ghe-backup-config verbose log redirects to file"
+(
+  set -e
+
+  export GHE_VERBOSE=1
+  export GHE_VERBOSE_LOG="$TRASHDIR/verbose.log"
+  . "share/github-backup-utils/ghe-backup-config"
+  ghe_verbose "Hello world"
+  [ "$(wc -l <"$GHE_VERBOSE_LOG")" -gt 0 ]
+  unset GHE_VERBOSE
+  unset GHE_VERBOSE_LOG
+)
+end_test


### PR DESCRIPTION
Verbose logging is super helpful for debugging backup problems, but writing [all verbose output to stdout](https://github.com/github/backup-utils/blob/ff640e7972d4724511eeb1c9e7c2eb826c9564f1/share/github-backup-utils/ghe-backup-config#L29-L35) means that it can't easily be enabled if stdout should remain easily readable or mailable. For example, an admin might like to receive an email via cron after a backup has completed, with the text showing the backup steps and [confirming when the backup run finished](https://github.com/github/backup-utils/blob/ff640e7972d4724511eeb1c9e7c2eb826c9564f1/bin/ghe-backup#L220).

This PR adds a `GHE_VERBOSE_LOG` setting, which may be pointed to a file that the verbose output will be written to. If a backup fails, the log can then be used to investigate the problem further.

/cc @snh @terrorobe 