### PR TITLE
Switch SSH port and extended options to ensure correct port selection

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -274,7 +274,7 @@ ssh_host_part () {
 # This is used primarily to break hostspecs with non-standard ports down for
 # rsync commands.
 ssh_port_part () {
-  [ "${1##*:}" = "$1" ] && echo 122 || echo "${1##*:}"
+  [ "${1##*:}" = "$1" ] && echo 22 || echo "${1##*:}"
 }
 
 # Usage: ghe_remote_logger <message>...

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -89,7 +89,7 @@ end_test
 begin_test "ghe-backup-config ssh_port_part"
 (
   set -e
-  [ "$(ssh_port_part 'github.example.com')" = "122" ]
+  [ "$(ssh_port_part 'github.example.com')" = "22" ]
   [ "$(ssh_port_part 'github.example.com:22')" = "22" ]
   [ "$(ssh_port_part 'github.example.com:5000')" = "5000" ]
   [ "$(ssh_port_part 'git@github.example.com:5000')" = "5000" ]


### PR DESCRIPTION
https://github.com/github/backup-utils/issues/433 identified a problem where backups of pages and storage would fail with:

```
This port is reserved for git operations.
To administer the host over SSH, use port 122 with `ssh -p 122`.
rsync: connection unexpectedly closed (0 bytes received so far) [receiver]
rsync error: error in rsync protocol data stream (code 12) at io.c(600) [receiver=3.0.6]
```

... if you include `-p 122` in `GHE_EXTRA_SSH_OPTS` in your `backup.config`.

After a bit of digging, I worked out it's due to the port detection logic performed by `ghe-host-check` being overruled by the port checking in `ghe-ssh` resulting in two `-p` arguments - one from the port determination and one from the extended options, with the latter, `-p 22` overruling the former:

```
* Transferring pages files ...
+ ghe-rsync -avz -e 'ssh -q -p 122 -i <ssh_key> -p 22  -l admin' '--rsync-path=sudo -u git rsync' --link-dest=../../current/pages <hostname>:/data/user/pages/ /<path>/<to>/data/20180831T140503/pages
This port is reserved for git operations.
To administer the host over SSH, use port 122 with `ssh -p 122`.
rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]
rsync error: error in rsync protocol data stream (code 12) at io.c(226) [Receiver=3.1.1]
+ cleanup
+ rm -rf /tmp/backup-utils-restore-aC0i3N
```

Switching the order of the extended options and the determined port in `ghe-ssh` gives us our desired behaviour:

```
* Transferring pages files ...
+ ghe-rsync -avz -e 'ssh -q -p 122 -i <ssh_key> -p 122  -l admin' '--rsync-path=sudo -u git rsync' --link-dest=../../current/pages <hostname>:/data/user/pages/ /<path>/<to>/data/20180831T141251/pages
receiving incremental file list
./
```

Yes, it's duplicated, but it's now the correct port, thus effectively ignoring the port in the extended options. I've not gone the route of stripping duplicate options just yet as this is potentially fraught with complicated logic.

Fixes https://github.com/github/backup-utils/issues/433