### PR TITLE
Only perform stale node cleanup when restoring to configured instances

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -341,8 +341,8 @@ else
   fi
 fi
 
-# Clean up all stale replicas
-if ! $CLUSTER; then
+# Clean up all stale replicas on configured instances.
+if ! $CLUSTER && $instance_configured; then
   restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)
   other_nodes=$(echo "
     set -o pipefail; \

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -58,6 +58,9 @@ begin_test "ghe-restore into configured vm"
   # verify connect to right host
   grep -q "Connect 127.0.0.1:22 OK" "$TRASHDIR/restore-out"
 
+  # verify stale servers were cleared
+  grep -q "ghe-cluster-cleanup-node OK" "$TRASHDIR/restore-out"
+
   # Verify all the data we've restored is as expected
   verify_all_restored_data
 )
@@ -140,6 +143,12 @@ begin_test "ghe-restore -c into unconfigured vm"
   # verify connect to right host
   grep -q "Connect 127.0.0.1:22 OK" "$TRASHDIR/restore-out"
 
+  # verify attempt to clear stale servers was not made
+  grep -q "ghe-cluster-cleanup-node OK" "$TRASHDIR/restore-out" && {
+    echo "ghe-cluster-cleanup-node should not run on unconfigured nodes."
+    exit 1
+  }
+
   # Verify all the data we've restored is as expected
   verify_all_restored_data
 )
@@ -167,6 +176,12 @@ begin_test "ghe-restore into unconfigured vm"
 
   # verify connect to right host
   grep -q "Connect 127.0.0.1:22 OK" "$TRASHDIR/restore-out"
+
+  # verify attempt to clear stale servers was not made
+  grep -q "ghe-cluster-cleanup-node OK" "$TRASHDIR/restore-out" && {
+    echo "ghe-cluster-cleanup-node should not run on unconfigured nodes."
+    exit 1
+  }
 
   # Verify all the data we've restored is as expected
   verify_all_restored_data

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -413,8 +413,6 @@ verify_all_restored_data() {
     grep -q "fake ghe-export-ssh-host-keys data" "$TRASHDIR/restore-out"
     # verify all ES data was transferred from live directory to the temporary restore directory
     diff -ru --exclude="*.gz" "$GHE_DATA_DIR/current/elasticsearch" "$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore"
-    # verify stale servers were cleared
-    grep -q "ghe-cluster-cleanup-node OK" "$TRASHDIR/restore-out"
   else
     grep -q "fake audit log last yr last mth" "$TRASHDIR/restore-out"
     grep -q "fake audit log this yr this mth" "$TRASHDIR/restore-out"


### PR DESCRIPTION
Unconfigured instances may have pending database migrations that could cause the required database queries to fail. We can't predict which migrations will affect the cleanup so the best option is to not run them on unconfigured instances.

Future work will look into how we can best perform this cleanup when restoring to unconfigured nodes. In the mean time, a manual cleanup can be performed later, if need be.