### PR TITLE
Document not to use replica

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -48,3 +48,9 @@ GHE_NUM_SNAPSHOTS=10
 #
 # WARNING: do not enable this, only useful for debugging/development
 #GHE_BACKUP_FSCK=no
+
+# The PATH for the backup utilities to use. The default PATH used is that of the
+# executing user which may not always be customizable or contain all the utilities
+# required by the backup utilities.
+#
+#PATH=""

--- a/backup.config-example
+++ b/backup.config-example
@@ -48,9 +48,3 @@ GHE_NUM_SNAPSHOTS=10
 #
 # WARNING: do not enable this, only useful for debugging/development
 #GHE_BACKUP_FSCK=no
-
-# The PATH for the backup utilities to use. The default PATH used is that of the
-# executing user which may not always be customizable or contain all the utilities
-# required by the backup utilities.
-#
-#PATH=""

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,9 +12,12 @@
     backup and restore GitHub Enterprise 2.10 and earlier.
 
  2. Copy the [`backup.config-example`][3] file to `backup.config` and modify as
-    necessary. The `GHE_HOSTNAME` value must be set to the GitHub Enterprise
+    necessary. The `GHE_HOSTNAME` value must be set to the primary GitHub Enterprise
     host name. Additional options are available and documented in the
     configuration file but none are required for basic backup functionality.
+
+    As the data on a High Availability replica may be in a transient state at the time of backup,
+    Backup Utilities should not be used to backup data from a High Availability replica.
 
     * Backup Utilities will attempt to load the backup configuration from the following
       locations, in this order:


### PR DESCRIPTION
This is a bit of housework to clean up a few stale PRs.

~~The first change introduces the `PATH` option to ` backup.config-example` which is useful to set for hosts where the required commands aren't in the user's default path and the implementer isn't in a position to change the user's path. We already honour this, so documenting it is all that's needed.~~

Update: after internal discussions, reverted ☝️ as this makes it far too easy to make a mistake.

This makes the relevant part of https://github.com/github/backup-utils/pull/294 moot. The `ps` change is no longer needed thanks to https://github.com/github/backup-utils/pull/435 .

The second change makes it clear that backups need to be performed against the primary GitHub Enterprise instance. This is already enforced by Backup Utilities, but not yet documented.

This makes https://github.com/github/backup-utils/pull/398 moot.
