### PR TITLE
Restore target is ignored when specified on the command line

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -63,7 +63,7 @@ while true; do
       ;;
     *)
       if [ -n "$1" ]; then
-        GHE_RESTORE_HOST="$1"
+        GHE_RESTORE_HOST_OPT="$1"
         shift
       else
         break
@@ -86,7 +86,7 @@ cleanup () {
 . "$( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config"
 
 # Grab the host arg
-GHE_HOSTNAME="$GHE_RESTORE_HOST"
+GHE_HOSTNAME="${GHE_RESTORE_HOST_OPT:-$GHE_RESTORE_HOST}"
 
 # Hostname without any port suffix
 hostname=$(echo "$GHE_HOSTNAME" | cut -f 1 -d :)

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -188,6 +188,40 @@ begin_test "ghe-restore into unconfigured vm"
 )
 end_test
 
+begin_test "ghe-restore with host arg and config value"
+(
+  set -e
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+
+  # set as configured, enable maintenance mode and create required directories
+  setup_maintenance_mode "configured"
+
+  # set restore host environ var (which we shouldn't see)
+  GHE_RESTORE_HOST="broken.config.restore.host"
+  export GHE_RESTORE_HOST
+
+  # set restore host config var (which we shouldn't see)
+  GHE_BACKUP_CONFIG_TEMP="${GHE_BACKUP_CONFIG}.temp"
+  cp "$GHE_BACKUP_CONFIG" "$GHE_BACKUP_CONFIG_TEMP"
+  echo 'GHE_RESTORE_HOST="broken.config.restore.host"' >> "$GHE_BACKUP_CONFIG_TEMP"
+  GHE_BACKUP_CONFIG="$GHE_BACKUP_CONFIG_TEMP"
+  export GHE_BACKUP_CONFIG
+
+  # run it
+  output="$(ghe-restore -f localhost)" || false
+
+  # clean up the config file
+  rm "$GHE_BACKUP_CONFIG_TEMP"
+
+  # verify host arg overrides configured restore host
+  echo "$output" | grep -q 'Connect localhost:22 OK'
+
+  # Verify all the data we've restored is as expected
+  verify_all_restored_data
+)
+end_test
+
 begin_test "ghe-restore with host arg"
 (
   set -e
@@ -198,7 +232,7 @@ begin_test "ghe-restore with host arg"
   setup_maintenance_mode "configured"
 
   # set restore host environ var
-  GHE_RESTORE_HOST=127.0.0.1
+  GHE_RESTORE_HOST="broken.environ.restore.host"
   export GHE_RESTORE_HOST
 
   # run it


### PR DESCRIPTION
The change places the command line restore host arg into a temporary holding variable (`GHE_RESTORE_HOST_OPT`) so it's not stomped on by the version imported from the `backup.config` file.

It then either copies the target into `GHE_HOSTNAME` after the config file has been loaded or uses `GHE_RESTORE_HOST` if a target wasn't specified on the command line.

I believe I introduced this bug in https://github.com/github/backup-utils/pull/449/files 😞.

However, I'm unsure why the test at https://github.com/github/backup-utils/blob/master/test/test-ghe-restore.sh#L191-L213 didn't pick it up? I'm still investigating that, but I wanted to surface this bug now.

/cc @lildude - FYI and 👀on the test if you get a chance before I revisit it again next week.
/cc @jatoben - As we'd discussed the problem previously.