### PR TITLE
Check whether the MySQL audit logger is enabled

### DIFF
--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -42,7 +42,8 @@ mysql_table_schema_available(){
 # Check whether the remote host is running a version where the MySQL backend
 # is supported, i.e: < 2.19
 is_mysql_supported(){
-   [ "$(version "$GHE_REMOTE_VERSION")" -lt "$(version 2.19.0)" ]
+  ghe-ssh sudo grep -q "ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED='1'" \
+    /data/github/current/.app-config/env.d/99-instance.sh
 }
 
 # Helper function to set remote flags in `/data/user/common/audit-log-import`

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -42,7 +42,8 @@ mysql_table_schema_available(){
 # Check whether the remote host is running a version where the MySQL backend
 # is supported, i.e: < 2.19
 is_mysql_supported(){
-  ghe-ssh "$GHE_HOSTNAME" "sudo grep \"ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED='1'\" /data/github/current/.app-config/env.d/99-instance.sh"
+  echo 'sudo bash -c ". /data/github/current/.app-config/env.d/99-instance.sh;' \
+     'test \"\$ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED\" = \"1\""' | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
 }
 
 # Helper function to set remote flags in `/data/user/common/audit-log-import`

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -42,7 +42,7 @@ mysql_table_schema_available(){
 # Check whether the remote host is running a version where the MySQL backend
 # is supported, i.e: < 2.19
 is_mysql_supported(){
-  ghe-ssh sudo grep -q "ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED='1'" \
+  ghe-ssh "$GHE_HOSTNAME" sudo grep -q "ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED='1'" \
     /data/github/current/.app-config/env.d/99-instance.sh
 }
 

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -42,8 +42,7 @@ mysql_table_schema_available(){
 # Check whether the remote host is running a version where the MySQL backend
 # is supported, i.e: < 2.19
 is_mysql_supported(){
-  ghe-ssh "$GHE_HOSTNAME" sudo grep -q "ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED='1'" \
-    /data/github/current/.app-config/env.d/99-instance.sh
+  ghe-ssh "$GHE_HOSTNAME" "sudo grep \"ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED='1'\" /data/github/current/.app-config/env.d/99-instance.sh"
 }
 
 # Helper function to set remote flags in `/data/user/common/audit-log-import`


### PR DESCRIPTION
Check whether or not the MySQL audit logger is enabled to decide when the  MySQL audit logs should be backed up.

We are planning to backport the changes that roll back the MySQL-based audit log. This PR is necessary to detect whether or not a specific GHES version is using the MySQL audit logger.

The new code checks the runtime configuration to verify the logger is enabled instead of checking specific GHES versions. 