### PR TITLE
Verbose logging improvements from `hobart-logging`

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -80,7 +80,7 @@ fi
 # otherwise, redirect it to /dev/null. Write verbose output to fd 3.
 if [ -n "$GHE_VERBOSE" ]; then
   if [ -n "$GHE_VERBOSE_LOG" ]; then
-    exec 3<> "$GHE_VERBOSE_LOG"
+    exec 3>> "$GHE_VERBOSE_LOG"
   else
     exec 3>&1
   fi

--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -166,7 +166,7 @@ rsync_repository_data () {
       --files-from="$files_list" \
       --ignore-missing-args \
       "$host:$GHE_REMOTE_DATA_USER_DIR/repositories/" \
-      "$backup_dir" 1>&3
+      "$backup_dir" 1>&3 2>&3
   else
     shift
     ghe-rsync -avr \
@@ -176,7 +176,7 @@ rsync_repository_data () {
       --include-from=- --exclude=\* \
       --ignore-missing-args \
       "$host:$GHE_REMOTE_DATA_USER_DIR/repositories/" \
-      "$backup_dir" 1>&3
+      "$backup_dir" 1>&3 2>&3
   fi
 }
 


### PR DESCRIPTION
This PR:

* Prevents each backup stage from overwriting the verbose log by telling bash to append instead
* Collects STDERR output from `ghe-backup-repositories` `rsync` invocations as well.

These are the only changes that are left from the `hobart-logging` branch, the rest has already been merged to `master. After this PR is merged we can finally put the branch to rest.

/cc @snh @jatoben who worked on the `hobart-logging` branch the most