### PR TITLE
Cleanup all SSH muxes in a non blocking way

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -101,7 +101,7 @@ cleanup () {
   fi
 
   # Cleanup SSH multiplexing
-  ghe-ssh --clean "$GHE_HOSTNAME"
+  ghe-ssh --clean
 }
 
 # Setup exit traps

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -73,7 +73,7 @@ cleanup () {
   fi
 
   # Cleanup SSH multiplexing
-  ghe-ssh --clean "$GHE_HOSTNAME"
+  ghe-ssh --clean
 }
 
 # Bring in the backup configuration

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -38,9 +38,7 @@ while true; do
 done
 
 if [ -n "$cleanup_mux" ]; then
-  while find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1; do
-    find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1
-  done
+  find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1
   exit
 fi
 

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -23,7 +23,7 @@ while true; do
       ;;
     -c|--clean)
       cleanup_mux=1
-      shift
+      break
       ;;
     --)
       echo "Error: illegal '--' in ssh invocation"
@@ -36,6 +36,13 @@ while true; do
       ;;
   esac
 done
+
+if [ -n "$cleanup_mux" ]; then
+  while find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1; do
+    find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1
+  done
+  exit
+fi
 
 # Show usage with no host
 [ -z "$host" ] && print_usage
@@ -77,12 +84,5 @@ fi
 $GHE_VERBOSE_SSH && set -x
 
 # Exec ssh command with modified host / port args and add nice to command.
-if [ -z "$cleanup_mux" ]; then
-  # Exec ssh command with modified host / port args and add nice to command.
-  # shellcheck disable=SC2090 # We don't need the quote/backslashes respected
-  exec ssh -p $port $opts -o BatchMode=yes "$host" -- $GHE_NICE $GHE_IONICE "$@"
-elif [ -z "$GHE_DISABLE_SSH_MUX" ]; then
-  while ssh -O check -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1; do
-    ssh -O stop -o ControlPath="$controlpath" "$GHE_HOSTNAME" > /dev/null 2>&1
-  done
-fi
+# shellcheck disable=SC2090 # We don't need the quote/backslashes respected
+exec ssh -p $port $opts -o BatchMode=yes "$host" -- $GHE_NICE $GHE_IONICE "$@"

--- a/share/github-backup-utils/ghe-ssh
+++ b/share/github-backup-utils/ghe-ssh
@@ -38,7 +38,7 @@ while true; do
 done
 
 if [ -n "$cleanup_mux" ]; then
-  find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1
+  find $TMPDIR -name ".ghe-sshmux-*" -type s -exec ssh -O stop -S {} - \; >/dev/null 2>&1 || true
   exit
 fi
 


### PR DESCRIPTION
`ghe-ssh --cleanup`, and the way we call it in its current form only cleans up a single multiplexing socket, and leaves behind sockets for each of the cluster nodes when backing up a cluster.

This PR updates the cleanup functionality to instead locate and attempt to stop all active multiplexing sockets once, and then moves on, doing so in a non-blocking way, which will prevent the backup utilities from exiting non-zero should a socket not able to be cleaned up. This particular issue (blocking) appears to have been encountered a couple of times recently by GitHub Enterprise administrators.