### PR TITLE
Cater for v that may occur in the version string

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -302,5 +302,5 @@ ghe_debug() {
 }
 
 version() {
-  echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+  echo "${@#v}" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }


### PR DESCRIPTION
As discovered by @terrorobe in https://github.com/github/backup-utils/issues/457, when the version string contains a `v`, eg `v2.15.3`, the version comparison doesn't quite work as expected:

```
++ version v2.15.3
++ echo v2.15.3
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
++ version 2.12.9
++ echo 2.12.9
++ awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+ '[' 0015003000 -ge 2012009000 ']'
```

This isn't a problem when we're testing for `-le` but does cause a problem for all other instances.

This PR resolves this by ignoring the `v` if it's present:

```console
$ version 2.15.4
2015004000
$ version v2.15.4
2015004000
$
```
