### PR TITLE
Bump version: 2.15.0

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -113,7 +113,7 @@ fi
 
 # backup-utils 2.13 onwards limits support to the current and previous two releases
 # of GitHub Enterprise.
-supported_minimum_version="2.11.0"
+supported_minimum_version="2.13.0"
 
 if [ "$(version $version)" -ge "$(version $supported_minimum_version)" ]; then
   supported=1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,11 @@
 github-backup-utils (2.15.0) UNRELEASED; urgency=medium
 
 
+ -- Colin Seymour <colin@github.com>  Tue, 16 Oct 2018 16:40:03 +0000
+
+github-backup-utils (2.15.0) UNRELEASED; urgency=medium
+
+
  -- Colin Seymour <colin@github.com>  Tue, 16 Oct 2018 16:07:36 +0000
 
 github-backup-utils (2.14.3) UNRELEASED; urgency=medium

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -42,7 +42,7 @@ export GHE_BACKUP_CONFIG GHE_DATA_DIR GHE_REMOTE_DATA_DIR GHE_REMOTE_ROOT_DIR
 
 # The default remote appliance version. This may be set in the environment prior
 # to invoking tests to emulate a different remote vm version.
-: ${GHE_TEST_REMOTE_VERSION:=2.11.0}
+: ${GHE_TEST_REMOTE_VERSION:=2.15.0}
 export GHE_TEST_REMOTE_VERSION
 
 # Source in the backup config and set GHE_REMOTE_XXX variables based on the


### PR DESCRIPTION
Includes general improvements & bug fixes and support for GitHub Enterprise v2.15.0

/cc @github/backup-utils