### PR TITLE
Only need to mention GHE version support if .0 release.

### DIFF
--- a/script/release
+++ b/script/release
@@ -407,7 +407,8 @@ if $PROGRAM_NAME == __FILE__
 
     puts 'Updating changelog...'
     update_changelog release_changes, DEB_PKG_NAME, version
-    release_body = "Includes general improvements, bug fixes and support for GitHub Enterprise v#{version}"
+    release_body = "Includes general improvements & bug fixes"
+    release_body += " and support for GitHub Enterprise v#{version}" unless min_version.nil?
     release_changes.each do |c|
       release_body += "\n* #{c}"
     end


### PR DESCRIPTION
I noticed today when publishing v2.14.1 that the release includes mention of a GitHub Enterprise version suggesting the patch release of Backup Utilities is tied to the patch release of GitHub Enterprise. This is not the case. The extra "and support for GitHub Enterprise v#{version}" is only needed for .0 releases where there _is_ a link.