### PR TITLE
Raise an error if the current symlink doesn't exist when attempting to restore it

### DIFF
--- a/share/github-backup-utils/ghe-restore-snapshot-path
+++ b/share/github-backup-utils/ghe-restore-snapshot-path
@@ -23,7 +23,8 @@ if [ "$GHE_RESTORE_SNAPSHOT" = "current" ]; then
 fi
 
 # Bail out if we don't have a good snapshot.
-if [ ! -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT" ]; then
+if [ -z "$GHE_RESTORE_SNAPSHOT" ] || [ ! -d "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT" ]; then
+  : "${GHE_RESTORE_SNAPSHOT:=current}"
   echo "Error: Snapshot '$GHE_RESTORE_SNAPSHOT' doesn't exist." 1>&2
   exit 1
 fi

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -10,6 +10,28 @@ setup_test_data "$GHE_DATA_DIR/1"
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"
 
+begin_test "ghe-restore reports an error when current symlink doesn't exist"
+(
+  set -e
+  rm "$GHE_DATA_DIR/current"
+
+  ghe-restore -v -f localhost > "$TRASHDIR/restore-out" 2>&1 || true
+  ln -s 1 "$GHE_DATA_DIR/current"
+  grep -q "Error: Snapshot 'current' doesn't exist." "$TRASHDIR/restore-out"
+)
+end_test
+
+begin_test "ghe-restore reports an error when specified snapshot doesn't exist"
+(
+  set -e
+  rm "$GHE_DATA_DIR/current"
+
+  ghe-restore -v -f -s foo localhost > "$TRASHDIR/restore-out" 2>&1 || true
+  ln -s 1 "$GHE_DATA_DIR/current"
+  grep -q "Error: Snapshot 'foo' doesn't exist." "$TRASHDIR/restore-out"
+)
+end_test
+
 begin_test "ghe-restore into configured vm"
 (
   set -e

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -10,23 +10,23 @@ setup_test_data "$GHE_DATA_DIR/1"
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"
 
-begin_test "ghe-restore reports an error when current symlink doesn't exist"
+begin_test "ghe-restore-snapshot-path reports an error when current symlink doesn't exist"
 (
   set -e
   rm "$GHE_DATA_DIR/current"
 
-  ghe-restore -v -f localhost > "$TRASHDIR/restore-out" 2>&1 || true
+  ghe-restore-snapshot-path > "$TRASHDIR/restore-out" 2>&1 || true
   ln -s 1 "$GHE_DATA_DIR/current"
   grep -q "Error: Snapshot 'current' doesn't exist." "$TRASHDIR/restore-out"
 )
 end_test
 
-begin_test "ghe-restore reports an error when specified snapshot doesn't exist"
+begin_test "ghe-restore-snapshot-path reports an error when specified snapshot doesn't exist"
 (
   set -e
   rm "$GHE_DATA_DIR/current"
 
-  ghe-restore -v -f -s foo localhost > "$TRASHDIR/restore-out" 2>&1 || true
+  ghe-restore-snapshot-path foo > "$TRASHDIR/restore-out" 2>&1 || true
   ln -s 1 "$GHE_DATA_DIR/current"
   grep -q "Error: Snapshot 'foo' doesn't exist." "$TRASHDIR/restore-out"
 )


### PR DESCRIPTION
If the data directory lacks a _current_ symlink, `ghe-restore-snapshot-path` doesn't currently notice, and reports a somewhat misleading error:

```
$ bin/ghe-restore -v github.example.com
Checking for leaked keys in the backup snapshot that is being restored ...
* No leaked keys found
cat: /data/backup-utils/data//strategy: No such file or directory
```

This occurs because the output of `readlink` in `ghe-restore-snapshot-path` isn't checked, and [the directory existence test](https://github.com/github/backup-utils/blob/2527b47b73fe029a748993fd9d27d45b2a9415ba/share/github-backup-utils/ghe-restore-snapshot-path#L26-L29) ends up testing for the presence of `GHE_DATA_DIR`.

Here, I've added a check for an empty `GHE_RESTORE_SNAPSHOT`, and tests to verify this case as well as when a snapshot is specified with `-s`.