### PR TITLE
add option to generate a persistent rsync log

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -28,6 +28,12 @@ GHE_NUM_SNAPSHOTS=10
 #
 #GHE_VERBOSE_LOG="/var/log/backup-verbose.log"
 
+# If set to 'yes', a file `rsync.log` containing all rsync file operations
+# is stored in the snapshot along with the backup data. This log file can
+# be used to analyze the changes between snapshots.
+#
+#GHE_RSYNC_LOG=yes
+
 # Any extra options passed to the SSH command.
 # In a single instance environment, nothing is required by default.
 # In a clustering environment, "-i abs-path-to-ssh-private-key" is required.

--- a/share/github-backup-utils/ghe-rsync
+++ b/share/github-backup-utils/ghe-rsync
@@ -25,6 +25,12 @@ else
   done
 fi
 
+# If rsync logging is enabled and the rsync version supports the log file flag
+# (since v2.6.9), then generate logs with the format "<Operation>:<filename>"
+if [ "$GHE_RSYNC_LOG" = "yes" ] && rsync -h | grep '\-\-log-file-format' >/dev/null 2>&1; then
+  GHE_EXTRA_RSYNC_OPTS="$GHE_EXTRA_RSYNC_OPTS --log-file=$GHE_SNAPSHOT_DIR/rsync.log --log-file-format='%o:%f'"
+fi
+
 (rsync "${parameters[@]}" $GHE_EXTRA_RSYNC_OPTS 3>&1 1>&2 2>&3 3>&- |
   (egrep -v "$ignoreout" || true)) 3>&1 1>&2 2>&3 3>&- |
   (egrep -v "$ignoreout" || true)


### PR DESCRIPTION
Generate a log file with all rsync operations during a ghe-backup run.
This allows users to scan changed content between two consecutive
backup runs.