### PR TITLE
Remove the -H option from rsync when restoring repositories & gists

### DIFF
--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -147,7 +147,7 @@ for file_list in $tempdir/*.rsync; do
     server=$host
   fi
   ghe_verbose "* Transferring repository networks to $server ..."
-  ghe-rsync -avrHR --delete \
+  ghe-rsync -avrR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \
     --rsync-path="sudo -u git rsync" \
     --files-from=$file_list \

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -139,7 +139,7 @@ for file_list in $tempdir/*.rsync; do
     server=$host
   fi
   ghe_verbose "* Transferring gists to $server"
-  ghe-rsync -avrHR --delete \
+  ghe-rsync -avrR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \
     --rsync-path="sudo -u git rsync" \
     --files-from=$file_list \

--- a/share/github-backup-utils/ghe-restore-repositories-rsync
+++ b/share/github-backup-utils/ghe-restore-repositories-rsync
@@ -37,7 +37,7 @@ ghe-gc-disable $GHE_HOSTNAME
 
 # Transfer all git repository data from the latest snapshot to the GitHub
 # instance in a single rsync invocation.
-ghe-rsync -avH --delete \
+ghe-rsync -av --delete \
     --exclude ".sync_in_progress" \
     -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
     --rsync-path="sudo -u git rsync" \


### PR DESCRIPTION
This PR removes the rsync `-H | --hard-links` option from the restore subcommands for repositories and Gists. Hard links are not needed during these parts of the restore process, and in rare cases, including `-H` has resulted in errors such as https://bugzilla.samba.org/show_bug.cgi?id=12769#c3.