### PR TITLE
Improve multi-platform detection of simultaneous ghe-backup runs

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -119,12 +119,14 @@ if [ -f ../in-progress ]; then
   progress=$(cat ../in-progress)
   snapshot=$(echo "$progress" | cut -d ' ' -f 1)
   pid=$(echo "$progress" | cut -d ' ' -f 2)
-  if ! ps -p $pid | grep ghe-backup; then
+  if ! ps -p "$pid" >/dev/null 2>&1; then
     # We can safely remove in-progress, ghe-prune-snapshots
     # will clean up the failed backup.
     unlink ../in-progress
   else
-    echo "Error: backup process $pid of $GHE_HOSTNAME already in progress in snapshot $snapshot. Aborting." 1>&2
+    echo "Error: A backup of $GHE_HOSTNAME may still be running on PID $pid." 1>&2
+    echo "If PID $pid is not a process related to the backup utilities, please remove" 1>&2
+    echo "the $GHE_DATA_DIR/in-progress file and try again." 1>&2
     exit 1
   fi
 fi


### PR DESCRIPTION
This change corrects an issue where the PID provided by the `in-progress` file isn't correctly identified on Ubuntu systems. The `ps -p PID` command returns `bash` instead of `ghe-backup`, which results in the subsequent `grep` not returning a match.

After this change `ghe-backup` will stop if any process is found on the reported PID. As this could (rarely) result in false matches, a message has been added to warn the admin and recommend they examine the PID to see if it is indeed related and if not, remove the stale `in-progress` file. 

False positives here should only occur if the `in-progress` file is left behind for some reason, and another process starts on the same PID that `ghe-backup` used in its previous run.

The message is similar to the one presented when a legacy `in-progress` symlink is detected.

/cc @github/backup-utils for review.