### PR TITLE
Fix restoring of audit and hookshot logs to cluster nodes

### DIFF
--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -20,7 +20,7 @@ GHE_HOSTNAME="$1"
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-indices=$(find -print0 $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz 2>/dev/null | xargs -0 -I{} -n1 basename {} .gz)
+indices=$(find $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz -print0 2>/dev/null | xargs -0 -I{} -n1 basename {} .gz)
 
 # Platform neutral and robust method of determining last month
 this_yr=$(date +"%Y")

--- a/share/github-backup-utils/ghe-restore-es-hookshot
+++ b/share/github-backup-utils/ghe-restore-es-hookshot
@@ -22,7 +22,7 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 
 last_index=$(ghe-ssh "$GHE_HOSTNAME" 'curl -s "localhost:9201/_cat/indices/hookshot-logs-*"' | cut -d ' ' -f 3 | sort | tail -2 | head -1)
 
-indices=$(find -print0 $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/hookshot/*.gz 2>/dev/null | xargs -0 -I{} -n1 basename {} .gz)
+indices=$(find $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/hookshot/*.gz -print0 2>/dev/null | xargs -0 -I{} -n1 basename {} .gz)
 tmp_list="$(mktemp -t backup-utils-restore-XXXXXX)"
 if ghe-ssh "$GHE_HOSTNAME" -- "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/configured' ]"; then
   configured=true

--- a/test/bin/ghe-es-load-json
+++ b/test/bin/ghe-es-load-json
@@ -1,1 +1,5 @@
-ghe-fake-true
+#!/usr/bin/env bash
+# Usage: ghe-es-load-json
+# Emulates the remote GitHub ghe-es-load-json command. Tests use this
+# to assert that the command was executed.
+cat -

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -252,13 +252,13 @@ setup_test_data () {
 
   mkdir -p "$loc/audit-log/"
   cd "$loc/audit-log/"
-  touch audit_log-1-$last_yr-$last_mth-1.gz
-  touch audit_log-1-$this_yr-$this_mth-1.gz
+  echo "fake audit log last yr last mth" | gzip > audit_log-1-$last_yr-$last_mth-1.gz
+  echo "fake audit log this yr this mth" | gzip > audit_log-1-$this_yr-$this_mth-1.gz
 
   # Create hookshot logs
   mkdir -p "$loc/hookshot/"
   cd "$loc/hookshot/"
-  touch hookshot-logs-2018-03-05.gz
+  echo "fake hookshot log" | gzip > hookshot-logs-2018-03-05.gz
 
   # Create some test repositories in the remote repositories dir
   mkdir -p "$loc/repositories/info"
@@ -413,6 +413,10 @@ verify_all_restored_data() {
     grep -q "fake ghe-export-ssh-host-keys data" "$TRASHDIR/restore-out"
     # verify all ES data was transferred from live directory to the temporary restore directory
     diff -ru --exclude="*.gz" "$GHE_DATA_DIR/current/elasticsearch" "$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore"
+  else
+    grep -q "fake audit log last yr last mth" "$TRASHDIR/restore-out"
+    grep -q "fake audit log this yr this mth" "$TRASHDIR/restore-out"
+    grep -q "fake hookshot log" "$TRASHDIR/restore-out"
   fi
 
   # verify settings import was *not* run due to instance already being


### PR DESCRIPTION
I've just discovered I made a syntactical error when implementing the Shellcheck recommendations in https://github.com/github/backup-utils/pull/387 that broke the restoring of hookshot and audit logs to a cluster: I put the `-print0` in the wrong place. 😊

This PR fixes that by moving the `-print0` to the end of the `find` command.

I've also added a test to catch this in future.