### PR TITLE
adding `|| true` to consul stop

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -258,8 +258,8 @@ if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
   echo "Restoring UUID ..."
   cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
   ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul" || true 
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft || true "
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul" || true
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft"
   fi
 
 echo "Restoring MySQL database ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -258,8 +258,8 @@ if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
   echo "Restoring UUID ..."
   cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
   ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul"
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft"
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul || true "
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft || true "
   fi
 
 echo "Restoring MySQL database ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -258,7 +258,7 @@ if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
   echo "Restoring UUID ..."
   cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
   ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul || true "
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul" || true 
   ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft || true "
   fi
 

--- a/test/bin/systemctl
+++ b/test/bin/systemctl
@@ -1,1 +1,0 @@
-ghe-fake-true


### PR DESCRIPTION
This changes the result of stopping of `consul` via `ghe-restore` 
This will use `sudo systemctl stop consul || true`

/related https://github.com/github/backup-utils/pull/442
/cc @lildude 