### PR TITLE
Prevent restoring snapshots to older releases

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -91,6 +91,17 @@ if [ -z "$version" ]; then
   exit 2
 fi
 
+# Block restoring snapshots to older releases of GitHub Enterprise
+if [ -n "$GHE_RESTORE_SNAPSHOT_PATH" ]; then
+  snapshot_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)
+  # shellcheck disable=SC2046 # Word splitting is required to populate the variables
+  read -r snapshot_version_major snapshot_version_minor _ <<<$(ghe_parse_version $snapshot_version)
+  if [ "$(version $GHE_REMOTE_VERSION)" -lt "$(version $snapshot_version_major.$snapshot_version_minor.0)" ]; then
+    echo "Error: Snapshot can not be restored to an older release of GitHub Enterprise." >&2
+    exit 1
+  fi
+fi
+
 if [ -z "$GHE_ALLOW_REPLICA_BACKUP" ]; then
   if [ "$(ghe-ssh $host -- cat $GHE_REMOTE_ROOT_DIR/etc/github/repl-state 2>/dev/null || true)" = "replica" ]; then
     echo "Error: high availability replica detected." 1>&2

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -106,6 +106,15 @@ GHE_BACKUP_STRATEGY=$(cat "$GHE_RESTORE_SNAPSHOT_PATH/strategy")
 # Perform a host-check and establish the remote version in GHE_REMOTE_VERSION.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
+# Block restoring snapshots to older releases of GitHub Enterprise
+snapshot_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)
+# shellcheck disable=SC2046 # Word splitting is required to populate the variables
+read -r snapshot_version_major snapshot_version_minor _ <<<$(ghe_parse_version $snapshot_version)
+if [ "$(version $GHE_REMOTE_VERSION)" -lt "$(version $snapshot_version_major.$snapshot_version_minor.0)" ]; then
+  echo "Error: Snapshot can not be restored to an older release of GitHub Enterprise." >&2
+  exit 1
+fi
+
 # Figure out if this instance has been configured or is entirely new.
 instance_configured=false
 if ghe-ssh "$GHE_HOSTNAME" -- "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/configured' ]"; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -106,15 +106,6 @@ GHE_BACKUP_STRATEGY=$(cat "$GHE_RESTORE_SNAPSHOT_PATH/strategy")
 # Perform a host-check and establish the remote version in GHE_REMOTE_VERSION.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-# Block restoring snapshots to older releases of GitHub Enterprise
-snapshot_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)
-# shellcheck disable=SC2046 # Word splitting is required to populate the variables
-read -r snapshot_version_major snapshot_version_minor _ <<<$(ghe_parse_version $snapshot_version)
-if [ "$(version $GHE_REMOTE_VERSION)" -lt "$(version $snapshot_version_major.$snapshot_version_minor.0)" ]; then
-  echo "Error: Snapshot can not be restored to an older release of GitHub Enterprise." >&2
-  exit 1
-fi
-
 # Figure out if this instance has been configured or is entirely new.
 instance_configured=false
 if ghe-ssh "$GHE_HOSTNAME" -- "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/configured' ]"; then

--- a/test/test-ghe-host-check.sh
+++ b/test/test-ghe-host-check.sh
@@ -78,3 +78,16 @@ begin_test "ghe-host-check detects high availability replica"
   GHE_ALLOW_REPLICA_BACKUP=yes ghe-host-check
 )
 end_test
+
+begin_test "ghe-host-check blocks restore to old release"
+(
+  set -e
+  
+  mkdir -p "$GHE_DATA_DIR/current/"
+  echo "$GHE_TEST_REMOTE_VERSION" > "$GHE_DATA_DIR/current/version"
+
+  # shellcheck disable=SC2046 # Word splitting is required to populate the variables
+  read -r bu_version_major bu_version_minor bu_version_patch <<<$(ghe_parse_version $GHE_TEST_REMOTE_VERSION)
+  ! GHE_TEST_REMOTE_VERSION=$bu_version_major.$((bu_version_minor-1)).$bu_version_patch ghe-restore -v
+)
+end_test

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -398,18 +398,6 @@ begin_test "ghe-restore exits early on unsupported version"
 )
 end_test
 
-begin_test "ghe-restore exits early when restoring to older release"
-(
-  set -e
-  GHE_RESTORE_HOST=127.0.0.1
-  export GHE_RESTORE_HOST
-
-  # shellcheck disable=SC2046 # Word splitting is required to populate the variables
-  read -r bu_version_major bu_version_minor bu_version_patch <<<$(ghe_parse_version $GHE_TEST_REMOTE_VERSION)
-  ! GHE_TEST_REMOTE_VERSION=$bu_version_major.$((bu_version_minor-1)).$bu_version_patch ghe-restore -v
-)
-end_test
-
 # Reset data for sub-subsequent tests
 rm -rf "$GHE_DATA_DIR/1"
 setup_test_data "$GHE_DATA_DIR/1"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -341,7 +341,7 @@ begin_test "ghe-restore fails when restore 2.9/2.10 snapshot without audit log m
   set -e
 
   # noop if not testing against 2.11
-  if [ "$GHE_VERSION_MAJOR" -ne 2 ] && [ "$GHE_VERSION_MINOR" -ne 11 ]; then
+  if [ "$(version $GHE_REMOTE_VERSION)" -ne "$(version 2.11.0)" ]; then
     skip_test
   fi
 
@@ -368,7 +368,7 @@ begin_test "ghe-restore force restore of 2.9/2.10 snapshot without audit log mig
   set -e
 
   # noop if not testing against 2.11
-  if [ "$GHE_VERSION_MAJOR" -ne 2 ] && [ "$GHE_VERSION_MINOR" -ne 11 ]; then
+  if [ "$(version $GHE_REMOTE_VERSION)" -ne "$(version 2.11.0)" ]; then
     skip_test
   fi
 

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -398,6 +398,18 @@ begin_test "ghe-restore exits early on unsupported version"
 )
 end_test
 
+begin_test "ghe-restore exits early when restoring to older release"
+(
+  set -e
+  GHE_RESTORE_HOST=127.0.0.1
+  export GHE_RESTORE_HOST
+
+  # shellcheck disable=SC2046 # Word splitting is required to populate the variables
+  read -r bu_version_major bu_version_minor bu_version_patch <<<$(ghe_parse_version $GHE_TEST_REMOTE_VERSION)
+  ! GHE_TEST_REMOTE_VERSION=$bu_version_major.$((bu_version_minor-1)).$bu_version_patch ghe-restore -v
+)
+end_test
+
 # Reset data for sub-subsequent tests
 rm -rf "$GHE_DATA_DIR/1"
 setup_test_data "$GHE_DATA_DIR/1"


### PR DESCRIPTION
As pointed out in https://github.com/github/backup-utils/issues/403, Backup Utilities currently allows snapshots to be restored to older releases of GitHub Enterprise than that of the snapshot, ie 2.14.x to 2.13.x.

This isn't supported and causes problems when the database migrations run as they're only intended to be run in ascending order.

This PR implements a block to stop attempts to restore snapshots of newer releases of GitHub Enterprise to older releases of GitHub Enterprise. Snapshots can still be restored to older patch releases of the same release, eg 2.14.2 to 2.14.0, as no migrations take in during patch releases.

Whilst I was at it, I also simplified the version checking for two other tests, though I'm contemplating removing these tests entirely as we don't mimic restores against 2.11.0 anymore.

Fixes https://github.com/github/backup-utils/issues/403