### PR TITLE
Use remote's mktemp to create temp dir on remote host

### DIFF
--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -64,9 +64,9 @@ user="${host%@*}"
 hostnames=$host
 ssh_config_file_opt=
 tempdir=$(mktemp -d -t backup-utils-backup-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+remote_tempdir=$(ghe-ssh "$GHE_HOSTNAME" -- mktemp -d -t backup-utils-backup-XXXXXX)
 routes_list=$tempdir/routes_list
-local_routes_list=$tempdir/local_routes_list
+remote_routes_list=$remote_tempdir/remote_routes_list
 opts="$GHE_EXTRA_SSH_OPTS"
 
 # git server hostnames under cluster
@@ -93,6 +93,7 @@ cleanup() {
     ghe-gc-enable $ssh_config_file_opt $hostname:$port || true
   done
 
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $remote_tempdir
   rm -rf $tempdir
 }
 trap 'cleanup' EXIT
@@ -122,20 +123,20 @@ fi
 # more performant than performing over an SSH pipe.
 #
 bm_start "$(basename $0) - Generating routes"
-echo "github-env ./bin/dgit-cluster-backup-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
-ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+echo "github-env ./bin/dgit-cluster-backup-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "\n$(cat $local_routes_list)"
+ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe_debug "\n$(cat $routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
 if [ "$GHE_BACKUP_STRATEGY" != "cluster" ]; then
   server=$host
 fi
-cat $local_routes_list | awk -v tempdir="$tempdir" -v server="$server" '{ for(i=2;i<=NF;i++){ server != "" ? host=server : host=$i; print $1 > (tempdir"/"host".rsync") }}'
+cat $routes_list | awk -v tempdir="$tempdir" -v server="$server" '{ for(i=2;i<=NF;i++){ server != "" ? host=server : host=$i; print $1 > (tempdir"/"host".rsync") }}'
 ghe_debug "\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -37,9 +37,9 @@ user="${host%@*}"
 hostnames=$host
 ssh_config_file_opt=
 tempdir=$(mktemp -d -t backup-utils-backup-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+remote_tempdir=$(ghe-ssh "$GHE_HOSTNAME" -- mktemp -d -t backup-utils-backup-XXXXXX)
 routes_list=$tempdir/routes_list
-local_routes_list=$tempdir/local_routes_list
+remote_routes_list=$remote_tempdir/remote_routes_list
 opts="$GHE_EXTRA_SSH_OPTS"
 
 # storage server hostnames under cluster
@@ -62,7 +62,7 @@ cleanup() {
     ghe-gc-enable $ssh_config_file_opt $hostname:$port || true
   done
 
-  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $remote_tempdir
   rm -rf $tempdir
 }
 trap 'cleanup' EXIT INT
@@ -91,20 +91,20 @@ fi
 # more performant than performing over an SSH pipe.
 #
 bm_start "$(basename $0) - Generating routes"
-echo "github-env ./bin/storage-cluster-backup-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
-ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+echo "github-env ./bin/storage-cluster-backup-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "\n$(cat $local_routes_list)"
+ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe_debug "\n$(cat $routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
 if [ "$GHE_BACKUP_STRATEGY" != "cluster" ]; then
   server=$host
 fi
-cat $local_routes_list | awk -v tempdir="$tempdir" -v server="$server" '{ for(i=2;i<=NF;i++){ server != "" ? host=server : host=$i; print $1 > (tempdir"/"host".rsync") }}'
+cat $routes_list | awk -v tempdir="$tempdir" -v server="$server" '{ for(i=2;i<=NF;i++){ server != "" ? host=server : host=$i; print $1 > (tempdir"/"host".rsync") }}'
 ghe_debug "\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -44,12 +44,13 @@ user="${host%@*}"
 
 hostnames=$host
 tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+remote_tempdir=$(ghe-ssh "$GHE_HOSTNAME" -- mktemp -d -t backup-utils-restore-XXXXXX)
 opts="$GHE_EXTRA_SSH_OPTS"
 ssh_config_file_opt=
 tmp_list=$tempdir/tmp_list
+remote_tmp_list=$remote_tempdir/remote_tmp_list
 routes_list=$tempdir/routes_list
-local_routes_list=$tempdir/local_routes_list
+remote_routes_list=$remote_tempdir/remote_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -61,7 +62,7 @@ fi
 
 cleanup() {
   rm -rf $tempdir
-  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $remote_tempdir
   true
 }
 
@@ -102,22 +103,22 @@ bm_end "$(basename $0) - Building pages list"
 # more performant than performing over an SSH pipe.
 #
 bm_start "$(basename $0) - Transferring pages list"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_tmp_list
 ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring pages list"
 
 bm_start "$(basename $0) - Generating routes"
-echo "cat $tmp_list | github-env ./bin/dpages-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
-ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+echo "cat $remote_tmp_list | github-env ./bin/dpages-cluster-restore-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "\n$(cat $local_routes_list)"
+ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe_debug "\n$(cat $routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
 ghe_debug "\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -161,7 +161,7 @@ if $CLUSTER; then
   ghe_verbose "Finalizing routes"
   cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_to_restore
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $remote_to_restore $tempdir/chunk
+    split -l 1000 $remote_to_restore $remote_tempdir/chunk
     chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
 EOF

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -43,13 +43,14 @@ user="${host%@*}"
 
 hostnames=$host
 tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+remote_tempdir=$(ghe-ssh "$GHE_HOSTNAME" -- mktemp -d -t backup-utils-restore-XXXXXX)
 ssh_config_file_opt=
 opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
+remote_tmp_list=$remote_tempdir/remote_tmp_list
 to_restore=$tempdir/to_restore
 routes_list=$tempdir/routes_list
-local_routes_list=$tempdir/local_routes_list
+remote_routes_list=$remote_tempdir/remote_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -63,7 +64,7 @@ cleanup() {
   for hostname in $hostnames; do
     ghe-gc-enable $ssh_config_file_opt $hostname:$port || true
   done
-  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $remote_tempdir
   rm -rf $tempdir
 }
 trap cleanup EXIT
@@ -109,23 +110,23 @@ bm_end "$(basename $0) - Building network list"
 # more performant than performing over an SSH pipe.
 #
 bm_start "$(basename $0) - Transferring network list"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_tmp_list
 ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring network list"
 
 bm_start "$(basename $0) - Generating routes"
-echo "cat $tmp_list | github-env ./bin/dgit-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
-ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+echo "cat $remote_tmp_list | github-env ./bin/dgit-cluster-restore-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "\n$(cat $local_routes_list)"
+ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe_debug "\n$(cat $routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
-cat $local_routes_list | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' > $to_restore
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk '{ n = split($1, p, "/"); printf p[n] " /data/repositories/" $1; $1=""; print $0}' > $to_restore
 ghe_debug "\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -49,6 +49,7 @@ opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
 remote_tmp_list=$remote_tempdir/remote_tmp_list
 to_restore=$tempdir/to_restore
+remote_to_restore=$remote_tempdir/remote_to_restore
 routes_list=$tempdir/routes_list
 remote_routes_list=$remote_tempdir/remote_routes_list
 
@@ -158,10 +159,10 @@ bm_end "$(basename $0) - Restoring repository networks"
 if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
-  cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
+  cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_to_restore
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $to_restore $tempdir/chunk
-    chunks=\$(find $tempdir/ -name chunk\*)
+    split -l 1000 $remote_to_restore $tempdir/chunk
+    chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/dgit-cluster-restore-finalize" -- \$chunks
 EOF
   bm_end "$(basename $0) - Finalizing routes"

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -51,6 +51,7 @@ opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
 remote_tmp_list=$remote_tempdir/remote_tmp_list
 to_restore=$tempdir/to_restore
+remote_to_restore=$remote_tempdir/remote_to_restore
 routes_list=$tempdir/routes_list
 remote_routes_list=$remote_tempdir/remote_routes_list
 
@@ -149,10 +150,10 @@ bm_end "$(basename $0) - Restoring gists"
 if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
-  cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $to_restore
+  cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_to_restore
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $to_restore $tempdir/chunk
-    chunks=\$(find $tempdir/ -name chunk\*)
+    split -l 1000 $remote_to_restore $tempdir/chunk
+    chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
 EOF
   bm_end "$(basename $0) - Finalizing routes"

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -45,13 +45,14 @@ user="${host%@*}"
 
 hostnames=$host
 tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+remote_tempdir=$(ghe-ssh "$GHE_HOSTNAME" -- mktemp -d -t backup-utils-restore-XXXXXX)
 ssh_config_file_opt=
 opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
+remote_tmp_list=$remote_tempdir/remote_tmp_list
 to_restore=$tempdir/to_restore
 routes_list=$tempdir/routes_list
-local_routes_list=$tempdir/local_routes_list
+remote_routes_list=$remote_tempdir/remote_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -102,23 +103,23 @@ bm_end "$(basename $0) - Building gist list"
 # more performant than performing over an SSH pipe.
 #
 bm_start "$(basename $0) - Transferring gist list"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_tmp_list
 ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring gist list"
 
 bm_start "$(basename $0) - Generating routes"
-echo "cat $tmp_list | github-env ./bin/gist-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
-ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+echo "cat $remote_tmp_list | github-env ./bin/gist-cluster-restore-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Transferring routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "\n$(cat $local_routes_list)"
+ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe_debug "\n$(cat $routes_list)"
 bm_end "$(basename $0) - Transferring routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
-cat $local_routes_list | awk '{ n = split($1, p, "/"); i = p[n]; sub(/\.git/, "", i); printf i " /data/repositories/" $1; $1=""; print $0}' > $to_restore
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk '{ n = split($1, p, "/"); i = p[n]; sub(/\.git/, "", i); printf i " /data/repositories/" $1; $1=""; print $0}' > $to_restore
 ghe_debug "\n$(ls -l $tempdir/*.rsync && cat $to_restore)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -152,7 +152,7 @@ if $CLUSTER; then
   ghe_verbose "Finalizing routes"
   cat $to_restore | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_to_restore
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $remote_to_restore $tempdir/chunk
+    split -l 1000 $remote_to_restore $remote_tempdir/chunk
     chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/gist-cluster-restore-finalize" -- \$chunks
 EOF

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -45,12 +45,13 @@ user="${host%@*}"
 
 hostnames=$host
 tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
-ghe-ssh "$GHE_HOSTNAME" -- mkdir -p $tempdir
+remote_tempdir=$(ghe-ssh "$GHE_HOSTNAME" -- mktemp -d -t backup-utils-restore-XXXXXX)
 ssh_config_file_opt=
 opts="$GHE_EXTRA_SSH_OPTS"
 tmp_list=$tempdir/tmp_list
+remote_tmp_list=$remote_tempdir/remote_tmp_list
 routes_list=$tempdir/routes_list
-local_routes_list=$tempdir/local_routes_list
+remote_routes_list=$remote_tempdir/remote_routes_list
 
 if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
@@ -62,7 +63,7 @@ fi
 
 cleanup() {
   rm -rf $tempdir
-  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $tempdir
+  ghe-ssh "$GHE_HOSTNAME" -- rm -rf $remote_tempdir
   true
 }
 
@@ -94,22 +95,22 @@ bm_end "$(basename $0) - Building object list"
 # more performant than performing over an SSH pipe.
 #
 bm_start "$(basename $0) - Transferring object list"
-cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $tmp_list
+cat $tmp_list | ghe-ssh "$GHE_HOSTNAME" -- sponge $remote_tmp_list
 ghe_debug "\n$(cat $tmp_list)"
 bm_end "$(basename $0) - Transferring object list"
 
 bm_start "$(basename $0) - Generating routes"
-echo "cat $tmp_list | github-env ./bin/storage-cluster-restore-routes > $routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
-ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list)"
+echo "cat $remote_tmp_list | github-env ./bin/storage-cluster-restore-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" /bin/bash
+ghe_debug "\n$(ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list)"
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $routes_list > $local_routes_list
-ghe_debug "\n$(cat $local_routes_list)"
+ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe_debug "\n$(cat $routes_list)"
 bm_end "$(basename $0) - Fetching routes"
 
 bm_start "$(basename $0) - Processing routes"
-cat $local_routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
+cat $routes_list | awk -v tempdir="$tempdir" '{ for(i=2;i<=NF;i++){ print substr($1,1,1) "/" substr($1,1,2) "/" substr($1,3,2) "/" $1 > (tempdir"/"$i".rsync") }}'
 ghe_debug "\n$(ls -l $tempdir/*.rsync)"
 bm_end "$(basename $0) - Processing routes"
 

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -143,7 +143,7 @@ if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $remote_routes_list $tempdir/chunk
+    split -l 1000 $remote_routes_list $remote_tempdir/chunk
     chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
 EOF

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -143,8 +143,8 @@ if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $routes_list $tempdir/chunk
-    chunks=\$(find $tempdir/ -name chunk\*)
+    split -l 1000 $remote_routes_list $tempdir/chunk
+    chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/storage-cluster-restore-finalize" -- \$chunks
 EOF
   bm_end "$(basename $0) - Finalizing routes"


### PR DESCRIPTION
At the moment, when we create the temporary directory on the remote GitHub Enterprise host during a backup or restore, we create it using the path determined by running `mktemp` on the backup host.

For the most part this works, however it doesn't work when the backup host uses a different OS with a different default `$TMPDIR`, like macOS which uses `/var/folders`.

This PR addresses this by using `mkdir` on the GitHub Enterprise appliance to create the tempdir there.

/cc @jatoben 