### PR TITLE
Don't fail a backup if the Management Console password isn't set

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -26,7 +26,9 @@ echo "* Transferring license data ..." 1>&3
 ghe-ssh "$host" -- "sudo cat '$GHE_REMOTE_LICENSE_FILE'" > enterprise.ghl
 
 echo "* Transferring management console password ..." 1>&3
-ghe-ssh "$host" -- ghe-config secrets.manage > manage-password+ || true
+ghe-ssh "$host" -- ghe-config secrets.manage > manage-password+ || (
+  echo "Warning: Management Console password not set" >&2
+)
 if [ -n "$(cat manage-password+)" ]; then
   mv manage-password+ manage-password
 else

--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -26,7 +26,7 @@ echo "* Transferring license data ..." 1>&3
 ghe-ssh "$host" -- "sudo cat '$GHE_REMOTE_LICENSE_FILE'" > enterprise.ghl
 
 echo "* Transferring management console password ..." 1>&3
-ghe-ssh "$host" -- ghe-config secrets.manage > manage-password+
+ghe-ssh "$host" -- ghe-config secrets.manage > manage-password+ || true
 if [ -n "$(cat manage-password+)" ]; then
   mv manage-password+ manage-password
 else


### PR DESCRIPTION
When configuring a GitHub Enterprise cluster using automation on platforms such as AWS, the Management Console password is not required and setting it may be skipped. This causes the settings backup to fail, as `ghe-config secrets.manage` exits non-zero due to the non-existent key.

The change here causes `ghe-backup-settings` to print a warning instead; for example:

```
$ bin/ghe-backup
Starting backup of github.example.com with backup-utils v2.14.0 in snapshot 20180713T162211
Connect github.example.com:122 OK (v2.13.4)
Backing up GitHub settings ...
Warning: Management Console password not set
Backing up SSH authorized keys ...
Backing up SSH host keys ...
Backing up MySQL database ...
Backing up Redis database ...
Backing up audit log ...
Backing up hookshot logs ...
Backing up Git repositories ...
Backing up GitHub Pages ...
Backing up storage data ...
Backing up custom Git hooks ...
Completed backup of github.example.com:122 in snapshot 20180713T162211 at 16:22:38
```

@github/backup-utils Thoughts on this approach?