### PR TITLE
make GHE_HOSTNAME available to ghe-backup-config

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -81,12 +81,12 @@ cleanup () {
   ghe-ssh --clean
 }
 
+# Grab the host arg
+export GHE_HOSTNAME="${GHE_RESTORE_HOST_OPT:-$GHE_RESTORE_HOST}"
+
 # Bring in the backup configuration
 # shellcheck source=share/github-backup-utils/ghe-backup-config
 . "$( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config"
-
-# Grab the host arg
-GHE_HOSTNAME="${GHE_RESTORE_HOST_OPT:-$GHE_RESTORE_HOST}"
 
 # Hostname without any port suffix
 hostname=$(echo "$GHE_HOSTNAME" | cut -f 1 -d :)

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -82,7 +82,7 @@ cleanup () {
 }
 
 # Grab the host arg
-export GHE_HOSTNAME="${GHE_RESTORE_HOST_OPT:-$GHE_RESTORE_HOST}"
+GHE_HOSTNAME="${GHE_RESTORE_HOST_OPT:-$GHE_RESTORE_HOST}"
 
 # Bring in the backup configuration
 # shellcheck source=share/github-backup-utils/ghe-backup-config


### PR DESCRIPTION
Not sure if I'm missing something here. I'm working on much needed maintenance and upgrading for our enterprise server and was testing restoring from a snapshot. 

In my use case, we don't store a restore host in the backup config, which seems to be a legitimate scenario. Thus, GHE_HOSTNAME in ghe-backup-config will only be taken from GHE_HOSTNAME_PRESERVE.
How is ghe-backup-config supposed to get GHE_HOSTNAME if it's not inherited from the parent shell?
appreciate any input here.
