### PR TITLE
Remove temporary exclude file from the backup host not the target GHES appliance

### DIFF
--- a/share/github-backup-utils/ghe-backup-es-rsync
+++ b/share/github-backup-utils/ghe-backup-es-rsync
@@ -67,7 +67,7 @@ cleanup () {
   ghe_verbose "* Enabling ES index flushing ..."
   echo '{"index":{"translog.disable_flush":false}}' |
   ghe-ssh "$host" -- curl -s -XPUT "localhost:9200/_settings" -d @- >/dev/null
-  ghe-ssh "$host" rm -rf "$exclude_file"
+  rm -rf "$exclude_file"
 }
 trap 'cleanup' EXIT
 trap 'exit $?' INT # ^C always terminate


### PR DESCRIPTION
A temporary exclusion file is created on the backup host during the rsync of ES indexes in order to prevent audit logs from being unnecessarily transferred. 

During the post-script cleanup we mistakenly attempt to remove the temporary file from the target GHES server rather than the backup host. The result is that the backup host accumulates stale exclusion files over time.

The one line change here removes the `ghe-ssh` call from the front of the `rm` so the temporary file is removed as intended.