### PR TITLE
Redirect ghe-export-audit-logs stderr output when using verbose output

### DIFF
--- a/share/github-backup-utils/ghe-backup-mysql-audit-log
+++ b/share/github-backup-utils/ghe-backup-mysql-audit-log
@@ -41,7 +41,7 @@ setup(){
 # months in MySQL. For each month: number of entries, minum ID, maximum ID
 fetch_current_meta(){
   local meta
-  if ! meta=$(ghe-ssh "$host" "sudo ghe-export-audit-logs months" | grep -v NULL 2>&3); then
+  if ! meta=$(ghe-ssh "$host" "sudo ghe-export-audit-logs months" 2>&3 | grep -v NULL 2>&3); then
     ghe_verbose "Error: failed to retrieve audit log metadata"
     exit 1
   fi


### PR DESCRIPTION
As described in #496, the execution of `ghe-export-audit-logs` is missing a `stderr` redirect to `&3` which is the file descriptor we use to redirect debug output to.

Without this fix, users running the script will see debug output in stderr even when `-v` is not used.

fixes #496