### PR TITLE
Detect storage user on each host being backed up or restored

### DIFF
--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -113,12 +113,11 @@ if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   exit 0
 fi
 
-storage_user=$(ghe-ssh "$GHE_HOSTNAME" -- stat -c %U /data/user/storage || echo git)
-
 # rsync all the storage objects
 bm_start "$(basename $0) - Storage object sync"
 for file_list in $tempdir/*.rsync; do
   hostname=$(basename $file_list .rsync)
+  storage_user=$(ghe-ssh $ssh_config_file_opt $hostname:$port -- stat -c %U /data/user/storage || echo git)
 
   object_num=$(cat $file_list | wc -l)
   ghe_verbose "* Transferring $object_num objects from $hostname"

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -119,8 +119,6 @@ if ! ls $tempdir/*.rsync >/dev/null 2>&1; then
   exit 0
 fi
 
-storage_user=$(ghe-ssh "$GHE_HOSTNAME" -- stat -c %U /data/user/storage || echo git)
-
 # rsync all the objects to the storage server where they belong.
 # One rsync invocation per server available.
 bm_start "$(basename $0) - Restoring objects"
@@ -130,6 +128,8 @@ for file_list in $tempdir/*.rsync; do
   else
     server=$host
   fi
+  storage_user=$(ghe-ssh $ssh_config_file_opt $server:$port -- stat -c %U /data/user/storage || echo git)
+
   ghe_verbose "* Transferring data to $server ..."
   ghe-rsync -arvHR --delete \
     -e "ssh -q $opts -p $port $ssh_config_file_opt -l $user" \


### PR DESCRIPTION
If a backup or restore targets a GitHub Enterprise Server cluster node that was upgraded from a previous release to the 2.16 series and isn't running the storage service, the user account detection added in https://github.com/github/backup-utils/pull/448 will return an incorrect result. `rsync` then won't have the correct permissions to copy storage data.

This PR aims to fix that by running the user detection on each storage node, rather than the target of the `ghe-backup` or `ghe-restore`.