### PR TITLE
Add build dependency rsync

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Twan Wolthof <xeago@spotify.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), git, devscripts, moreutils, jq
+Build-Depends: debhelper (>= 9), git, devscripts, moreutils, jq, rsync (>= 2.6.4)
 
 Package: github-backup-utils
 Architecture: any


### PR DESCRIPTION
This is to address tests failure:

```
test: ghe-backup first snapshot ... ...                                         FAILED (0s)
    ++ date +%s
    + before_time=1560955867
    + set -e
    + '[' '!' -d /<<PKGBUILDDIR>>/test/tmp/test-ghe-backup.sh-10011/data/current ']'
    + ghe-backup -v
    Error: rsync encountered an error that could indicate a problem with permissions,
    hard links, symbolic links, or another issue that may affect backups.
    /<<PKGBUILDDIR>>/bin/ghe-backup: line 70: rsync: command not found
    test failed. last command exited with 1
    ++ date +%s
    + after_time=1560955867
    + elapsed_time=0
```