### PR TITLE
Use remote tempdir when finalizing Pages routes

### DIFF
--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -148,8 +148,8 @@ if $CLUSTER; then
   bm_start "$(basename $0) - Finalizing routes"
   ghe_verbose "Finalizing routes"
   ghe-ssh "$GHE_HOSTNAME" -- /bin/bash >&3 <<EOF
-    split -l 1000 $routes_list $tempdir/chunk
-    chunks=\$(find $tempdir/ -name chunk\*)
+    split -l 1000 $remote_routes_list $remote_tempdir/chunk
+    chunks=\$(find $remote_tempdir/ -name chunk\*)
     parallel -i /bin/sh -c "cat {} | github-env ./bin/dpages-cluster-restore-finalize" -- \$chunks
 EOF
   bm_end "$(basename $0) - Finalizing routes"


### PR DESCRIPTION
When restoring to a GitHub Enterprise cluster, the route finalization for Pages used the local temporary directory, rather than the remote. That caused errors like this in the backup output:

```
Restoring GitHub Pages ...
split: cannot open ‘/tmp/backup-utils-restore-lNUyjP/routes_list’ for reading: No such file or directory
find: `/tmp/backup-utils-restore-lNUyjP/': No such file or directory
```

This PR updates the Pages finalize step to use `$remote_routes_list` and `$remote_tempdir`, preventing the error. I've tested with a local cluster and confirmed that Pages are restored correctly with the change.