### PR TITLE
Handle stale node cleanup when grep filters out all nodes

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -348,7 +348,8 @@ if ! $CLUSTER; then
     set -o pipefail; \
     ghe-spokes server show --json \
     | jq -r '.[] | select(.host | contains(\"git-server\")).host' \
-    | sed 's/^git-server-//g' | grep -F -x -v \"$restored_uuid\"" \
+    | sed 's/^git-server-//g' \
+    | ( grep -F -x -v \"$restored_uuid\" || true )" \
   | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash)
   if [ -n "$other_nodes" ]; then
     echo "Cleaning up stale nodes ..."


### PR DESCRIPTION
When implementing https://github.com/github/backup-utils/pull/396 I completely forgot `grep -v` will exit 1 if the `grep -v` filters out all content and returns nothing.

This was missed in my initial testing but showed up in internal tests once the PR was merged.

This PR addresses.