### PR TITLE
Disable pager and context when running git-diff

### DIFF
--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -370,7 +370,7 @@ if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
   (cd $backup_dir/ && find * -mindepth 5 -maxdepth 6 -type d -name \*.git -exec dirname {} \; | sort | uniq) > $tempdir/destination_routes
 
-  git diff -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more repository networks and/or gists were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
+  git --no-pager diff -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more repository networks and/or gists were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 
   bm_end "$(basename $0) - Verifying Routes"
 fi

--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -370,7 +370,7 @@ if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
   (cd $backup_dir/ && find * -mindepth 5 -maxdepth 6 -type d -name \*.git -exec dirname {} \; | sort | uniq) > $tempdir/destination_routes
 
-  git --no-pager diff -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more repository networks and/or gists were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
+  git --no-pager diff --unified=0 --no-prefix -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more repository networks and/or gists were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 
   bm_end "$(basename $0) - Verifying Routes"
 fi

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -143,7 +143,7 @@ if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
   (cd $backup_dir/ && find * -mindepth 3 -maxdepth 3 -type f -print | sort | uniq) > $tempdir/destination_routes
 
-  git diff -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more storage objects were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
+  git --no-pager diff -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more storage objects were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 
   bm_end "$(basename $0) - Verifying Routes"
 fi

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -143,7 +143,7 @@ if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
   (cd $backup_dir/ && find * -mindepth 3 -maxdepth 3 -type f -print | sort | uniq) > $tempdir/destination_routes
 
-  git --no-pager diff -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more storage objects were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
+  git --no-pager diff --unified=0 --no-prefix -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more storage objects were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 
   bm_end "$(basename $0) - Verifying Routes"
 fi


### PR DESCRIPTION
The pager (if invoked due to excessive output) prevents the backup from running non-interactively. Passing `--no-pager` to `git` disables this. 

Also disables context, since this adds no value in this situation and just makes the output more noisy.