### PR TITLE
Update Debian package depends to include git

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), git, devscripts, moreutils, jq, rsync (>= 2.6.4
 
 Package: github-backup-utils
 Architecture: any
-Depends: ${misc:Depends}, rsync (>= 2.6.4), moreutils, jq
+Depends: ${misc:Depends}, rsync (>= 2.6.4), moreutils, jq, git
 Description: Backup and recovery utilities for GitHub Enterprise Server
  The backup utilities implement a number of advanced capabilities for backup
  hosts, built on top of the backup and restore features already included in


### PR DESCRIPTION
Closes #479

Ensures that the host [package requirements](https://github.com/github/backup-utils/blob/master/docs/requirements.md#backup-host-requirements) are met when the .dpkg is used.