### PR TITLE
Skip backup and retore audit_entries indiviually if binary backup is available

### DIFF
--- a/share/github-backup-utils/ghe-backup-audit-log
+++ b/share/github-backup-utils/ghe-backup-audit-log
@@ -35,7 +35,7 @@ is_binary_backup(){
 
 backup_mysql(){
   if is_binary_backup; then
-    ghe-verbose "Skip backup audit_entries for Mysql since it is using binary backup"
+    ghe_verbose "Skip backup audit_entries for Mysql since it is using binary backup"
     return
   fi
   if is_skip_truncate_enabled; then

--- a/share/github-backup-utils/ghe-backup-audit-log
+++ b/share/github-backup-utils/ghe-backup-audit-log
@@ -29,7 +29,15 @@ is_skip_truncate_enabled(){
   ghe-ssh "$host" test -e "$GHE_REMOTE_DATA_USER_DIR/common/audit-log-import/skip_truncate"
 }
 
+is_binary_backup(){
+  ghe-ssh "$host" ghe-config --true "mysql.backup.binary"
+}
+
 backup_mysql(){
+  if is_binary_backup; then
+    ghe-verbose "Skip backup audit_entries for Mysql since it is using binary backup"
+    return
+  fi
   if is_skip_truncate_enabled; then
     # As skip_truncate exists, we need to also backup the audit entries
     # in MySQL because Elasticsearch may not be fully synced.

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -47,7 +47,7 @@ is_mysql_supported(){
 }
 
 is_binary_backup(){
-  ghe-ssh "$host" ghe-config --true "mysql.backup.binary"
+  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
 }
 
 # Helper function to set remote flags in `/data/user/common/audit-log-import`

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -46,6 +46,10 @@ is_mysql_supported(){
      'test \"\$ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED\" = \"1\""' | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
 }
 
+is_binary_backup(){
+  ghe-ssh "$host" ghe-config --true "mysql.backup.binary"
+}
+
 # Helper function to set remote flags in `/data/user/common/audit-log-import`
 # if it's supported, i.e: directory exists.
 set_remote_flag(){
@@ -107,7 +111,17 @@ do_restore(){
     ghe_verbose "Elasticsearch data is available"
 
     restore_es
-    restore_mysql --only-schema
+
+    if is_binary_backup; then
+      ghe_verbose "Table audit_entries is already restored by binary backup"
+    else
+      restore_mysql --only-schema
+    fi
+    return
+  fi
+
+  if is_binary_backup; then
+    ghe_verbose "Table audit_entries is already restored by binary backup"
     return
   fi
 


### PR DESCRIPTION
As state in https://github.com/github/ghes-infrastructure/issues/113, we can skip the backup / restore for audit_entries if we have binary backup. (Binary backup will restore the table completely anyway as a full backup restore) 

cc @shlomi-noach 