### PR TITLE
check dependency versions and warn if they are outdated

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -41,6 +41,14 @@ done
 # shellcheck source=share/github-backup-utils/ghe-backup-config
 . "$( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config"
 
+# Recommend recent versions of the dependencies
+# Please keep these versions in sync with the docs!
+# https://github.com/github/backup-utils/blob/master/docs/requirements.md#backup-host-requirements
+check_version bash  --version 4.4.12
+check_version git   --version 2.11.0
+check_version rsync --version 3.1.2
+check_version ssh   -V        7.4
+
 # Used to record failed backup steps
 failures=
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -6,7 +6,7 @@ storage and must have network connectivity with the GitHub Enterprise Server app
 ## Backup host requirements
 
 Backup host software requirements are modest: Linux or other modern Unix operating
-system with [bash][1], [git][2], [OpenSSH][3] 5.6 or newer, and [rsync][4] v2.6.4 or newer.
+system with [bash][1], [git][2], [OpenSSH][3] 7.4 or newer, and [rsync][4] v3.1.2 or newer.
 
 We encourage the use of [Docker](docker.md) if your backup host doesn't meet these
 requirements, or if Docker is your preferred platform.

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -215,6 +215,22 @@ if ! type readlink 1>/dev/null 2>&1; then
   }
 fi
 
+# Check the version of a given command and print a warning if the minimum
+# recommended version is not met.
+check_version () {
+  local cmd=$1
+  local cmd_version_option=$2
+  local min_version=$3
+  if ! $cmd $cmd_version_option 2>&1 | perl -pse '
+    use version;
+    my @v = $_ =~ /([0-9]+([.][0-9]+)+)/;
+    exit (version->parse(@v[0]) lt version->parse($min));
+    ' -- -min=$min_version >/dev/null 2>&1; then
+      echo "Warning: outdated $cmd version detected,"\
+           "GitHub recommends to upgrade to $min_version or higher"
+  fi
+}
+
 # Run ghe-host-check and establish the version of the remote GitHub instance in
 # the exported GHE_REMOTE_VERSION variable. If the remote version has already
 # been established then don't perform the host check again. Utilities in share/github-backup-utils


### PR DESCRIPTION
I picked the checked versions somewhat arbitrarily based on the versions
shipped with Debian 9 (Stretch). The intention is to encourage users to
update. If these versions are not met, then everything works as before
as we only print a warning if the versions are not met.

Please note: This commit introduces Perl as dependency. However, this
should not be a problem as Git depends on Perl as well. Since Git is
required by backup-utils, we can assume that Perl is installed on the
backup host.