### PR TITLE
Remove 2.11 and earlier specific code and tests

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -137,21 +137,6 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
   exit 1
 fi
 
-# Only allow restores of 2.9 and 2.10 snapshots that have run the audit log migration to 2.11 and above
-if ! $force; then
-  snapshot_instance_version=$(cat $GHE_RESTORE_SNAPSHOT_PATH/version)
-  snapshot_version_major=$(echo "${snapshot_instance_version#v}" | cut -f 1 -d .)
-  snapshot_version_minor=$(echo "$snapshot_instance_version"     | cut -f 2 -d .)
-  if ! test -f $GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete && \
-     [ "$snapshot_version_major" -eq 2 ] && [ "$snapshot_version_minor" -lt 11 ] && \
-     [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 11 ]; then
-        echo "Error: Snapshot must be from GitHub Enterprise v2.9 or v2.10 after running the" >&2
-        echo "       audit log migration, or from v2.11.0 or above." >&2
-        echo "Please see https://git.io/v5rCE for the audit log migration procedure." >&2
-        exit 1
-  fi
-fi
-
 # Prompt to verify the restore host given is correct. Restoring overwrites
 # important data on the destination appliance that cannot be recovered. This is
 # mostly to prevent accidents where the backup host is given to restore instead

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -336,58 +336,6 @@ begin_test "ghe-restore honours --help and -h flags"
 )
 end_test
 
-begin_test "ghe-restore fails when restore 2.9/2.10 snapshot without audit log migration sentinel file to 2.11"
-(
-  set -e
-
-  # noop if not testing against 2.11
-  if [ "$(version $GHE_REMOTE_VERSION)" -ne "$(version 2.11.0)" ]; then
-    skip_test
-  fi
-
-  rm -rf "$GHE_REMOTE_ROOT_DIR"
-  setup_remote_metadata
-
-  echo "rsync" > "$GHE_DATA_DIR/current/strategy"
-  echo "v2.9.10" > "$GHE_DATA_DIR/current/version"
-  rm "$GHE_DATA_DIR/current/es-scan-complete"
-
-  ! output=$(ghe-restore -v localhost 2>&1)
-
-  echo $output | grep -q "Error: Snapshot must be from GitHub Enterprise v2.9 or v2.10 after running the"
-
-  echo "v2.10.5" > "$GHE_DATA_DIR/current/version"
-  ! output=$(ghe-restore -v localhost 2>&1)
-
-  echo $output | grep -q "Error: Snapshot must be from GitHub Enterprise v2.9 or v2.10 after running the"
-)
-end_test
-
-begin_test "ghe-restore force restore of 2.9/2.10 snapshot without audit log migration sentinel file to 2.11"
-(
-  set -e
-
-  # noop if not testing against 2.11
-  if [ "$(version $GHE_REMOTE_VERSION)" -ne "$(version 2.11.0)" ]; then
-    skip_test
-  fi
-
-  rm -rf "$GHE_REMOTE_ROOT_DIR"
-  setup_remote_metadata
-
-  echo "rsync" > "$GHE_DATA_DIR/current/strategy"
-  echo "v2.9.10" > "$GHE_DATA_DIR/current/version"
-
-  # Create fake remote repositories dir
-  mkdir -p "$GHE_REMOTE_DATA_USER_DIR/repositories"
-
-  ghe-restore -v -f localhost
-
-  echo "v2.10.5" > "$GHE_DATA_DIR/current/version"
-  ghe-restore -v -f localhost
-)
-end_test
-
 begin_test "ghe-restore exits early on unsupported version"
 (
   set -e


### PR DESCRIPTION
GitHub Enterprise 2.11.0 is now end of life and no longer supported by the current release of backup-utils.

This PR removes a 2.11-specific restore step and corresponding tests.