### PR TITLE
Fix audit log import to MySQL flag removal for old snapshots and skip rsync'ed indices

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-rsync
+++ b/share/github-backup-utils/ghe-backup-es-rsync
@@ -35,7 +35,7 @@ echo elasticsearch.yml >"$exclude_file"
 # as those indices will be rebuilt from MySQL during a restore
 if [ "$GHE_BACKUP_ES_AUDIT_LOGS" = "no" ] && ghe-ssh "$host" test -e "/data/user/common/audit-log-import/complete"; then
   ghe_verbose "* Excluding Audit Log indices"
-  ghe-ssh "$host" curl -s 'localhost:9201/_cat/indices/audit_log?h=uuid' >>$exclude_file 2>&3
+  ghe-ssh "$host" curl -s 'http://localhost:9201/_cat/indices/audit_log?h=uuid' >>$exclude_file 2>&3
 fi
 
 # Verify that the /data/elasticsearch directory exists.

--- a/share/github-backup-utils/ghe-backup-es-rsync
+++ b/share/github-backup-utils/ghe-backup-es-rsync
@@ -27,6 +27,17 @@ fi
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$GHE_SNAPSHOT_DIR/elasticsearch"
 
+# Create exclude file
+exclude_file="$(mktemp)"
+echo elasticsearch.yml >"$exclude_file"
+
+# Exclude audit log indices when configuration says so and import to MySQL is complete
+# as those indices will be rebuilt from MySQL during a restore
+if [ "$GHE_BACKUP_ES_AUDIT_LOGS" = "no" ] && ghe-ssh "$host" test -e "/data/user/common/audit-log-import/complete"; then
+  ghe_verbose "* Excluding Audit Log indices"
+  ghe-ssh "$host" curl -s 'localhost:9201/_cat/indices/audit_log?h=uuid' >>$exclude_file 2>&3
+fi
+
 # Verify that the /data/elasticsearch directory exists.
 if ! ghe-ssh "$host" -- "[ -d '$GHE_REMOTE_DATA_USER_DIR/elasticsearch' ]"; then
   ghe_verbose "* The '$GHE_REMOTE_DATA_USER_DIR/elasticsearch' directory doesn't exist."
@@ -47,15 +58,16 @@ ghe-rsync -avz \
   -e "ghe-ssh -p $(ssh_port_part "$host")" \
   --rsync-path="sudo -u elasticsearch rsync" \
   $link_dest \
-  --exclude='elasticsearch.yml' \
+  --exclude-from="$exclude_file" \
   "$(ssh_host_part "$host"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch/" \
   "$GHE_SNAPSHOT_DIR/elasticsearch" 1>&3
 
-# Set up a trap to re-enable flushing on exit
+# Set up a trap to re-enable flushing on exit and remove temp file
 cleanup () {
   ghe_verbose "* Enabling ES index flushing ..."
   echo '{"index":{"translog.disable_flush":false}}' |
   ghe-ssh "$host" -- curl -s -XPUT "localhost:9200/_settings" -d @- >/dev/null
+  ghe-ssh "$host" rm -rf "$exclude_file"
 }
 trap 'cleanup' EXIT
 trap 'exit $?' INT # ^C always terminate
@@ -72,7 +84,7 @@ ghe-rsync -avz \
   -e "ghe-ssh -p $(ssh_port_part "$host")" \
   --rsync-path="sudo -u elasticsearch rsync" \
   $link_dest \
-  --exclude='elasticsearch.yml' \
+  --exclude-from="$exclude_file" \
   "$(ssh_host_part "$host"):$GHE_REMOTE_DATA_USER_DIR/elasticsearch/" \
   "$GHE_SNAPSHOT_DIR/elasticsearch" 1>&3
 

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -35,8 +35,14 @@ mysql_restored_enabled(){
 }
 
 remove_complete_flag(){
-  ghe_verbose "Setting instance as pending for audit log import to MySQL"
+  ghe_verbose "Setting instance(s) as pending for audit log import to MySQL"
   ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf $GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import/complete" 1>&3 2>&3
+
+  if $CLUSTER; then
+    if ! ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- sudo rm -rf /data/user/common/audit-log-import/complete" 1>&3 2>&3; then
+      ghe_verbose "Failed to set as pending for audit log import to MySQL all instances in cluster"
+    fi
+  fi
 }
 
 # Use `ghe-backup-mysql-audit-log` to dump the audit entries.

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -85,6 +85,11 @@ should_start_reindex(){
     ghe_verbose "ghe-auditlog-repiar doesn't exist"
     return 1
   fi
+
+  if ! $CLUSTER; then
+    ghe_verbose "skipping ghe-auditlog-repair as remote instance is not a clustering setup"
+    return 1
+  fi
 }
 
 do_restore(){

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -85,11 +85,6 @@ should_start_reindex(){
     ghe_verbose "ghe-auditlog-repiar doesn't exist"
     return 1
   fi
-
-  if ! $CLUSTER; then
-    ghe_verbose "skipping ghe-auditlog-repair as remote instance is not a clustering setup"
-    return 1
-  fi
 }
 
 do_restore(){

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -34,6 +34,11 @@ mysql_restored_enabled(){
   test -e "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/audit-log-mysql"
 }
 
+remove_complete_flag(){
+  ghe_verbose "Setting instance as pending for audit log import to MySQL"
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf $GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import/complete" 1>&3 2>&3
+}
+
 # Use `ghe-backup-mysql-audit-log` to dump the audit entries.
 # If the import to MySQL is complete, add a flag in the snapshot to indicate so.
 restore_mysql(){
@@ -42,8 +47,7 @@ restore_mysql(){
   "${base_path}/ghe-restore-mysql-audit-log" "$GHE_HOSTNAME"
 
   if ! is_import_complete; then
-    ghe_verbose "Audit log import to MySQL is not complete"
-    ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf $GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import/complete" 1>&3 2>&3
+    remove_complete_flag
     return
   fi
 
@@ -88,6 +92,7 @@ do_restore(){
     restore_mysql
   else
     ghe_verbose "MySQL audit log restore is not enabled"
+    remove_complete_flag
   fi
 
   if es_restore_enabled; then

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -246,6 +246,32 @@ begin_test "ghe-restore with no pages backup"
 )
 end_test
 
+begin_test "ghe-restore removes audit log import to MySQL flag when is a < 2.17 snapshot"
+(
+  set -e
+
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+
+  # set as configured, enable maintenance mode and create required directories
+  setup_maintenance_mode "configured"
+
+  flag="$GHE_REMOTE_ROOT_DIR/data/user/common/audit-log-import/complete"
+  mkdir -p "$(dirname $flag)"
+  touch "$flag"
+
+  if ! output=$(ghe-restore -v -f localhost 2>&1); then
+    echo "Error: failed to restore $output" >&2
+    exit 1
+  fi
+
+  ! test -e "$flag" || {
+    echo "Error: the restore process should've removed $flag" >&2
+    exit 1
+  }
+)
+end_test
+
 begin_test "ghe-restore cluster backup to non-cluster appliance"
 (
   set -e


### PR DESCRIPTION
This PR solves two issues that could potentially cause data loss in the upcoming 2.17 version.

## Fix audit log import flag

### Problem
If an old snapshot (<2.17) is restored in a 2.17 instance where the audit import to MySQL is marked as complete in `/data/user/common/audit-log-import/complete`, the restored instance wrongly keeps the flag that indicates the import is complete.

This could cause a data loss because under certain circumstances a new backup would assume that data is migrated to MySQL when it's not.

### Solution
The solution is simple: if a restored snapshot doesn't contain an `audit-log-mysql` directory, it means it's an old snapshot. In that case, we remove the flag on the instance where the restore is happening.

### Skip rsync'ed audit log indices when GHE_BACKUP_ES_AUDIT_LOGS=no

### Problem
Audit log indices can be backed up from:

- MySQL
- Elasticsearch through JSON dumps
- Elasticsearch through rsync

When `GHE_BACKUP_ES_AUDIT_LOGS=no` only MySQL should be used.

JSON dumps are correctly skipped, however all the indices including the audit log ones are rsynced in a subsequent step.

### Solution
When `GHE_BACKUP_ES_AUDIT_LOGS=no` and the import is complete, we configure the rsync step to ignore all the audit log indices.

To do so, we build a file that contains the  `UUIDs` of the audit log indices. Note this is what is used in disk and not the actual index name.

The UUIDs are fetched through a simple:

```
curl -s http://localhost:9201/_cat/indices/audit_log?h=uuid
```

The file containing this list  is passed as a`--exclude-from` rsync parameter that contains one directory/pattern to exclude per line.