### PR TITLE
Replace "sed -E" in ghe-host-check with a more portable solution

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -84,7 +84,7 @@ if [ $rc -ne 0 ]; then
   exit $rc
 fi
 
-version=$(echo "$output" | head -1 | awk '{print $NF}')
+version=$(echo "$output" | grep "GitHub Enterprise" | awk '{print $NF}')
 
 if [ -z "$version" ]; then
   echo "Error: failed to parse version on '$host' or this isn't a GitHub appliance." 1>&2

--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -84,7 +84,7 @@ if [ $rc -ne 0 ]; then
   exit $rc
 fi
 
-version=$(echo "$output" | sed -E -n 's/GitHub Enterprise( Server)? version (.*)/\2/p')
+version=$(echo "$output" | head -1 | awk '{print $NF}')
 
 if [ -z "$version" ]; then
   echo "Error: failed to parse version on '$host' or this isn't a GitHub appliance." 1>&2


### PR DESCRIPTION
On older backup hosts, `sed` doesn't include the `-E` option which results in a `ghe-host-check` failure. While replacing `sed` with a newer option would be ideal, it's not always achievable in a short timeframe.

The proposed solution requires the version string to be at the end of the first string returned—is that a valid long term assumption? It will cope with any future product name changes more gracefully however, which is what `sed -E` was added to accomodate.