### PR TITLE
Removing unneeded COPY from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ADD https://github.com/github/backup-utils/archive/stable.tar.gz /
 RUN tar xzvf /stable.tar.gz --strip-components=1 -C /backup-utils && \
     rm -r /stable.tar.gz
 
-COPY share/github-backup-utils/ghe-docker-init /backup-utils/share/github-backup-utils/ghe-docker-init
 RUN chmod +x /backup-utils/share/github-backup-utils/ghe-docker-init
 
 ENTRYPOINT ["/backup-utils/share/github-backup-utils/ghe-docker-init"]


### PR DESCRIPTION
Is this `COPY` to permit overriding functionality/convenience? The `ghe-docker-init` file is copied from the the previously downloaded `tar.gz`, so removing this line removes the need to have this repository cloned altogether.