### PR TITLE
consul recover from uuid change

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -258,7 +258,9 @@ if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
   echo "Restoring UUID ..."
   cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
   ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
-fi
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul"
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft"
+  fi
 
 echo "Restoring MySQL database ..."
 ghe-restore-mysql "$GHE_HOSTNAME" 1>&3

--- a/test/bin/systemctl
+++ b/test/bin/systemctl
@@ -1,0 +1,1 @@
+ghe-fake-true


### PR DESCRIPTION
`ghe-restore` was restoring a `uuid` file that consul now heavily relies on. 

/cc @lildude