### PR TITLE
ghe-host-check -F configfile

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -6,6 +6,7 @@
 #/ OPTIONS:
 #/   -h | --help       Show this message.
 #/        --version    Display version information.
+#/   -F <configfile>   Alternative backup configuration file.
 #/   <host>            The GitHub Enterprise Server host to check. When no
 #/                     <host> is provided, the $GHE_HOSTNAME configured in
 #/                     backup.config is assumed.
@@ -15,6 +16,10 @@ set -e
 
 while true; do
   case "$1" in
+    -F)
+      export GHE_BACKUP_CONFIG="$2"
+      shift 2
+      ;;
     -h|--help)
       export GHE_SHOW_HELP=true
       shift

--- a/test/test-ghe-host-check.sh
+++ b/test/test-ghe-host-check.sh
@@ -26,6 +26,21 @@ begin_test "ghe-host-check with host arg"
 )
 end_test
 
+begin_test "ghe-host-check with configfile arg"
+(
+  set -e
+
+  # Fake backup config for this test
+  configfile=$(mktemp "$TRASHDIR/backup.config.XXXXXX")
+  echo 'GHE_HOSTNAME=example.com' > $configfile
+
+  ghe-host-check -F $configfile
+
+  ghe-host-check -F $configfile | grep OK
+  ghe-host-check -F $configfile | grep example.com
+)
+end_test
+
 begin_test "ghe-host-check honours --version flag"
 (
   set -e


### PR DESCRIPTION
This is meant to check against the hostname of a config file
that was not put into place yet. Works like

    GHE_BACKUP_CONFIG=configfile ghe-host-check

but with a documented -F option.

One use case is validating a newly generated `backup.config` file
before putting it into production (for example, via Puppet).