### PR TITLE
Check the user that owns storage instead of assuming the git user

### DIFF
--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -113,6 +113,8 @@ if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   exit 0
 fi
 
+storage_user=$(ghe-ssh "$GHE_HOSTNAME" -- stat -c %U /data/user/storage || echo git)
+
 # rsync all the storage objects
 bm_start "$(basename $0) - Storage object sync"
 for file_list in $tempdir/*.rsync; do
@@ -124,7 +126,7 @@ for file_list in $tempdir/*.rsync; do
   ghe-rsync -avr \
   -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \
   $link_dest "$@" \
-  --rsync-path='sudo -u git rsync' \
+  --rsync-path="sudo -u $storage_user rsync" \
   --files-from="$file_list" \
   --ignore-missing-args \
   --size-only \

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -119,6 +119,8 @@ if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   exit 0
 fi
 
+storage_user=$(ghe-ssh "$GHE_HOSTNAME" -- stat -c %U /data/user/storage || echo git)
+
 # rsync all the objects to the storage server where they belong.
 # One rsync invocation per server available.
 bm_start "$(basename $0) - Restoring objects"
@@ -131,7 +133,7 @@ for file_list in $tempdir/*.rsync; do
   ghe_verbose "* Transferring data to $server ..."
   ghe-rsync -arvHR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \
-    --rsync-path="sudo -u git rsync" \
+    --rsync-path="sudo -u $storage_user rsync" \
     --files-from=$file_list \
     --size-only \
     "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/storage/./" \


### PR DESCRIPTION
This ensures this keeps working if we would change the user that owns this directory in the future.