### PR TITLE
Remove check for git from ghe-ssh

### DIFF
--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -62,11 +62,6 @@ if echo "$*" | grep "[|;]" >/dev/null || [ "$(echo "$*" | wc -l)" -gt 1 ]; then
   exit 1
 fi
 
-# Warn if git is not installed, and set GHE_DISABLE_SSH_MUX=true
-if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
-  command -v git >/dev/null 2>&1 || echo "Warning: SSH multiplexing requires git but it's not installed." && export GHE_DISABLE_SSH_MUX=true
-fi
-
 if [ -z "$GHE_DISABLE_SSH_MUX" ]; then
   controlpath="$TMPDIR/.ghe-sshmux-$(echo -n "$user@$host:$port" | git hash-object --stdin | cut -c 1-8)"
   # shellcheck disable=SC2089 # We don't use bash arrays


### PR DESCRIPTION
The changes in https://github.com/github/backup-utils/pull/362 and https://github.com/github/backup-utils/pull/378 introduced a bug that effectively disabled SSH multiplexing in all cases. 

The `&&` isn't interpreted as part of the `||`, so `GHE_DISABLE_SSH_MUX` was always being set to true. This can be demonstrated with the following example:

```sh
$ true || echo "One" && echo "Two"
Two
$ false || echo "One" && echo "Two"
One
Two
```

As `git` is listed as part of our requirements, and is being used in more and more places in the backup utilities, it should no-longer be considered optional.

/cc @github/backup-utils @djdefi 