### PR TITLE
Backport 534 for 2.19: Make sure the absence of audit_entries table is not fatal

### DIFF
--- a/share/github-backup-utils/ghe-backup-audit-log
+++ b/share/github-backup-utils/ghe-backup-audit-log
@@ -29,6 +29,11 @@ is_skip_truncate_enabled(){
   ghe-ssh "$host" test -e "$GHE_REMOTE_DATA_USER_DIR/common/audit-log-import/skip_truncate"
 }
 
+# Check whether the audit_entries table is deleted
+audit_entries_deleted(){
+   [ -z "$(ghe-ssh "$host" -- "/usr/local/share/enterprise/github-mysql 'SHOW TABLES LIKE \"audit_entries\"'")" ]
+}
+
 is_binary_backup(){
   ghe-ssh "$host" ghe-config --true "mysql.backup.binary"
 }
@@ -38,7 +43,10 @@ backup_mysql(){
     ghe_verbose "Skip backup audit_entries for Mysql since it is using binary backup"
     return
   fi
-  if is_skip_truncate_enabled; then
+
+  if audit_entries_deleted; then
+    ghe_verbose "audit_entries table does not exist"
+  elif is_skip_truncate_enabled; then
     # As skip_truncate exists, we need to also backup the audit entries
     # in MySQL because Elasticsearch may not be fully synced.
     "${base_path}/ghe-backup-mysql-audit-log"

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -90,6 +90,11 @@ restore_mysql(){
 
   ghe_verbose "Restoring MySQL audit logs ..."
 
+  if ! mysql_table_schema_available; then
+    ghe_verbose "schema.gz does not exist"
+    return
+  fi
+
   "${base_path}/ghe-restore-mysql-audit-log" "$GHE_HOSTNAME" "$only_schema"
 }
 


### PR DESCRIPTION
This PR backports #534 to stable (2.19).

In order to avoid issues with the absence of the `audit_entries` table in certain scenarios:

1. Do not try to backup the table if it doesn't exist
2. Do not try to restore the schema if the snapshot doesn't contain one