### PR TITLE
Make audit log backup process aware of MySQL import

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -10,6 +10,34 @@ set -e
 # shellcheck source=share/github-backup-utils/ghe-backup-config
 . "$( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config"
 
+# Function to back up ES indices
+backup_indices(){
+  if ! indices=$(ghe-ssh "$host" "curl -s \"localhost:9201/_cat/indices/audit_log*?h=index,pri.store.size&bytes=b\""); then
+    echo "Error: failed to retrieve audit log indices." 1>&2
+    exit 1
+  fi
+
+  # Exit if no indices were found
+  [ -z "$indices" ] && exit
+
+  IFS=$'\n'
+  for index in $indices; do
+    IFS=' '
+    set $index
+    index_name=$1
+    index_size=$2
+
+    if [[ -f $GHE_DATA_DIR/current/audit-log/$index_name.gz && $(cat $GHE_DATA_DIR/current/audit-log/$index_name.gz.size 2>/dev/null || true) -eq $index_size ]]; then
+      # Hard link any indices that have not changed since the last backup
+      ln $GHE_DATA_DIR/current/audit-log/$index_name.gz $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz
+      ln $GHE_DATA_DIR/current/audit-log/$index_name.gz.size $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz.size
+    else
+      echo "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:9201/$index_name\" | gzip" | ghe-ssh "$host" -- /bin/bash > $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz
+      echo $index_size > $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz.size
+    fi
+  done
+}
+
 bm_start "$(basename $0)"
 
 # Set up remote host and root elastic backup directory based on config
@@ -21,36 +49,13 @@ ghe_remote_version_required "$host"
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/audit-log"
 
-if ! indices=$(ghe-ssh "$host" "curl -s \"localhost:9201/_cat/indices/audit_log*?h=index,pri.store.size&bytes=b\""); then
-  echo "Error: failed to retrieve audit log indices." 1>&2
-  exit 1
+# If /data/user/common/audit-log-import/complete is present, the migration
+# to MySQL has already happened and the data is already in MySQL and we are done.
+# Otherwise  we need to back up the ES indices instead.
+if  ghe-ssh "$host" test -e "$GHE_REMOTE_DATA_USER_DIR/common/audit-log-import/complete"; then
+  touch "$GHE_SNAPSHOT_DIR/audit-log/mysql-import-complete"
+else
+  backup_indices
 fi
-
-# Exit if no indices were found
-[ -z "$indices" ] && exit
-
-# Determine if the audit log migration has occurred or is needed.
-if echo 'set -o pipefail; ! test -e /data/user/common/es-scan-complete && test -f /usr/local/share/enterprise/run-audit-log-transitions.sh' | ghe-ssh "$host" /bin/bash; then
-  if echo 'set -o pipefail; echo n | /usr/local/share/enterprise/run-audit-log-transitions.sh > /dev/null 2>&1 && touch /data/user/common/es-scan-complete' | ghe-ssh "$host" /bin/bash; then
-    touch $GHE_SNAPSHOT_DIR/es-scan-complete
-  fi
-fi
-
-IFS=$'\n'
-for index in $indices; do
-  IFS=' '
-  set $index
-  index_name=$1
-  index_size=$2
-
-  if [[ -f $GHE_DATA_DIR/current/audit-log/$index_name.gz && $(cat $GHE_DATA_DIR/current/audit-log/$index_name.gz.size 2>/dev/null || true) -eq $index_size ]]; then
-    # Hard link any indices that have not changed since the last backup
-    ln $GHE_DATA_DIR/current/audit-log/$index_name.gz $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz
-    ln $GHE_DATA_DIR/current/audit-log/$index_name.gz.size $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz.size
-  else
-    echo "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:9201/$index_name\" | gzip" | ghe-ssh "$host" -- /bin/bash > $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz
-    echo $index_size > $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz.size
-  fi
-done
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -20,55 +20,74 @@ GHE_HOSTNAME="$1"
 # Perform a host-check and establish GHE_REMOTE_XXX variables.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-indices=$(find $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz -print0 2>/dev/null | xargs -0 -I{} -n1 basename {} .gz)
+restore_indices(){
+  local indices
+  indices=$(find $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/*.gz -print0 2>/dev/null | xargs -0 -I{} -n1 basename {} .gz)
 
-# Platform neutral and robust method of determining last month
-this_yr=$(date +"%Y")
-this_mth=$(date +"%-m")
-last_mth=$(( $this_mth - 1 ))
-last_yr=$this_yr
-if [ "$last_mth" = 0 ]; then
-  last_mth=12
-  last_yr=$(( $this_yr - 1 ))
-fi
-
-last_month=$(printf "audit_log(-[0-9]+)?-%4d-%02d(-[0-9]+)?" $last_yr $last_mth)
-current_month=$(printf "audit_log(-[0-9]+)?-%4d-%02d(-[0-9]+)?" $this_yr $this_mth)
-
-tmp_list="$(mktemp -t backup-utils-restore-XXXXXX)"
-if ghe-ssh "$GHE_HOSTNAME" -- "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/configured' ]"; then
-  configured=true
-fi
-
-# Only restore indices that don't exist and the last two months' indices.
-for index in $indices; do
-  if ! ghe-ssh "$GHE_HOSTNAME" "curl -f -s -XGET http://localhost:9201/$index > /dev/null" || [[ $index =~ $last_month ]] || [[ $index =~ $current_month ]]; then
-    echo "$index.gz" >> $tmp_list
-  fi
-done
-
-if [ -s "$tmp_list" ]; then
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore'" 1>&3
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo chown elasticsearch:elasticsearch '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore'" 1>&3
-
-  ghe-rsync -avz --delete \
-    -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
-    --rsync-path="sudo -u elasticsearch rsync" \
-    --files-from=$tmp_list \
-    "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/" \
-    "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/" 1>&3
-
-  if $CLUSTER || [ -n "$configured" ]; then
-    for index in $(cat $tmp_list | sed 's/\.gz$//g'); do
-      ghe_verbose "* Restoring $index"
-      echo "export PATH=\$PATH:/usr/local/share/enterprise && sudo gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
-      ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
-    done
-
-    ghe-ssh "$GHE_HOSTNAME" -- "sudo sh -c 'rm $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/*.gz'" 1>&3
+  # Platform neutral and robust method of determining last month
+  local this_yr
+  this_yr=$(date +"%Y")
+  local this_mth
+  this_mth=$(date +"%-m")
+  local last_mth
+  last_mth=$(( $this_mth - 1 ))
+  local last_yr
+  last_yr=$this_yr
+  if [ "$last_mth" = 0 ]; then
+    last_mth=12
+    last_yr=$(( $this_yr - 1 ))
   fi
 
-  rm $tmp_list
+  local last_month
+  last_month=$(printf "audit_log(-[0-9]+)?-%4d-%02d(-[0-9]+)?" $last_yr $last_mth)
+  local current_month
+  current_month=$(printf "audit_log(-[0-9]+)?-%4d-%02d(-[0-9]+)?" $this_yr $this_mth)
+
+  local tmp_list
+  tmp_list="$(mktemp -t backup-utils-restore-XXXXXX)"
+  if ghe-ssh "$GHE_HOSTNAME" -- "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/configured' ]"; then
+    configured=true
+  fi
+
+  # Only restore indices that don't exist and the last two months' indices.
+  for index in $indices; do
+    if ! ghe-ssh "$GHE_HOSTNAME" "curl -f -s -XGET http://localhost:9201/$index > /dev/null" || [[ $index =~ $last_month ]] || [[ $index =~ $current_month ]]; then
+      echo "$index.gz" >> $tmp_list
+    fi
+  done
+
+  if [ -s "$tmp_list" ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore'" 1>&3
+    ghe-ssh "$GHE_HOSTNAME" -- "sudo chown elasticsearch:elasticsearch '$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore'" 1>&3
+
+    ghe-rsync -avz --delete \
+      -e "ghe-ssh -p $(ssh_port_part "$GHE_HOSTNAME")" \
+      --rsync-path="sudo -u elasticsearch rsync" \
+      --files-from=$tmp_list \
+      "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/" \
+      "$(ssh_host_part "$GHE_HOSTNAME"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/" 1>&3
+
+    if $CLUSTER || [ -n "$configured" ]; then
+      for index in $(cat $tmp_list | sed 's/\.gz$//g'); do
+        ghe_verbose "* Restoring $index"
+        echo "export PATH=\$PATH:/usr/local/share/enterprise && sudo gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
+        ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
+      done
+
+      ghe-ssh "$GHE_HOSTNAME" -- "sudo sh -c 'rm $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/*.gz'" 1>&3
+    fi
+
+    rm $tmp_list
+  fi
+}
+
+# If $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/mysql-import-complete" is present,
+# the snapshot contains audit log data that is already in MySQL and we are done.
+# Otherwise we need to restore the ES indices instead.
+if test -e "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log/mysql-import-complete"; then
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo touch $GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import/complete" 1>&3
+else
+  restore_indices
 fi
 
 bm_end "$(basename $0)"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -344,3 +344,19 @@ begin_test "ghe-backup missing directories or files on source appliance"
     verify_all_backedup_data
 )
 end_test
+
+begin_test "ghe-backup creates audit log import to MySQL flag in snapshot when present"
+(
+  set -e
+
+  mkdir "$GHE_REMOTE_DATA_USER_DIR/common/audit-log-import"
+  touch "$GHE_REMOTE_DATA_USER_DIR/common/audit-log-import/complete"
+
+  if ! output=$(ghe-backup -v 2>&1); then
+    echo "Error: failed to backup $output" >&2
+    exit 1
+  fi
+
+  test -e "$GHE_DATA_DIR/current/audit-log/mysql-import-complete"
+)
+end_test

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -246,6 +246,33 @@ begin_test "ghe-restore with no pages backup"
 )
 end_test
 
+begin_test "ghe-restore creates audit log import to MySQL flag in file system when present"
+(
+  set -e
+
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+
+  # set as configured, enable maintenance mode and create required directories
+  setup_maintenance_mode "configured"
+
+  touch "$GHE_DATA_DIR/current/audit-log/mysql-import-complete"
+  mkdir "$GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import"
+
+  if ! output=$(ghe-restore -v -f localhost 2>&1); then
+    echo "Error: failed to restore $output" >&2
+    exit 1
+  fi
+
+  flag="$GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import/complete"
+  test -e "$flag" || {
+    echo "Error: the restore process should've created $flag" >&2
+    exit 1
+  }
+)
+end_test
+
+
 begin_test "ghe-restore cluster backup to non-cluster appliance"
 (
   set -e


### PR DESCRIPTION
We need to make `backup utils` aware of the audit log import to MySQL.

The state of the migration, or to be more precise, whether or not the migration is complete is marked by a flag in `/data/user/common/audit-log-import/complete`.

This the proposal to handle this:

- At backup time
  1. If the flag exists, we don't need to do anything else apart from making sure the flag itself makes it to the snapshot
  2. If the flag doesn't exist, we back up the ES indices as usual

- At restore time
  1. If the flag exists in the snapshot, we don't need to do anything else apart from make sure we create the flag in the instance's filesystem
  2. If the flag doesn't exist, we restore the ES indices as usual

Some implementation details:

- I removed the code to check an old transition that is not needed any longer
- I basically wrapped the old method into their respective functions and added logic to call them when the flag is not present.