### PR TITLE
Use sentinel file to identify type of mysql backup

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -174,10 +174,18 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-ssh-host-keys' > ssh-host-keys.tar ||
 failures="$failures ssh-host-keys"
 bm_end "ghe-export-ssh-host-keys"
 
+# if we are going to take a binary backup
+is_binary_backup(){
+  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
+}
+
 echo "Backing up MySQL database ..."
 bm_start "ghe-export-mysql"
 echo 'set -o pipefail; ghe-export-mysql | gzip' |
 ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz || failures="$failures mysql"
+if is_binary_backup; then
+  touch mysql-binary-backup-sentinel
+fi
 bm_end "ghe-export-mysql"
 
 echo "Backing up Redis database ..."

--- a/share/github-backup-utils/ghe-restore-audit-log
+++ b/share/github-backup-utils/ghe-restore-audit-log
@@ -46,8 +46,9 @@ is_mysql_supported(){
      'test \"\$ENTERPRISE_AUDIT_LOG_MYSQL_LOGGER_ENABLED\" = \"1\""' | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
 }
 
+# Check if the backup is binary by looking up the sentinel file 
 is_binary_backup(){
-  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
+  test -f "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"/mysql-binary-backup-sentinel 
 }
 
 # Helper function to set remote flags in `/data/user/common/audit-log-import`

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -43,14 +43,22 @@ is_binary_backup_feature_on(){
   ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
 }
 
-if is_binary_backup; then
-  if ! is_binary_backup_feature_on; then
+if is_binary_backup_feature_on; then
+  # Feature "mysql.backup.binary" is on, which means new backup scripts are available
+  if is_binary_backup; then
+    IMPORT_MYSQL=ghe-import-mysql-xtrabackup
+  else
+    IMPORT_MYSQL=ghe-import-mysql-mysqldump
+  fi
+else
+  # We do not allow to restore binary backup without "mysql.backup.binary" set 
+  if is_binary_backup; then
     echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2  
     exit 2
+  else
+    # legacy mode
+    IMPORT_MYSQL=ghe-import-mysql
   fi
-  IMPORT_MYSQL=ghe-import-mysql-xtrabackup
-else
-  IMPORT_MYSQL=ghe-import-mysql-mysqldump
 fi
 
 ghe-ssh "$GHE_HOSTNAME" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/tmp'" 1>&3

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -33,13 +33,32 @@ cleanup() {
 }
 trap 'cleanup' INT TERM EXIT
 
+# Check if the backup is binary by looking up the sentinel file 
+is_binary_backup(){
+  test -f $snapshot_dir/mysql-binary-backup-sentinel 
+}
+
+# if mysql.backup.binary feature flag is on
+is_binary_backup_feature_on(){
+  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
+}
+
+if is_binary_backup; then
+  if ! is_binary_backup_feature_on; then
+    echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2  
+    exit 2
+  fi
+  IMPORT_MYSQL=ghe-import-mysql-xtrabackup
+else
+  IMPORT_MYSQL=ghe-import-mysql-mysqldump
+fi
+
 ghe-ssh "$GHE_HOSTNAME" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/tmp'" 1>&3
 
 # Transfer MySQL data from the snapshot to the GitHub instance.
 cat $snapshot_dir/mysql.sql.gz | ghe-ssh "$GHE_HOSTNAME" -- "sudo dd of=$GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz >/dev/null 2>&1"
 
 # Import the database
-echo "gunzip -cd $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz | ghe-import-mysql" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
-
+echo "gunzip -cd $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz | $IMPORT_MYSQL" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
 
 bm_end "$(basename $0)"

--- a/test/bin/ghe-import-mysql-mysqldump
+++ b/test/bin/ghe-import-mysql-mysqldump
@@ -1,0 +1,1 @@
+ghe-fake-import-command

--- a/test/bin/ghe-import-mysql-xtrabackup
+++ b/test/bin/ghe-import-mysql-xtrabackup
@@ -1,0 +1,1 @@
+ghe-fake-import-command


### PR DESCRIPTION
For customer, we like them to be able to restore old logical backup without much effort to reset the `mysql.backup.binary` feature flag. This means following assumptions for backup-util

1. Feature flag `mysql.backup.binary` decides if a new backup taken is a binary backup or logical backup, it doesn't affect logic how we restore backup
2. Restore logic is decided by existence of sentinel file `mysql-binary-backup-sentinel` under snapshot dir. We always assume when customer restore backup using `ghe-restore`, the backup is taken by `ghe-backup`, no matter it is binary or logical backup (depending on `mysql.backup.binary`)
3. `ghe-import-mysql` still uses `mysql.backup.binary` feature flag to decide if it will restore backup as logical or binary. For example, even we restore from a logical backup, the replication configuration will restore from a binary backup from primary if `mysql.backup.binary` is set.
4. We will fail the restore if `ghe-import-mysql` is not set and we try to restore from a binary backup.
5. If `mysql.backup.binary` is not set, we still call `ghe-import-mysql` for the reason of back-compat (older version of GHES does not have new script). Also new version `ghe-import-mysql` will use logical restore script if `mysql.backup.binary` not set.

Tests
- [x] Restore from binary backup with `mysql.backup.binary=true`
- [x] Restore from logical backup with `mysql.backup.binary=false`
- [x] Restore from logical backup with `mysql.backup.binary=true`
- [x] Restore from binary backup with  `mysql.backup.binary=true` --> this suppose to fail

TODO
- [ ] Update current binary backups on test storage (AWS S3) with sentinel file after this change merges

/cc @sbryant @shlomi-noach @github/ghes-infrastructure  
