### PR TITLE
add Dockerfile based on alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,22 @@
+FROM alpine:latest
+
+RUN apk --update --no-cache add \
+    tar \
+    rsync \
+    ca-certificates \
+    openssh \
+    git \
+    bash \
+    gawk \
+    procps
+
+WORKDIR /backup-utils
+ADD https://github.com/github/backup-utils/archive/stable.tar.gz /
+RUN tar xzvf /stable.tar.gz --strip-components=1 -C /backup-utils && \
+    mv /usr/bin/gawk /usr/bin/awk && \
+    rm -r /stable.tar.gz
+
+RUN chmod +x /backup-utils/share/github-backup-utils/ghe-docker-init
+
+ENTRYPOINT ["/backup-utils/share/github-backup-utils/ghe-docker-init"]
+CMD ["ghe-host-check"]


### PR DESCRIPTION
This PR adds a Dockerfile based on alpine instead of Debian.

Why the need for something besides Debian? My organization typically blocks any images that have known high/critical CVE, and Debian images have numerous.

The vast majority of the Dockerfile matches that of the orginal, but has a few modifications that include:

- Install [gawk](https://pkgs.alpinelinux.org/package/edge/main/x86/gawk) to override the busybox version of awk
- Install [procps](https://pkgs.alpinelinux.org/package/v3.4/main/x86/procps) to overide the busybox version of ps
- Install openssh package instead of ssh

Both of the afermentioned busybox changes are needed to make those utilies respond in the same fashion as the debian equivalents 