### PR TITLE
Fix permissions issues when repeat restoring to configured cluster instance

### DIFF
--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -61,11 +61,11 @@ if [ -s "$tmp_list" ]; then
   if $CLUSTER || [ -n "$configured" ]; then
     for index in $(cat $tmp_list | sed 's/\.gz$//g'); do
       ghe_verbose "* Restoring $index"
-      echo "export PATH=\$PATH:/usr/local/share/enterprise && gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
+      echo "export PATH=\$PATH:/usr/local/share/enterprise && sudo gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
       ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
     done
 
-    ghe-ssh "$GHE_HOSTNAME" -- "sudo rm $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/*.gz" 1>&3
+    ghe-ssh "$GHE_HOSTNAME" -- "sudo sh -c 'rm $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/*.gz'" 1>&3
   fi
 
   rm $tmp_list

--- a/share/github-backup-utils/ghe-restore-es-hookshot
+++ b/share/github-backup-utils/ghe-restore-es-hookshot
@@ -48,11 +48,10 @@ if [ -s "$tmp_list" ]; then
   if $CLUSTER || [ -n "$configured" ]; then
     for index in $(cat $tmp_list | sed 's/\.gz$//g'); do
       ghe_verbose "* Restoring $index"
-      echo "export PATH=\$PATH:/usr/local/share/enterprise && gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
+      echo "export PATH=\$PATH:/usr/local/share/enterprise && sudo gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
       ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
     done
-    
-    ghe-ssh "$GHE_HOSTNAME" -- "sudo rm $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/*.gz" 1>&3
+    ghe-ssh "$GHE_HOSTNAME" -- "sudo sh -c 'rm $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/*.gz'" 1>&3
   fi
 
   rm $tmp_list


### PR DESCRIPTION
During investigation of another problem today, I discovered I neglected to take into account all permissions scenarios when implementing the restore optimisations in https://github.com/github/backup-utils/pull/413.

I've since found that when repeat restoring to a configured cluster, you encounter permissions errors on subsequent restores like these:

```
[...]
* Restoring audit_log-1-2018-07-1
gzip: /data/user/elasticsearch-restore/audit_log-1-2018-07-1: Permission denied
Restoring hookshot logs ...
[...]
```

This affects both the restore of hookshot and audit logs.

This PR addresses this.