### PR TITLE
Adding a new option to create a staging instance safely

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -17,6 +17,8 @@
 #/   -v | --verbose    Enable verbose output.
 #/   -h | --help       Show this message.
 #/        --version    Display version information and exit.
+#/        --staging    Use this option to create a staging instance. Restore
+#/                     everything except UUID.
 #/   -s <snapshot-id>  Restore from the snapshot with the given id. Available
 #/                     snapshots may be listed under the data directory.
 #/   <host>            The <host> is the hostname or IP of the GitHub Enterprise
@@ -30,6 +32,7 @@ set -e
 
 # Parse arguments
 restore_settings=false
+restore_staging=false
 force=false
 while true; do
   case "$1" in
@@ -43,6 +46,10 @@ while true; do
       ;;
     -c|--config)
       restore_settings=true
+      shift
+      ;;
+    --staging)
+      restore_staging=true
       shift
       ;;
     -h|--help)
@@ -243,14 +250,14 @@ if ! $CLUSTER; then
   ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
 fi
 
-# Restore UUID if present and not restoring to cluster.
-if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
+# Restore UUID if present and not restoring to cluster and not for a staging instance.
+if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER && ! $restore_staging ; then
   echo "Restoring UUID ..."
   cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
   ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
   ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul" || true
   ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft"
-  fi
+fi
 
 echo "Restoring MySQL database ..."
 ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
@@ -336,7 +343,7 @@ else
 fi
 
 # Clean up all stale replicas on configured instances.
-if ! $CLUSTER && $instance_configured; then
+if ! $CLUSTER && $instance_configured && ! $restore_staging; then
   restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)
   other_nodes=$(echo "
     set -o pipefail; \

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -343,8 +343,12 @@ else
 fi
 
 # Clean up all stale replicas on configured instances.
-if ! $CLUSTER && $instance_configured && ! $restore_staging; then
-  restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)
+if ! $CLUSTER && $instance_configured; then
+  if $restore_staging; then
+    restored_uuid=$(echo "cat /data/user/common/uuid" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash)
+  else
+    restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)
+  fi
   other_nodes=$(echo "
     set -o pipefail; \
     ghe-spokes server show --json \

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -347,7 +347,7 @@ fi
 # Clean up all stale replicas on configured instances.
 if ! $CLUSTER && $instance_configured; then
   if $RESTORE_STAGING; then
-    restored_uuid=$(echo "cat /data/user/common/uuid" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash)
+    restored_uuid=$(echo "cat $GHE_REMOTE_DATA_USER_DIR/common/uuid" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash)
   else
     restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)
   fi

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -32,7 +32,7 @@ set -e
 
 # Parse arguments
 restore_settings=false
-restore_staging=false
+RESTORE_STAGING=false
 force=false
 while true; do
   case "$1" in
@@ -49,7 +49,7 @@ while true; do
       shift
       ;;
     --staging)
-      restore_staging=true
+      RESTORE_STAGING=true
       shift
       ;;
     -h|--help)
@@ -148,6 +148,8 @@ if ghe-ssh "$GHE_HOSTNAME" -- \
   echo "       Please teardown replication before restoring." >&2
   exit 1
 fi
+
+export RESTORE_STAGING
 
 # Prompt to verify the restore host given is correct. Restoring overwrites
 # important data on the destination appliance that cannot be recovered. This is
@@ -251,7 +253,7 @@ if ! $CLUSTER; then
 fi
 
 # Restore UUID if present and not restoring to cluster and not for a staging instance.
-if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER && ! $restore_staging ; then
+if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER && ! $RESTORE_STAGING ; then
   echo "Restoring UUID ..."
   cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
   ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
@@ -344,7 +346,7 @@ fi
 
 # Clean up all stale replicas on configured instances.
 if ! $CLUSTER && $instance_configured; then
-  if $restore_staging; then
+  if $RESTORE_STAGING; then
     restored_uuid=$(echo "cat /data/user/common/uuid" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash)
   else
     restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -39,7 +39,12 @@ ghe-ssh "$GHE_HOSTNAME" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/tmp'" 1>&3
 cat $snapshot_dir/mysql.sql.gz | ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of=$GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz >/dev/null 2>&1"
 
 # Import the database
-echo "gunzip -cd $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz | ghe-import-mysql" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
+extract_cmd="gunzip -cd $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz"
 
+if $restore_staging; then
+    extract_cmd="$extract_cmd | sed -e \"s/$(cat $snapshot_dir/uuid)/\$(cat /data/user/common/uuid)/g\""
+fi
+
+echo "$extract_cmd | ghe-import-mysql" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -42,7 +42,7 @@ cat $snapshot_dir/mysql.sql.gz | ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of=$GHE_REM
 extract_cmd="gunzip -cd $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz"
 
 if $RESTORE_STAGING; then
-    extract_cmd="$extract_cmd | sed -e \"s/$(cat $snapshot_dir/uuid)/\$(cat /data/user/common/uuid)/g\""
+    extract_cmd="$extract_cmd | sed -e \"s/$(cat $snapshot_dir/uuid)/\$(cat $GHE_REMOTE_DATA_USER_DIR/common/uuid)/g\""
 fi
 
 echo "$extract_cmd | ghe-import-mysql" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -41,7 +41,7 @@ cat $snapshot_dir/mysql.sql.gz | ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of=$GHE_REM
 # Import the database
 extract_cmd="gunzip -cd $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz"
 
-if $restore_staging; then
+if $RESTORE_STAGING; then
     extract_cmd="$extract_cmd | sed -e \"s/$(cat $snapshot_dir/uuid)/\$(cat /data/user/common/uuid)/g\""
 fi
 

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -75,13 +75,16 @@ begin_test "ghe-restore honours --staging flag"
   # set as configured, enable maintenance mode and create required directories
   setup_maintenance_mode "configured"
 
-  # set restore staging environ var
+  # set an environ var to skip uuid diff test
   GHE_RESTORE_STG=true
   export GHE_RESTORE_STG
 
   # set restore host environ var
   GHE_RESTORE_HOST=127.0.0.1
   export GHE_RESTORE_HOST
+
+  # when restoring to a fresh instance, uuid should already be on the instance
+  echo "fake-uuid" > $TRASHDIR/remote/data/user/common/uuid
 
   # run ghe-restore and write output to file for asserting against
   if ! GHE_DEBUG=1 ghe-restore -v -f --staging > "$TRASHDIR/restore-out" 2>&1; then

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -66,6 +66,41 @@ begin_test "ghe-restore into configured vm"
 )
 end_test
 
+begin_test "ghe-restore honours --staging flag"
+(
+  set -e
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+
+  # set as configured, enable maintenance mode and create required directories
+  setup_maintenance_mode "configured"
+
+  # set restore staging environ var
+  GHE_RESTORE_STG=true
+  export GHE_RESTORE_STG
+
+  # set restore host environ var
+  GHE_RESTORE_HOST=127.0.0.1
+  export GHE_RESTORE_HOST
+
+  # run ghe-restore and write output to file for asserting against
+  if ! GHE_DEBUG=1 ghe-restore -v -f --staging > "$TRASHDIR/restore-out" 2>&1; then
+      cat "$TRASHDIR/restore-out"
+      : ghe-restore should have exited successfully
+      false
+  fi
+
+  # for debugging
+  cat "$TRASHDIR/restore-out"
+
+  # verify uuid isn't restored
+  ! grep -q "Restoring UUID" "$TRASHDIR/restore-out"
+
+  # Verify all the data we've restored is as expected
+  verify_all_restored_data
+)
+end_test
+
 begin_test "ghe-restore logs the benchmark"
 (
   set -e

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -334,7 +334,9 @@ verify_common_data() {
   # tests that differ for cluster and single node backups and restores
   if [ "$(cat $GHE_DATA_DIR/current/strategy)" = "rsync" ]; then
     # verify the UUID was transferred
-    diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
+    if [ "$GHE_RESTORE_STG" != "true" ]; then
+      diff -ru "$GHE_REMOTE_DATA_USER_DIR/common/uuid" "$GHE_DATA_DIR/current/uuid"
+    fi
 
     # verify the audit log migration sentinel file has been created on 2.9 and above
     if [ "$GHE_VERSION_MAJOR" -eq 2 ] && [ "$GHE_VERSION_MINOR" -ge 9 ]; then


### PR DESCRIPTION
[Setting up a staging instance - GitHub Help](https://help.github.com/en/enterprise/2.16/admin/installation/setting-up-a-staging-instance) says that the recommended way to create a staging instance is to restore the latest backup data to a fresh instance.

However, the `ghe-restore` command restores the */data/user/common/uuid* file and it causes some problems especially when the staging instance is in the same network as the production instance. For example, I saw a case where a staging HA pair failed to restart replication after upgrading to GitHub Enterprise 2.16 series. Turns out it happened because Consul failed to choose the appropriate leader node due to the the duplicate UUIDs in the same network.

With this pull request, I'd like to suggest that we add the `--staging` option to the `ghe-restore` command so that the command restores everything except the uuid file.