### PR TITLE
Fix `ghe-backup-repositories` performance for large instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
         - brew install moreutils
         - brew install shellcheck
         - brew install jq
+        - brew install coreutils
       script: make test
     - os: linux
       dist: trusty
@@ -24,4 +25,5 @@ matrix:
             - moreutils
             - fakeroot
             - jq
+            - coreutils
       script: debuild -uc -us

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -306,21 +306,23 @@ version() {
 }
 
 fix_paths_for_ghe_version() {
-  local version_GHE_REMOTE_VERSION=$(version $GHE_REMOTE_VERSION)
-  local version_2_16_23=$(version 2.16.23)
-  local version_2_17_14=$(version 2.17.14)
-  local version_2_18_8=$(version 2.18.8)
-  local vesrion_2_19_3=$(version 2.19.3)
-  
-  while read -r line; do
-    if [[ "$GHE_REMOTE_VERSION" =~ 2.16. && "$version_GHE_REMOTE_VERSION" -ge "$version_2_16_23" ]] || \
-       [[ "$GHE_REMOTE_VERSION" =~ 2.17. && "$version_GHE_REMOTE_VERSION" -ge "$version_2_17_14" ]] || \
-       [[ "$GHE_REMOTE_VERSION" =~ 2.18. && "$version_GHE_REMOTE_VERSION" -ge "$version_2_18_8" ]] || \
-       [[ "$GHE_REMOTE_VERSION" =~ 2.19. && "$version_GHE_REMOTE_VERSION" -ge "$vesrion_2_19_3" ]] && \
-       [[ "$line" =~ gist ]]; then
-      echo "$line"
-    else
-      dirname "$line"
-    fi
-  done
+  ruby -e '
+    ghe_remote_version = ARGV.first
+    version_array = ghe_remote_version.split(".").map(&:to_i)
+    fail unless version_array.first >= 2
+    is_modern = version_array[0] > 2 ||
+      (version_array[0] == 2 && version_array[1] > 19) ||
+      (version_array[0] == 2 && version_array[1] == 19 && version_array[2] >= 3) ||
+      (version_array[0] == 2 && version_array[1] == 18 && version_array[2] >= 8) ||
+      (version_array[0] == 2 && version_array[1] == 17 && version_array[2] >= 14) ||
+      (version_array[0] == 2 && version_array[1] == 16 && version_array[2] >= 23)
+
+    $stdin.each_line do |line|
+      if is_modern && line =~ /gist/
+        puts line
+      else
+        puts File.dirname(line)
+      end
+    end
+  ' $(version $GHE_REMOTE_VERSION)
 }

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -324,5 +324,5 @@ fix_paths_for_ghe_version() {
         puts File.dirname(line)
       end
     end
-  ' $(version $GHE_REMOTE_VERSION)
+  ' "$GHE_REMOTE_VERSION"
 }

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -309,7 +309,8 @@ version() {
 # 2.18.8, and 2.19.3.  So we need to account for this difference here.
 fix_paths_for_ghe_version() {
   ruby -e '
-    ghe_remote_version = ARGV.first[1..-1] # removing "v" literal from version string
+    version = ARGV.first
+    ghe_remote_version = version[0] == "v" ? version[1..-1] : version # removing "v" literal from version string
     version_array = ghe_remote_version.split(".").map(&:to_i)
     fail unless version_array.first >= 2
     is_modern = version_array[0] > 2 ||

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -309,7 +309,7 @@ version() {
 # 2.18.8, and 2.19.3.  So we need to account for this difference here.
 fix_paths_for_ghe_version() {
   ruby -e '
-    ghe_remote_version = ARGV.first
+    ghe_remote_version = ARGV.first[1..-1] # removing "v" literal from version string
     version_array = ghe_remote_version.split(".").map(&:to_i)
     fail unless version_array.first >= 2
     is_modern = version_array[0] > 2 ||

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -306,26 +306,27 @@ version() {
 }
 
 # The list of gists returned by the source changed in 2.16.23, 2.17.14,
-# 2.18.8, and 2.19.3.  So we need to account for this difference here.
+# 2.18.8, and 2.19.3.  We need to account for this difference here.
+# In older versions, all paths need to be truncated with `dirname`.
+# In newer versions, gist paths are unmodified, and only other repo types
+# are truncated with `dirname`.
 fix_paths_for_ghe_version() {
-  ruby -e '
-    version = ARGV.first.gsub(/^v/, "")  # removing any leading "v" from version string
-    version_array = version.split(".").map(&:to_i)
-    fail unless version_array.first >= 2
+  if [[ "$GHE_REMOTE_VERSION" =~ 2.16. && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.16.23)" ]] || \
+     [[ "$GHE_REMOTE_VERSION" =~ 2.17. && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.17.14)" ]] || \
+     [[ "$GHE_REMOTE_VERSION" =~ 2.18. && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.18.8)" ]] || \
+     [[ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.19.3)" ]]; then
+    GIST_FILTER="-e /gist/b"
+  else
+    unset GIST_FILTER
+  fi
 
-    is_modern = version_array[0] > 2 ||
-      (version_array[0] == 2 && version_array[1] > 19) ||
-      (version_array[0] == 2 && version_array[1] == 19 && version_array[2] >= 3) ||
-      (version_array[0] == 2 && version_array[1] == 18 && version_array[2] >= 8) ||
-      (version_array[0] == 2 && version_array[1] == 17 && version_array[2] >= 14) ||
-      (version_array[0] == 2 && version_array[1] == 16 && version_array[2] >= 23)
-
-    $stdin.each_line do |line|
-      if is_modern && line =~ /gist/
-        puts line
-      else
-        puts File.dirname(line)
-      end
-    end
-  ' "$GHE_REMOTE_VERSION"
+  # This sed expression is equivalent to running `dirname` on each line,
+  # but without all the fork+exec overhead of calling `dirname` that many
+  # times:
+  #   1. strip off trailing slashes
+  #   2. if the result has no slashes in it, the dirname is "."
+  #   3. truncate from the final slash (if any) to the end
+  # If the GIST_FILTER was set above (because we're on a modern version of
+  # GHES), then don't modify lines with "gist" in them.
+  sed $GIST_FILTER -e 's/\/$//; s/^[^\/]*$/./; s/\/[^\/]*$//'
 }

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -305,7 +305,7 @@ version() {
   echo "${@#v}" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }
 
-parse_paths() {
+fix_paths_for_ghe_version() {
   local version_GHE_REMOTE_VERSION=$(version $GHE_REMOTE_VERSION)
   local version_2_16_23=$(version 2.16.23)
   local version_2_17_14=$(version 2.17.14)

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -304,3 +304,23 @@ ghe_debug() {
 version() {
   echo "${@#v}" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }
+
+parse_paths() {
+  local version_GHE_REMOTE_VERSION=$(version $GHE_REMOTE_VERSION)
+  local version_2_16_23=$(version 2.16.23)
+  local version_2_17_14=$(version 2.17.14)
+  local version_2_18_8=$(version 2.18.8)
+  local vesrion_2_19_3=$(version 2.19.3)
+  
+  while read -r line; do
+    if [[ "$GHE_REMOTE_VERSION" =~ 2.16 && "$version_GHE_REMOTE_VERSION" -ge "$version_2_16_23" ]] || \
+       [[ "$GHE_REMOTE_VERSION" =~ 2.17 && "$version_GHE_REMOTE_VERSION" -ge "$version_2_17_14" ]] || \
+       [[ "$GHE_REMOTE_VERSION" =~ 2.18 && "$version_GHE_REMOTE_VERSION" -ge "$version_2_18_8" ]] || \
+       [[ "$GHE_REMOTE_VERSION" =~ 2.19 && "$version_GHE_REMOTE_VERSION" -ge "$vesrion_2_19_3" ]] && \
+       (echo "$line" | grep -q "gist"); then
+      echo "$line"
+    else
+      dirname "$line"
+    fi
+  done
+}

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -305,6 +305,8 @@ version() {
   echo "${@#v}" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }
 
+# The list of gists returned by the source changed in 2.16.23, 2.17.14,
+# 2.18.8, and 2.19.3.  So we need to account for this difference here.
 fix_paths_for_ghe_version() {
   ruby -e '
     ghe_remote_version = ARGV.first

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -313,11 +313,11 @@ parse_paths() {
   local vesrion_2_19_3=$(version 2.19.3)
   
   while read -r line; do
-    if [[ "$GHE_REMOTE_VERSION" =~ 2.16 && "$version_GHE_REMOTE_VERSION" -ge "$version_2_16_23" ]] || \
-       [[ "$GHE_REMOTE_VERSION" =~ 2.17 && "$version_GHE_REMOTE_VERSION" -ge "$version_2_17_14" ]] || \
-       [[ "$GHE_REMOTE_VERSION" =~ 2.18 && "$version_GHE_REMOTE_VERSION" -ge "$version_2_18_8" ]] || \
-       [[ "$GHE_REMOTE_VERSION" =~ 2.19 && "$version_GHE_REMOTE_VERSION" -ge "$vesrion_2_19_3" ]] && \
-       (echo "$line" | grep -q "gist"); then
+    if [[ "$GHE_REMOTE_VERSION" =~ 2.16. && "$version_GHE_REMOTE_VERSION" -ge "$version_2_16_23" ]] || \
+       [[ "$GHE_REMOTE_VERSION" =~ 2.17. && "$version_GHE_REMOTE_VERSION" -ge "$version_2_17_14" ]] || \
+       [[ "$GHE_REMOTE_VERSION" =~ 2.18. && "$version_GHE_REMOTE_VERSION" -ge "$version_2_18_8" ]] || \
+       [[ "$GHE_REMOTE_VERSION" =~ 2.19. && "$version_GHE_REMOTE_VERSION" -ge "$vesrion_2_19_3" ]] && \
+       [[ "$line" =~ gist ]]; then
       echo "$line"
     else
       dirname "$line"

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -309,10 +309,10 @@ version() {
 # 2.18.8, and 2.19.3.  So we need to account for this difference here.
 fix_paths_for_ghe_version() {
   ruby -e '
-    version = ARGV.first
-    ghe_remote_version = version[0] == "v" ? version[1..-1] : version # removing "v" literal from version string
-    version_array = ghe_remote_version.split(".").map(&:to_i)
+    version = ARGV.first.gsub(/^v/, "")  # removing any leading "v" from version string
+    version_array = version.split(".").map(&:to_i)
     fail unless version_array.first >= 2
+
     is_modern = version_array[0] > 2 ||
       (version_array[0] == 2 && version_array[1] > 19) ||
       (version_array[0] == 2 && version_array[1] == 19 && version_array[2] >= 3) ||

--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -366,25 +366,8 @@ bm_end "$(basename $0) - Special Data Directories Sync"
 
 if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   bm_start "$(basename $0) - Verifying Routes"
-
-  # The list of gists returned by the source changed in 2.16.23, 2.17.14, 2.18.8 & 2.19.3
-  # so we need to account for this difference here.
-  parse_paths() {
-    while read -r line; do
-      if [[ "$GHE_REMOTE_VERSION" =~ 2.16 && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.16.23)" ]] || \
-         [[ "$GHE_REMOTE_VERSION" =~ 2.17 && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.17.14)" ]] || \
-         [[ "$GHE_REMOTE_VERSION" =~ 2.18 && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.18.8)" ]] || \
-         [[ "$GHE_REMOTE_VERSION" =~ 2.19 && "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.19.3)" ]] && \
-         (echo "$line" | grep -q "gist"); then
-        echo "$line"
-      else
-        dirname "$line"
-      fi
-    done
-  }
-
   cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
-  (cd $backup_dir/ && find * -mindepth 5 -maxdepth 6 -type d -name \*.git | parse_paths | sort | uniq) > $tempdir/destination_routes
+  (cd $backup_dir/ && find * -mindepth 5 -maxdepth 6 -type d -name \*.git | fix_paths_for_ghe_version | sort | uniq) > $tempdir/destination_routes
 
   git --no-pager diff --unified=0 --no-prefix -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more repository networks and/or gists were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 

--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -366,8 +366,8 @@ bm_end "$(basename $0) - Special Data Directories Sync"
 
 if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   bm_start "$(basename $0) - Verifying Routes"
-  cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
-  (cd $backup_dir/ && find * -mindepth 5 -maxdepth 6 -type d -name \*.git | fix_paths_for_ghe_version | sort | uniq) > $tempdir/destination_routes
+  cat $tempdir/*.rsync | uniq | sort | uniq > $tempdir/source_routes
+  (cd $backup_dir/ && find * -mindepth 5 -maxdepth 6 -type d -name \*.git | fix_paths_for_ghe_version | uniq | sort | uniq) > $tempdir/destination_routes
 
   git --no-pager diff --unified=0 --no-prefix -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more repository networks and/or gists were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -141,8 +141,8 @@ bm_end "$(basename $0) - Storage object sync"
 if [ -z "$GHE_SKIP_ROUTE_VERIFICATION" ]; then
   bm_start "$(basename $0) - Verifying Routes"
 
-  cat $tempdir/*.rsync | sort | uniq > $tempdir/source_routes
-  (cd $backup_dir/ && find * -mindepth 3 -maxdepth 3 -type f -print | sort | uniq) > $tempdir/destination_routes
+  cat $tempdir/*.rsync | uniq | sort | uniq > $tempdir/source_routes
+  (cd $backup_dir/ && find * -mindepth 3 -maxdepth 3 -type f -print | uniq | sort | uniq) > $tempdir/destination_routes
 
   git --no-pager diff --unified=0 --no-prefix -- $tempdir/source_routes $tempdir/destination_routes || echo "Warning: One or more storage objects were not found on the source appliance. Please contact GitHub Enterprise Support for assistance."
 

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -3,7 +3,7 @@
 TESTS_DIR="$(realpath "$(dirname "$0")")"
 # Bring in testlib
 # shellcheck source=test/testlib.sh
-. "$TESTS_DIR/testlib.sh"
+. "$(dirname "$0")/testlib.sh"
 
 # Create the backup data dir and fake remote repositories dirs
 mkdir -p "$GHE_DATA_DIR" "$GHE_REMOTE_DATA_USER_DIR"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -399,7 +399,7 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
     done
 
     # old versions change foo/gist to foo
-    for ver in 2.0.0 v2.0.0 v2.15.123 v2.16.22 v2.17.13 v2.18.7 v2.19.2; do
+    for ver in 1.0.0 bob a.b.c "" 1.2.16 2.0.0 v2.0.0 v2.15.123 v2.16.22 v2.17.13 v2.18.7 v2.19.2; do
         echo "## $ver, not gist"
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
@@ -413,16 +413,6 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
             GHE_REMOTE_VERSION=$ver
             echo foo/gist | fix_paths_for_ghe_version
         ")" == "foo" ]
-    done
-
-    # garbage versions make fix_paths_for_ghe_version fail
-    for ver in 1.0.0 bob "a b c" "-" "." ""; do
-        echo "## $ver, should fail"
-        bash -c "
-            source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
-            GHE_REMOTE_VERSION=$ver
-            ! echo foo/bar | fix_paths_for_ghe_version
-        "
     done
 )
 end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -352,7 +352,7 @@ begin_test "ghe-backup backup gist"
     timeout 2 bash -c "
     source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
     GHE_REMOTE_VERSION=2.16.23;
-    seq 1 10000 | sed -e 's/$/ gist/' | fix_paths_for_ghe_version | grep -c gist"
+    seq 1 100000 | sed -e 's/$/ gist/' | fix_paths_for_ghe_version | grep -c gist"
 )
 end_test
 
@@ -363,6 +363,6 @@ begin_test "ghe-backup backup wiki"
     timeout 2 bash -c "
     source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
     GHE_REMOTE_VERSION=2.16.23;
-    seq 1 10000 | sed -e 's/$/ wiki/' | fix_paths_for_ghe_version | grep -c '^\.$'"
+    seq 1 100000 | sed -e 's/$/ wiki/' | fix_paths_for_ghe_version | grep -c '^\.$'"
 )
 end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -346,12 +346,6 @@ begin_test "ghe-backup missing directories or files on source appliance"
 )
 end_test
 
-if [ "$(uname)" == "Darwin" ]; then
-    timeout() {
-        ruby -rtimeout -e 'duration = ARGV.shift.to_i; Timeout::timeout(duration) { system(*ARGV) }' "$@"
-    }
-fi
-
 # acceptance criteria is less then 2 seconds for 100,000 lines
 begin_test "ghe-backup fix_paths_for_ghe_version performance tests - gists"
 (

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -1,346 +1,368 @@
 #!/usr/bin/env bash
 # ghe-backup command tests
-
+TESTS_DIR="$(realpath "$(dirname "$0")")"
 # Bring in testlib
 # shellcheck source=test/testlib.sh
-. "$(dirname "$0")/testlib.sh"
+. "$TESTS_DIR/testlib.sh"
 
 # Create the backup data dir and fake remote repositories dirs
 mkdir -p "$GHE_DATA_DIR" "$GHE_REMOTE_DATA_USER_DIR"
 
 setup_test_data $GHE_REMOTE_DATA_USER_DIR
 
-begin_test "ghe-backup first snapshot"
+# begin_test "ghe-backup first snapshot"
+# (
+#   set -e
+
+#   # check that no current symlink exists yet
+#   [ ! -d "$GHE_DATA_DIR/current" ]
+
+#   # run it
+#   ghe-backup -v
+
+#   verify_all_backedup_data
+# )
+# end_test
+
+# begin_test "ghe-backup subsequent snapshot"
+# (
+#   set -e
+
+#   # wait a second for snapshot timestamp
+#   sleep 1
+
+#   # check that no current symlink exists yet
+#   [ -d "$GHE_DATA_DIR/current" ]
+
+#   # grab the first snapshot number so we can compare after
+#   first_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
+
+#   # run it
+#   ghe-backup
+
+#   # check that current symlink points to new snapshot
+#   this_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
+#   [ "$first_snapshot" != "$this_snapshot" ]
+
+#   verify_all_backedup_data
+# )
+# end_test
+
+# begin_test "ghe-backup logs the benchmark"
+# (
+#   set -e
+
+#   # wait a second for snapshot timestamp
+#   sleep 1
+
+#   export BM_TIMESTAMP=foo
+
+#   ghe-backup
+
+#   [ "$(grep took $GHE_DATA_DIR/current/benchmarks/benchmark.foo.log | wc -l)" -gt 1 ]
+# )
+# end_test
+
+# begin_test "ghe-backup with relative data dir path"
+# (
+#   set -e
+
+#   # wait a second for snapshot timestamp
+#   sleep 1
+
+#   # generate a timestamp
+#   GHE_SNAPSHOT_TIMESTAMP="relative-$(date +"%Y%m%dT%H%M%S")"
+#   export GHE_SNAPSHOT_TIMESTAMP
+
+#   # change working directory to the root directory
+#   cd $ROOTDIR
+
+#   # run it
+#   GHE_DATA_DIR=$(echo $GHE_DATA_DIR | sed 's|'$ROOTDIR'/||') ghe-backup
+
+#   # check that current symlink points to new snapshot
+#   [ "$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.*-> //')" = "$GHE_SNAPSHOT_TIMESTAMP" ]
+
+#   verify_all_backedup_data
+# )
+# end_test
+
+# begin_test "ghe-backup fails fast when old style run in progress"
+# (
+#   set -e
+
+#   ln -s 1 "$GHE_DATA_DIR/in-progress"
+#   ! ghe-backup
+
+#   unlink "$GHE_DATA_DIR/in-progress"
+# )
+# end_test
+
+# begin_test "ghe-backup cleans up stale in-progress file"
+# (
+#   set -e
+
+#   echo "20150928T153353 99999" > "$GHE_DATA_DIR/in-progress"
+#   ghe-backup
+
+#   [ ! -f "$GHE_DATA_DIR/in-progress" ]
+# )
+# end_test
+
+# begin_test "ghe-backup without management console password"
+# (
+#   set -e
+
+#   git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage ""
+#   ghe-backup
+
+#   [ ! -f "$GHE_DATA_DIR/current/manage-password" ]
+# )
+# end_test
+
+# begin_test "ghe-backup empty hookshot directory"
+# (
+#   set -e
+
+#   rm -rf $GHE_REMOTE_DATA_USER_DIR/hookshot/repository-*
+#   rm -rf $GHE_DATA_DIR/current/hookshot/repository-*
+#   ghe-backup
+
+#   # Check that the "--link-dest arg does not exist" message hasn't occurred.
+#   [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
+# )
+# end_test
+
+# begin_test "ghe-backup empty git-hooks directory"
+# (
+#   set -e
+
+#   rm -rf $GHE_REMOTE_DATA_USER_DIR/git-hooks/*
+#   rm -rf $GHE_DATA_DIR/current/git-hooks/*
+#   ghe-backup
+
+#   # Check that the "--link-dest arg does not exist" message hasn't occurred.
+#   [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
+# )
+# end_test
+
+# begin_test "ghe-backup fsck"
+# (
+#   set -e
+
+#   export GHE_BACKUP_FSCK=yes
+#   ghe-backup | grep -q "Repos verified: 6, Errors: 1, Took:"
+#   # Verbose mode disabled by default
+#   ! ghe-backup | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+#   ghe-backup -v | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+#   export GHE_BACKUP_FSCK=no
+#   ! ghe-backup | grep -q "Repos verified:"
+# )
+# end_test
+
+# begin_test "ghe-backup stores version when not run from a clone"
+# (
+#   set -e
+
+#   # Make sure this doesn't exist
+#   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
+
+#   tmpdir=$(mktemp -d "$TRASHDIR/foo.XXXXXX")
+
+#   # If user is running the tests extracted from a release tarball, git clone will fail.
+#   if GIT_DIR="$ROOTDIR/.git" git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+#     git clone "$ROOTDIR" "$tmpdir/backup-utils"
+#     cd "$tmpdir/backup-utils"
+#     rm -rf .git
+#     ./bin/ghe-backup
+
+#     # Verify that ghe-backup wrote its version information to the host
+#     [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]
+#   else
+#     echo ".git directory not found, skipping ghe-backup not from a clone test"
+#   fi
+# )
+# end_test
+
+# begin_test "ghe-backup with leaked SSH host key detection for current backup"
+# (
+#   set -e
+
+#   # Rename ghe-export-ssh-keys to generate a fake ssh
+#   cd "$ROOTDIR/test/bin"
+#   mv "ghe-export-ssh-host-keys" "ghe-export-ssh-host-keys.orig"
+#   ln -s ghe-gen-fake-ssh-tar ghe-export-ssh-host-keys
+#   cd -
+
+#   # Inject the fingerprint into the blacklist
+#   export FINGERPRINT_BLACKLIST="98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60"
+
+#   # Run it
+#   output=$(ghe-backup -v)
+
+#   # Set the export ssh back
+#   mv "$ROOTDIR/test/bin/ghe-export-ssh-host-keys.orig" "$ROOTDIR/test/bin/ghe-export-ssh-host-keys"
+
+#   # Test the output for leaked key detection
+#   echo $output| grep "The current backup contains leaked SSH host keys"
+
+# )
+# end_test
+
+# begin_test "ghe-backup with no leaked keys"
+# (
+#   set -e
+
+#   # Make sure there are no leaked key messages
+#   ! ghe-backup -v | grep "Leaked key"
+
+# )
+# end_test
+
+# begin_test "ghe-backup honours --version flag"
+# (
+#   set -e
+
+#   # Make sure a partial version string is returned
+#   ghe-backup --version | grep "GitHub backup-utils v"
+
+# )
+# end_test
+
+# begin_test "ghe-backup honours --help and -h flags"
+# (
+#   set -e
+
+#   arg_help=$(ghe-backup --help | grep -o 'Usage: ghe-backup')
+#   arg_h=$(ghe-backup -h | grep -o 'Usage: ghe-backup')
+
+#   # Make sure a Usage: string is returned and that it's the same for -h and --help
+#   [ "$arg_help" = "$arg_h" ] && echo $arg_help | grep -q "Usage: ghe-backup"
+
+# )
+# end_test
+
+# begin_test "ghe-backup exits early on unsupported version"
+# (
+#   set -e
+#   ! GHE_TEST_REMOTE_VERSION=2.10.0 ghe-backup -v
+# )
+# end_test
+
+# begin_test "ghe-backup-strategy returns rsync for HA backup"
+# (
+#   set -e
+#   touch "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
+#   output="$(ghe-backup-strategy)"
+#   rm "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
+#   [ "$output" = "rsync" ]
+# )
+# end_test
+
+# # Reset data for sub-subsequent tests
+# rm -rf $GHE_REMOTE_DATA_USER_DIR
+# setup_test_data $GHE_REMOTE_DATA_USER_DIR
+
+# begin_test "ghe-backup cluster"
+# (
+#   set -e
+#   setup_remote_cluster
+
+#   if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
+#     cat "$TRASHDIR/backup-out"
+#     : ghe-restore should have exited successfully
+#     false
+#   fi
+
+#   cat "$TRASHDIR/backup-out"
+
+#   # verify data was copied from multiple nodes
+#   # repositories
+#   grep -q "repositories from git-server-fake-uuid" "$TRASHDIR/backup-out"
+#   grep -q "repositories from git-server-fake-uuid1" "$TRASHDIR/backup-out"
+#   grep -q "repositories from git-server-fake-uuid2" "$TRASHDIR/backup-out"
+
+#   # storage
+#   grep -q "objects from storage-server-fake-uuid" "$TRASHDIR/backup-out"
+#   grep -q "objects from storage-server-fake-uuid1" "$TRASHDIR/backup-out"
+#   grep -q "objects from storage-server-fake-uuid2" "$TRASHDIR/backup-out"
+
+#   # pages
+#   grep -q "Starting backup for host: pages-server-fake-uuid" "$TRASHDIR/backup-out"
+#   grep -q "Starting backup for host: pages-server-fake-uuid1" "$TRASHDIR/backup-out"
+#   grep -q "Starting backup for host: pages-server-fake-uuid2" "$TRASHDIR/backup-out"
+
+#   # verify cluster.conf backed up
+#   [ -f "$GHE_DATA_DIR/current/cluster.conf" ]
+#   grep -q "fake cluster config" "$GHE_DATA_DIR/current/cluster.conf"
+
+#   verify_all_backedup_data
+# )
+# end_test
+
+# begin_test "ghe-backup not missing directories or files on source appliance"
+# (
+#     # Tests the scenario where the database and on disk state are consistent.
+#     set -e
+
+#     if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
+#       cat "$TRASHDIR/backup-out"
+#       : ghe-backup should have completed successfully
+#       false
+#     fi
+
+#     # Ensure the output doesn't contain the warnings
+#     grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
+#     grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
+
+#     verify_all_backedup_data
+# )
+# end_test
+
+# begin_test "ghe-backup missing directories or files on source appliance"
+# (
+#     # Tests the scenario where something exists in the database, but not on disk.
+#     set -e
+
+#     rm -rf $GHE_REMOTE_DATA_USER_DIR/repositories/1
+#     rm -rf $GHE_REMOTE_DATA_USER_DIR/storage/e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244
+
+#     if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
+#       cat "$TRASHDIR/backup-out"
+#       : ghe-backup should have completed successfully
+#       false
+#     fi
+
+#     # Check the output for the warnings
+#     grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out"
+#     grep -q "\-1/23/bb/4c/gist" "$TRASHDIR/backup-out"
+#     grep -q "\-1/nw/23/bb/4c/2345" "$TRASHDIR/backup-out"
+#     grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out"
+#     grep -q "\-e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244" "$TRASHDIR/backup-out"
+
+#     verify_all_backedup_data
+# )
+# end_test
+
+# acceptance criteria is less then 2 seconds for 10,000 lines
+begin_test "ghe-backup backup gist"
 (
-  set -e
-
-  # check that no current symlink exists yet
-  [ ! -d "$GHE_DATA_DIR/current" ]
-
-  # run it
-  ghe-backup -v
-
-  verify_all_backedup_data
-)
-end_test
-
-begin_test "ghe-backup subsequent snapshot"
-(
-  set -e
-
-  # wait a second for snapshot timestamp
-  sleep 1
-
-  # check that no current symlink exists yet
-  [ -d "$GHE_DATA_DIR/current" ]
-
-  # grab the first snapshot number so we can compare after
-  first_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
-
-  # run it
-  ghe-backup
-
-  # check that current symlink points to new snapshot
-  this_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
-  [ "$first_snapshot" != "$this_snapshot" ]
-
-  verify_all_backedup_data
-)
-end_test
-
-begin_test "ghe-backup logs the benchmark"
-(
-  set -e
-
-  # wait a second for snapshot timestamp
-  sleep 1
-
-  export BM_TIMESTAMP=foo
-
-  ghe-backup
-
-  [ "$(grep took $GHE_DATA_DIR/current/benchmarks/benchmark.foo.log | wc -l)" -gt 1 ]
-)
-end_test
-
-begin_test "ghe-backup with relative data dir path"
-(
-  set -e
-
-  # wait a second for snapshot timestamp
-  sleep 1
-
-  # generate a timestamp
-  GHE_SNAPSHOT_TIMESTAMP="relative-$(date +"%Y%m%dT%H%M%S")"
-  export GHE_SNAPSHOT_TIMESTAMP
-
-  # change working directory to the root directory
-  cd $ROOTDIR
-
-  # run it
-  GHE_DATA_DIR=$(echo $GHE_DATA_DIR | sed 's|'$ROOTDIR'/||') ghe-backup
-
-  # check that current symlink points to new snapshot
-  [ "$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.*-> //')" = "$GHE_SNAPSHOT_TIMESTAMP" ]
-
-  verify_all_backedup_data
-)
-end_test
-
-begin_test "ghe-backup fails fast when old style run in progress"
-(
-  set -e
-
-  ln -s 1 "$GHE_DATA_DIR/in-progress"
-  ! ghe-backup
-
-  unlink "$GHE_DATA_DIR/in-progress"
-)
-end_test
-
-begin_test "ghe-backup cleans up stale in-progress file"
-(
-  set -e
-
-  echo "20150928T153353 99999" > "$GHE_DATA_DIR/in-progress"
-  ghe-backup
-
-  [ ! -f "$GHE_DATA_DIR/in-progress" ]
-)
-end_test
-
-begin_test "ghe-backup without management console password"
-(
-  set -e
-
-  git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage ""
-  ghe-backup
-
-  [ ! -f "$GHE_DATA_DIR/current/manage-password" ]
-)
-end_test
-
-begin_test "ghe-backup empty hookshot directory"
-(
-  set -e
-
-  rm -rf $GHE_REMOTE_DATA_USER_DIR/hookshot/repository-*
-  rm -rf $GHE_DATA_DIR/current/hookshot/repository-*
-  ghe-backup
-
-  # Check that the "--link-dest arg does not exist" message hasn't occurred.
-  [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
-)
-end_test
-
-begin_test "ghe-backup empty git-hooks directory"
-(
-  set -e
-
-  rm -rf $GHE_REMOTE_DATA_USER_DIR/git-hooks/*
-  rm -rf $GHE_DATA_DIR/current/git-hooks/*
-  ghe-backup
-
-  # Check that the "--link-dest arg does not exist" message hasn't occurred.
-  [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
-)
-end_test
-
-begin_test "ghe-backup fsck"
-(
-  set -e
-
-  export GHE_BACKUP_FSCK=yes
-  ghe-backup | grep -q "Repos verified: 6, Errors: 1, Took:"
-  # Verbose mode disabled by default
-  ! ghe-backup | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-  ghe-backup -v | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
-  export GHE_BACKUP_FSCK=no
-  ! ghe-backup | grep -q "Repos verified:"
-)
-end_test
-
-begin_test "ghe-backup stores version when not run from a clone"
-(
-  set -e
-
-  # Make sure this doesn't exist
-  rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
-
-  tmpdir=$(mktemp -d "$TRASHDIR/foo.XXXXXX")
-
-  # If user is running the tests extracted from a release tarball, git clone will fail.
-  if GIT_DIR="$ROOTDIR/.git" git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-    git clone "$ROOTDIR" "$tmpdir/backup-utils"
-    cd "$tmpdir/backup-utils"
-    rm -rf .git
-    ./bin/ghe-backup
-
-    # Verify that ghe-backup wrote its version information to the host
-    [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]
-  else
-    echo ".git directory not found, skipping ghe-backup not from a clone test"
-  fi
-)
-end_test
-
-begin_test "ghe-backup with leaked SSH host key detection for current backup"
-(
-  set -e
-
-  # Rename ghe-export-ssh-keys to generate a fake ssh
-  cd "$ROOTDIR/test/bin"
-  mv "ghe-export-ssh-host-keys" "ghe-export-ssh-host-keys.orig"
-  ln -s ghe-gen-fake-ssh-tar ghe-export-ssh-host-keys
-  cd -
-
-  # Inject the fingerprint into the blacklist
-  export FINGERPRINT_BLACKLIST="98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60"
-
-  # Run it
-  output=$(ghe-backup -v)
-
-  # Set the export ssh back
-  mv "$ROOTDIR/test/bin/ghe-export-ssh-host-keys.orig" "$ROOTDIR/test/bin/ghe-export-ssh-host-keys"
-
-  # Test the output for leaked key detection
-  echo $output| grep "The current backup contains leaked SSH host keys"
-
-)
-end_test
-
-begin_test "ghe-backup with no leaked keys"
-(
-  set -e
-
-  # Make sure there are no leaked key messages
-  ! ghe-backup -v | grep "Leaked key"
-
-)
-end_test
-
-begin_test "ghe-backup honours --version flag"
-(
-  set -e
-
-  # Make sure a partial version string is returned
-  ghe-backup --version | grep "GitHub backup-utils v"
-
-)
-end_test
-
-begin_test "ghe-backup honours --help and -h flags"
-(
-  set -e
-
-  arg_help=$(ghe-backup --help | grep -o 'Usage: ghe-backup')
-  arg_h=$(ghe-backup -h | grep -o 'Usage: ghe-backup')
-
-  # Make sure a Usage: string is returned and that it's the same for -h and --help
-  [ "$arg_help" = "$arg_h" ] && echo $arg_help | grep -q "Usage: ghe-backup"
-
-)
-end_test
-
-begin_test "ghe-backup exits early on unsupported version"
-(
-  set -e
-  ! GHE_TEST_REMOTE_VERSION=2.10.0 ghe-backup -v
-)
-end_test
-
-begin_test "ghe-backup-strategy returns rsync for HA backup"
-(
-  set -e
-  touch "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
-  output="$(ghe-backup-strategy)"
-  rm "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
-  [ "$output" = "rsync" ]
-)
-end_test
-
-# Reset data for sub-subsequent tests
-rm -rf $GHE_REMOTE_DATA_USER_DIR
-setup_test_data $GHE_REMOTE_DATA_USER_DIR
-
-begin_test "ghe-backup cluster"
-(
-  set -e
-  setup_remote_cluster
-
-  if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
-    cat "$TRASHDIR/backup-out"
-    : ghe-restore should have exited successfully
-    false
-  fi
-
-  cat "$TRASHDIR/backup-out"
-
-  # verify data was copied from multiple nodes
-  # repositories
-  grep -q "repositories from git-server-fake-uuid" "$TRASHDIR/backup-out"
-  grep -q "repositories from git-server-fake-uuid1" "$TRASHDIR/backup-out"
-  grep -q "repositories from git-server-fake-uuid2" "$TRASHDIR/backup-out"
-
-  # storage
-  grep -q "objects from storage-server-fake-uuid" "$TRASHDIR/backup-out"
-  grep -q "objects from storage-server-fake-uuid1" "$TRASHDIR/backup-out"
-  grep -q "objects from storage-server-fake-uuid2" "$TRASHDIR/backup-out"
-
-  # pages
-  grep -q "Starting backup for host: pages-server-fake-uuid" "$TRASHDIR/backup-out"
-  grep -q "Starting backup for host: pages-server-fake-uuid1" "$TRASHDIR/backup-out"
-  grep -q "Starting backup for host: pages-server-fake-uuid2" "$TRASHDIR/backup-out"
-
-  # verify cluster.conf backed up
-  [ -f "$GHE_DATA_DIR/current/cluster.conf" ]
-  grep -q "fake cluster config" "$GHE_DATA_DIR/current/cluster.conf"
-
-  verify_all_backedup_data
-)
-end_test
-
-begin_test "ghe-backup not missing directories or files on source appliance"
-(
-    # Tests the scenario where the database and on disk state are consistent.
     set -e
-
-    if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
-      cat "$TRASHDIR/backup-out"
-      : ghe-backup should have completed successfully
-      false
-    fi
-
-    # Ensure the output doesn't contain the warnings
-    grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
-    grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
-
-    verify_all_backedup_data
+    timeout 2 bash -c "
+    source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+    GHE_REMOTE_VERSION=2.16.23;
+    seq 1 10000 | sed -e 's/$/ gist/' | parse_paths | grep -c gist"
 )
 end_test
 
-begin_test "ghe-backup missing directories or files on source appliance"
+# acceptance criteria is less then 2 seconds for 10,000 lines
+begin_test "ghe-backup backup wiki"
 (
-    # Tests the scenario where something exists in the database, but not on disk.
     set -e
-
-    rm -rf $GHE_REMOTE_DATA_USER_DIR/repositories/1
-    rm -rf $GHE_REMOTE_DATA_USER_DIR/storage/e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244
-
-    if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
-      cat "$TRASHDIR/backup-out"
-      : ghe-backup should have completed successfully
-      false
-    fi
-
-    # Check the output for the warnings
-    grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out"
-    grep -q "\-1/23/bb/4c/gist" "$TRASHDIR/backup-out"
-    grep -q "\-1/nw/23/bb/4c/2345" "$TRASHDIR/backup-out"
-    grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out"
-    grep -q "\-e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244" "$TRASHDIR/backup-out"
-
-    verify_all_backedup_data
+    timeout 2 bash -c "
+    source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+    GHE_REMOTE_VERSION=2.16.23;
+    seq 1 10000 | sed -e 's/$/ wiki/' | parse_paths | grep -c '^\.$'"
 )
 end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -382,7 +382,7 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
     set -e
 
     # modern versions keep foo/gist as foo/gist
-    for ver in 2.16.23 2.17.14 2.18.8 2.19.3 2.20.0 3.0.0; do
+    for ver in 2.16.23 v2.16.23 v2.17.14 v2.18.8 v2.19.3 v2.20.0 v3.0.0; do
         echo "## $ver, not gist"
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
@@ -399,7 +399,7 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
     done
 
     # old versions change foo/gist to foo
-    for ver in 2.0.0 2.15.123 2.16.22 2.17.13 2.18.7 2.19.2; do
+    for ver in 2.0.0 v2.0.0 v2.15.123 v2.16.22 v2.17.13 v2.18.7 v2.19.2; do
         echo "## $ver, not gist"
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -352,7 +352,7 @@ begin_test "ghe-backup backup gist"
     timeout 2 bash -c "
     source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
     GHE_REMOTE_VERSION=2.16.23;
-    seq 1 10000 | sed -e 's/$/ gist/' | parse_paths | grep -c gist"
+    seq 1 10000 | sed -e 's/$/ gist/' | fix_paths_for_ghe_version | grep -c gist"
 )
 end_test
 
@@ -363,6 +363,6 @@ begin_test "ghe-backup backup wiki"
     timeout 2 bash -c "
     source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
     GHE_REMOTE_VERSION=2.16.23;
-    seq 1 10000 | sed -e 's/$/ wiki/' | parse_paths | grep -c '^\.$'"
+    seq 1 10000 | sed -e 's/$/ wiki/' | fix_paths_for_ghe_version | grep -c '^\.$'"
 )
 end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -379,14 +379,14 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
         echo == $ver, not gist
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
-            GHE_REMOTE_VERSION=$ver
+            GHE_REMOTE_VERSION="$ver"
             echo foo/bar | fix_paths_for_ghe_version
         ")" == "foo" ]
 
         echo == $ver, gist
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
-            GHE_REMOTE_VERSION=$ver
+            GHE_REMOTE_VERSION="$ver"
             echo foo/gist | fix_paths_for_ghe_version
         ")" == "foo/gist" ]
     done
@@ -396,14 +396,14 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
         echo == $ver, not gist
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
-            GHE_REMOTE_VERSION=$ver
+            GHE_REMOTE_VERSION="$ver"
             echo foo/bar | fix_paths_for_ghe_version
         ")" == "foo" ]
 
         echo == $ver, gist
         [ "$(bash -c "
             source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
-            GHE_REMOTE_VERSION=$ver
+            GHE_REMOTE_VERSION="$ver"
             echo foo/gist | fix_paths_for_ghe_version
         ")" == "foo" ]
     done

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -408,5 +408,14 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
         ")" == "foo" ]
     done
 
+    # garbage versions make fix_paths_for_ghe_version fail
+    for ver in 1.0.0 bob "a b c" "-" "." ""; do
+        echo == $ver, should fail
+        bash -c "
+            source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+            GHE_REMOTE_VERSION="$ver"
+            ! echo foo/bar | fix_paths_for_ghe_version
+        "
+    done
 )
 end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -10,340 +10,340 @@ mkdir -p "$GHE_DATA_DIR" "$GHE_REMOTE_DATA_USER_DIR"
 
 setup_test_data $GHE_REMOTE_DATA_USER_DIR
 
-# begin_test "ghe-backup first snapshot"
-# (
-#   set -e
+begin_test "ghe-backup first snapshot"
+(
+  set -e
 
-#   # check that no current symlink exists yet
-#   [ ! -d "$GHE_DATA_DIR/current" ]
+  # check that no current symlink exists yet
+  [ ! -d "$GHE_DATA_DIR/current" ]
 
-#   # run it
-#   ghe-backup -v
+  # run it
+  ghe-backup -v
 
-#   verify_all_backedup_data
-# )
-# end_test
+  verify_all_backedup_data
+)
+end_test
 
-# begin_test "ghe-backup subsequent snapshot"
-# (
-#   set -e
+begin_test "ghe-backup subsequent snapshot"
+(
+  set -e
 
-#   # wait a second for snapshot timestamp
-#   sleep 1
+  # wait a second for snapshot timestamp
+  sleep 1
 
-#   # check that no current symlink exists yet
-#   [ -d "$GHE_DATA_DIR/current" ]
+  # check that no current symlink exists yet
+  [ -d "$GHE_DATA_DIR/current" ]
 
-#   # grab the first snapshot number so we can compare after
-#   first_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
+  # grab the first snapshot number so we can compare after
+  first_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
 
-#   # run it
-#   ghe-backup
+  # run it
+  ghe-backup
 
-#   # check that current symlink points to new snapshot
-#   this_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
-#   [ "$first_snapshot" != "$this_snapshot" ]
+  # check that current symlink points to new snapshot
+  this_snapshot=$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.* -> //')
+  [ "$first_snapshot" != "$this_snapshot" ]
 
-#   verify_all_backedup_data
-# )
-# end_test
+  verify_all_backedup_data
+)
+end_test
 
-# begin_test "ghe-backup logs the benchmark"
-# (
-#   set -e
+begin_test "ghe-backup logs the benchmark"
+(
+  set -e
 
-#   # wait a second for snapshot timestamp
-#   sleep 1
+  # wait a second for snapshot timestamp
+  sleep 1
 
-#   export BM_TIMESTAMP=foo
+  export BM_TIMESTAMP=foo
 
-#   ghe-backup
+  ghe-backup
 
-#   [ "$(grep took $GHE_DATA_DIR/current/benchmarks/benchmark.foo.log | wc -l)" -gt 1 ]
-# )
-# end_test
+  [ "$(grep took $GHE_DATA_DIR/current/benchmarks/benchmark.foo.log | wc -l)" -gt 1 ]
+)
+end_test
 
-# begin_test "ghe-backup with relative data dir path"
-# (
-#   set -e
+begin_test "ghe-backup with relative data dir path"
+(
+  set -e
 
-#   # wait a second for snapshot timestamp
-#   sleep 1
+  # wait a second for snapshot timestamp
+  sleep 1
 
-#   # generate a timestamp
-#   GHE_SNAPSHOT_TIMESTAMP="relative-$(date +"%Y%m%dT%H%M%S")"
-#   export GHE_SNAPSHOT_TIMESTAMP
+  # generate a timestamp
+  GHE_SNAPSHOT_TIMESTAMP="relative-$(date +"%Y%m%dT%H%M%S")"
+  export GHE_SNAPSHOT_TIMESTAMP
 
-#   # change working directory to the root directory
-#   cd $ROOTDIR
+  # change working directory to the root directory
+  cd $ROOTDIR
 
-#   # run it
-#   GHE_DATA_DIR=$(echo $GHE_DATA_DIR | sed 's|'$ROOTDIR'/||') ghe-backup
+  # run it
+  GHE_DATA_DIR=$(echo $GHE_DATA_DIR | sed 's|'$ROOTDIR'/||') ghe-backup
 
-#   # check that current symlink points to new snapshot
-#   [ "$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.*-> //')" = "$GHE_SNAPSHOT_TIMESTAMP" ]
+  # check that current symlink points to new snapshot
+  [ "$(ls -ld "$GHE_DATA_DIR/current" | sed 's/.*-> //')" = "$GHE_SNAPSHOT_TIMESTAMP" ]
 
-#   verify_all_backedup_data
-# )
-# end_test
+  verify_all_backedup_data
+)
+end_test
 
-# begin_test "ghe-backup fails fast when old style run in progress"
-# (
-#   set -e
+begin_test "ghe-backup fails fast when old style run in progress"
+(
+  set -e
 
-#   ln -s 1 "$GHE_DATA_DIR/in-progress"
-#   ! ghe-backup
+  ln -s 1 "$GHE_DATA_DIR/in-progress"
+  ! ghe-backup
 
-#   unlink "$GHE_DATA_DIR/in-progress"
-# )
-# end_test
+  unlink "$GHE_DATA_DIR/in-progress"
+)
+end_test
 
-# begin_test "ghe-backup cleans up stale in-progress file"
-# (
-#   set -e
+begin_test "ghe-backup cleans up stale in-progress file"
+(
+  set -e
 
-#   echo "20150928T153353 99999" > "$GHE_DATA_DIR/in-progress"
-#   ghe-backup
+  echo "20150928T153353 99999" > "$GHE_DATA_DIR/in-progress"
+  ghe-backup
 
-#   [ ! -f "$GHE_DATA_DIR/in-progress" ]
-# )
-# end_test
+  [ ! -f "$GHE_DATA_DIR/in-progress" ]
+)
+end_test
 
-# begin_test "ghe-backup without management console password"
-# (
-#   set -e
-
-#   git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage ""
-#   ghe-backup
-
-#   [ ! -f "$GHE_DATA_DIR/current/manage-password" ]
-# )
-# end_test
-
-# begin_test "ghe-backup empty hookshot directory"
-# (
-#   set -e
-
-#   rm -rf $GHE_REMOTE_DATA_USER_DIR/hookshot/repository-*
-#   rm -rf $GHE_DATA_DIR/current/hookshot/repository-*
-#   ghe-backup
-
-#   # Check that the "--link-dest arg does not exist" message hasn't occurred.
-#   [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
-# )
-# end_test
-
-# begin_test "ghe-backup empty git-hooks directory"
-# (
-#   set -e
-
-#   rm -rf $GHE_REMOTE_DATA_USER_DIR/git-hooks/*
-#   rm -rf $GHE_DATA_DIR/current/git-hooks/*
-#   ghe-backup
+begin_test "ghe-backup without management console password"
+(
+  set -e
+
+  git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage ""
+  ghe-backup
+
+  [ ! -f "$GHE_DATA_DIR/current/manage-password" ]
+)
+end_test
+
+begin_test "ghe-backup empty hookshot directory"
+(
+  set -e
+
+  rm -rf $GHE_REMOTE_DATA_USER_DIR/hookshot/repository-*
+  rm -rf $GHE_DATA_DIR/current/hookshot/repository-*
+  ghe-backup
+
+  # Check that the "--link-dest arg does not exist" message hasn't occurred.
+  [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
+)
+end_test
+
+begin_test "ghe-backup empty git-hooks directory"
+(
+  set -e
+
+  rm -rf $GHE_REMOTE_DATA_USER_DIR/git-hooks/*
+  rm -rf $GHE_DATA_DIR/current/git-hooks/*
+  ghe-backup
 
-#   # Check that the "--link-dest arg does not exist" message hasn't occurred.
-#   [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
-# )
-# end_test
+  # Check that the "--link-dest arg does not exist" message hasn't occurred.
+  [ ! "$(grep "[l]ink-dest arg does not exist" $TRASHDIR/out)" ]
+)
+end_test
 
-# begin_test "ghe-backup fsck"
-# (
-#   set -e
-
-#   export GHE_BACKUP_FSCK=yes
-#   ghe-backup | grep -q "Repos verified: 6, Errors: 1, Took:"
-#   # Verbose mode disabled by default
-#   ! ghe-backup | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-#   ghe-backup -v | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
-#   export GHE_BACKUP_FSCK=no
-#   ! ghe-backup | grep -q "Repos verified:"
-# )
-# end_test
-
-# begin_test "ghe-backup stores version when not run from a clone"
-# (
-#   set -e
-
-#   # Make sure this doesn't exist
-#   rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
-
-#   tmpdir=$(mktemp -d "$TRASHDIR/foo.XXXXXX")
-
-#   # If user is running the tests extracted from a release tarball, git clone will fail.
-#   if GIT_DIR="$ROOTDIR/.git" git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-#     git clone "$ROOTDIR" "$tmpdir/backup-utils"
-#     cd "$tmpdir/backup-utils"
-#     rm -rf .git
-#     ./bin/ghe-backup
-
-#     # Verify that ghe-backup wrote its version information to the host
-#     [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]
-#   else
-#     echo ".git directory not found, skipping ghe-backup not from a clone test"
-#   fi
-# )
-# end_test
-
-# begin_test "ghe-backup with leaked SSH host key detection for current backup"
-# (
-#   set -e
-
-#   # Rename ghe-export-ssh-keys to generate a fake ssh
-#   cd "$ROOTDIR/test/bin"
-#   mv "ghe-export-ssh-host-keys" "ghe-export-ssh-host-keys.orig"
-#   ln -s ghe-gen-fake-ssh-tar ghe-export-ssh-host-keys
-#   cd -
-
-#   # Inject the fingerprint into the blacklist
-#   export FINGERPRINT_BLACKLIST="98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60"
-
-#   # Run it
-#   output=$(ghe-backup -v)
-
-#   # Set the export ssh back
-#   mv "$ROOTDIR/test/bin/ghe-export-ssh-host-keys.orig" "$ROOTDIR/test/bin/ghe-export-ssh-host-keys"
-
-#   # Test the output for leaked key detection
-#   echo $output| grep "The current backup contains leaked SSH host keys"
-
-# )
-# end_test
-
-# begin_test "ghe-backup with no leaked keys"
-# (
-#   set -e
-
-#   # Make sure there are no leaked key messages
-#   ! ghe-backup -v | grep "Leaked key"
-
-# )
-# end_test
-
-# begin_test "ghe-backup honours --version flag"
-# (
-#   set -e
-
-#   # Make sure a partial version string is returned
-#   ghe-backup --version | grep "GitHub backup-utils v"
-
-# )
-# end_test
-
-# begin_test "ghe-backup honours --help and -h flags"
-# (
-#   set -e
-
-#   arg_help=$(ghe-backup --help | grep -o 'Usage: ghe-backup')
-#   arg_h=$(ghe-backup -h | grep -o 'Usage: ghe-backup')
-
-#   # Make sure a Usage: string is returned and that it's the same for -h and --help
-#   [ "$arg_help" = "$arg_h" ] && echo $arg_help | grep -q "Usage: ghe-backup"
-
-# )
-# end_test
-
-# begin_test "ghe-backup exits early on unsupported version"
-# (
-#   set -e
-#   ! GHE_TEST_REMOTE_VERSION=2.10.0 ghe-backup -v
-# )
-# end_test
-
-# begin_test "ghe-backup-strategy returns rsync for HA backup"
-# (
-#   set -e
-#   touch "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
-#   output="$(ghe-backup-strategy)"
-#   rm "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
-#   [ "$output" = "rsync" ]
-# )
-# end_test
-
-# # Reset data for sub-subsequent tests
-# rm -rf $GHE_REMOTE_DATA_USER_DIR
-# setup_test_data $GHE_REMOTE_DATA_USER_DIR
-
-# begin_test "ghe-backup cluster"
-# (
-#   set -e
-#   setup_remote_cluster
-
-#   if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
-#     cat "$TRASHDIR/backup-out"
-#     : ghe-restore should have exited successfully
-#     false
-#   fi
-
-#   cat "$TRASHDIR/backup-out"
-
-#   # verify data was copied from multiple nodes
-#   # repositories
-#   grep -q "repositories from git-server-fake-uuid" "$TRASHDIR/backup-out"
-#   grep -q "repositories from git-server-fake-uuid1" "$TRASHDIR/backup-out"
-#   grep -q "repositories from git-server-fake-uuid2" "$TRASHDIR/backup-out"
-
-#   # storage
-#   grep -q "objects from storage-server-fake-uuid" "$TRASHDIR/backup-out"
-#   grep -q "objects from storage-server-fake-uuid1" "$TRASHDIR/backup-out"
-#   grep -q "objects from storage-server-fake-uuid2" "$TRASHDIR/backup-out"
-
-#   # pages
-#   grep -q "Starting backup for host: pages-server-fake-uuid" "$TRASHDIR/backup-out"
-#   grep -q "Starting backup for host: pages-server-fake-uuid1" "$TRASHDIR/backup-out"
-#   grep -q "Starting backup for host: pages-server-fake-uuid2" "$TRASHDIR/backup-out"
-
-#   # verify cluster.conf backed up
-#   [ -f "$GHE_DATA_DIR/current/cluster.conf" ]
-#   grep -q "fake cluster config" "$GHE_DATA_DIR/current/cluster.conf"
-
-#   verify_all_backedup_data
-# )
-# end_test
-
-# begin_test "ghe-backup not missing directories or files on source appliance"
-# (
-#     # Tests the scenario where the database and on disk state are consistent.
-#     set -e
-
-#     if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
-#       cat "$TRASHDIR/backup-out"
-#       : ghe-backup should have completed successfully
-#       false
-#     fi
-
-#     # Ensure the output doesn't contain the warnings
-#     grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
-#     grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
-
-#     verify_all_backedup_data
-# )
-# end_test
-
-# begin_test "ghe-backup missing directories or files on source appliance"
-# (
-#     # Tests the scenario where something exists in the database, but not on disk.
-#     set -e
-
-#     rm -rf $GHE_REMOTE_DATA_USER_DIR/repositories/1
-#     rm -rf $GHE_REMOTE_DATA_USER_DIR/storage/e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244
-
-#     if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
-#       cat "$TRASHDIR/backup-out"
-#       : ghe-backup should have completed successfully
-#       false
-#     fi
-
-#     # Check the output for the warnings
-#     grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out"
-#     grep -q "\-1/23/bb/4c/gist" "$TRASHDIR/backup-out"
-#     grep -q "\-1/nw/23/bb/4c/2345" "$TRASHDIR/backup-out"
-#     grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out"
-#     grep -q "\-e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244" "$TRASHDIR/backup-out"
-
-#     verify_all_backedup_data
-# )
-# end_test
+begin_test "ghe-backup fsck"
+(
+  set -e
+
+  export GHE_BACKUP_FSCK=yes
+  ghe-backup | grep -q "Repos verified: 6, Errors: 1, Took:"
+  # Verbose mode disabled by default
+  ! ghe-backup | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  ghe-backup -v | grep -q "missing tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+  export GHE_BACKUP_FSCK=no
+  ! ghe-backup | grep -q "Repos verified:"
+)
+end_test
+
+begin_test "ghe-backup stores version when not run from a clone"
+(
+  set -e
+
+  # Make sure this doesn't exist
+  rm -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version"
+
+  tmpdir=$(mktemp -d "$TRASHDIR/foo.XXXXXX")
+
+  # If user is running the tests extracted from a release tarball, git clone will fail.
+  if GIT_DIR="$ROOTDIR/.git" git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    git clone "$ROOTDIR" "$tmpdir/backup-utils"
+    cd "$tmpdir/backup-utils"
+    rm -rf .git
+    ./bin/ghe-backup
+
+    # Verify that ghe-backup wrote its version information to the host
+    [ -f "$GHE_REMOTE_DATA_USER_DIR/common/backup-utils-version" ]
+  else
+    echo ".git directory not found, skipping ghe-backup not from a clone test"
+  fi
+)
+end_test
+
+begin_test "ghe-backup with leaked SSH host key detection for current backup"
+(
+  set -e
+
+  # Rename ghe-export-ssh-keys to generate a fake ssh
+  cd "$ROOTDIR/test/bin"
+  mv "ghe-export-ssh-host-keys" "ghe-export-ssh-host-keys.orig"
+  ln -s ghe-gen-fake-ssh-tar ghe-export-ssh-host-keys
+  cd -
+
+  # Inject the fingerprint into the blacklist
+  export FINGERPRINT_BLACKLIST="98:d8:99:d3:be:c0:55:05:db:b0:53:2f:1f:ad:b3:60"
+
+  # Run it
+  output=$(ghe-backup -v)
+
+  # Set the export ssh back
+  mv "$ROOTDIR/test/bin/ghe-export-ssh-host-keys.orig" "$ROOTDIR/test/bin/ghe-export-ssh-host-keys"
+
+  # Test the output for leaked key detection
+  echo $output| grep "The current backup contains leaked SSH host keys"
+
+)
+end_test
+
+begin_test "ghe-backup with no leaked keys"
+(
+  set -e
+
+  # Make sure there are no leaked key messages
+  ! ghe-backup -v | grep "Leaked key"
+
+)
+end_test
+
+begin_test "ghe-backup honours --version flag"
+(
+  set -e
+
+  # Make sure a partial version string is returned
+  ghe-backup --version | grep "GitHub backup-utils v"
+
+)
+end_test
+
+begin_test "ghe-backup honours --help and -h flags"
+(
+  set -e
+
+  arg_help=$(ghe-backup --help | grep -o 'Usage: ghe-backup')
+  arg_h=$(ghe-backup -h | grep -o 'Usage: ghe-backup')
+
+  # Make sure a Usage: string is returned and that it's the same for -h and --help
+  [ "$arg_help" = "$arg_h" ] && echo $arg_help | grep -q "Usage: ghe-backup"
+
+)
+end_test
+
+begin_test "ghe-backup exits early on unsupported version"
+(
+  set -e
+  ! GHE_TEST_REMOTE_VERSION=2.10.0 ghe-backup -v
+)
+end_test
+
+begin_test "ghe-backup-strategy returns rsync for HA backup"
+(
+  set -e
+  touch "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
+  output="$(ghe-backup-strategy)"
+  rm "$GHE_REMOTE_ROOT_DIR/etc/github/repl-state"
+  [ "$output" = "rsync" ]
+)
+end_test
+
+# Reset data for sub-subsequent tests
+rm -rf $GHE_REMOTE_DATA_USER_DIR
+setup_test_data $GHE_REMOTE_DATA_USER_DIR
+
+begin_test "ghe-backup cluster"
+(
+  set -e
+  setup_remote_cluster
+
+  if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
+    cat "$TRASHDIR/backup-out"
+    : ghe-restore should have exited successfully
+    false
+  fi
+
+  cat "$TRASHDIR/backup-out"
+
+  # verify data was copied from multiple nodes
+  # repositories
+  grep -q "repositories from git-server-fake-uuid" "$TRASHDIR/backup-out"
+  grep -q "repositories from git-server-fake-uuid1" "$TRASHDIR/backup-out"
+  grep -q "repositories from git-server-fake-uuid2" "$TRASHDIR/backup-out"
+
+  # storage
+  grep -q "objects from storage-server-fake-uuid" "$TRASHDIR/backup-out"
+  grep -q "objects from storage-server-fake-uuid1" "$TRASHDIR/backup-out"
+  grep -q "objects from storage-server-fake-uuid2" "$TRASHDIR/backup-out"
+
+  # pages
+  grep -q "Starting backup for host: pages-server-fake-uuid" "$TRASHDIR/backup-out"
+  grep -q "Starting backup for host: pages-server-fake-uuid1" "$TRASHDIR/backup-out"
+  grep -q "Starting backup for host: pages-server-fake-uuid2" "$TRASHDIR/backup-out"
+
+  # verify cluster.conf backed up
+  [ -f "$GHE_DATA_DIR/current/cluster.conf" ]
+  grep -q "fake cluster config" "$GHE_DATA_DIR/current/cluster.conf"
+
+  verify_all_backedup_data
+)
+end_test
+
+begin_test "ghe-backup not missing directories or files on source appliance"
+(
+    # Tests the scenario where the database and on disk state are consistent.
+    set -e
+
+    if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
+      cat "$TRASHDIR/backup-out"
+      : ghe-backup should have completed successfully
+      false
+    fi
+
+    # Ensure the output doesn't contain the warnings
+    grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
+    grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out" && exit 1
+
+    verify_all_backedup_data
+)
+end_test
+
+begin_test "ghe-backup missing directories or files on source appliance"
+(
+    # Tests the scenario where something exists in the database, but not on disk.
+    set -e
+
+    rm -rf $GHE_REMOTE_DATA_USER_DIR/repositories/1
+    rm -rf $GHE_REMOTE_DATA_USER_DIR/storage/e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244
+
+    if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
+      cat "$TRASHDIR/backup-out"
+      : ghe-backup should have completed successfully
+      false
+    fi
+
+    # Check the output for the warnings
+    grep -q "Warning: One or more repository networks and/or gists were not found on the source appliance." "$TRASHDIR/backup-out"
+    grep -q "\-1/23/bb/4c/gist" "$TRASHDIR/backup-out"
+    grep -q "\-1/nw/23/bb/4c/2345" "$TRASHDIR/backup-out"
+    grep -q "Warning: One or more storage objects were not found on the source appliance." "$TRASHDIR/backup-out"
+    grep -q "\-e/ed/1a/ed1aa60f0706cefde8ba2b3be662d3a0e0e1fbc94a52a3201944684cc0c5f244" "$TRASHDIR/backup-out"
+
+    verify_all_backedup_data
+)
+end_test
 
 # acceptance criteria is less then 2 seconds for 100,000 lines
 begin_test "ghe-backup backup gist"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -350,9 +350,10 @@ begin_test "ghe-backup backup gist"
 (
     set -e
     timeout 2 bash -c "
-    source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-    GHE_REMOTE_VERSION=2.16.23;
-    seq 1 100000 | sed -e 's/$/ gist/' | fix_paths_for_ghe_version | grep -c gist"
+        source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+        GHE_REMOTE_VERSION=2.16.23;
+        seq 1 100000 | sed -e 's/$/ gist/' | fix_paths_for_ghe_version | grep -c gist
+    "
 )
 end_test
 
@@ -361,8 +362,9 @@ begin_test "ghe-backup backup wiki"
 (
     set -e
     timeout 2 bash -c "
-    source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-    GHE_REMOTE_VERSION=2.16.23;
-    seq 1 100000 | sed -e 's/$/ wiki/' | fix_paths_for_ghe_version | grep -c '^\.$'"
+        source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+        GHE_REMOTE_VERSION=2.16.23;
+        seq 1 100000 | sed -e 's/$/ wiki/' | fix_paths_for_ghe_version | grep -c '^\.$'
+    "
 )
 end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -345,7 +345,7 @@ setup_test_data $GHE_REMOTE_DATA_USER_DIR
 # )
 # end_test
 
-# acceptance criteria is less then 2 seconds for 10,000 lines
+# acceptance criteria is less then 2 seconds for 100,000 lines
 begin_test "ghe-backup backup gist"
 (
     set -e
@@ -356,7 +356,7 @@ begin_test "ghe-backup backup gist"
 )
 end_test
 
-# acceptance criteria is less then 2 seconds for 10,000 lines
+# acceptance criteria is less then 2 seconds for 100,000 lines
 begin_test "ghe-backup backup wiki"
 (
     set -e

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -368,3 +368,45 @@ begin_test "ghe-backup backup wiki"
     "
 )
 end_test
+
+# check fix_paths_for_ghe_version version thresholds
+begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
+(
+    set -e
+
+    # modern versions keep foo/gist as foo/gist
+    for ver in 2.16.23 2.17.14 2.18.8 2.19.3 2.20.0 3.0.0; do
+        echo == $ver, not gist
+        [ "$(bash -c "
+            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+            GHE_REMOTE_VERSION=$ver;
+            echo foo/bar | fix_paths_for_ghe_version
+        ")" == "foo" ]
+
+        echo == $ver, gist
+        [ "$(bash -c "
+            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+            GHE_REMOTE_VERSION=$ver;
+            echo foo/gist | fix_paths_for_ghe_version
+        ")" == "foo/gist" ]
+    done
+
+    # old versions change foo/gist to foo
+    for ver in 2.0.0 2.15.123 2.16.22 2.17.13 2.18.7 2.19.2; do
+        echo == $ver, not gist
+        [ "$(bash -c "
+            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+            GHE_REMOTE_VERSION=$ver;
+            echo foo/bar | fix_paths_for_ghe_version
+        ")" == "foo" ]
+
+        echo == $ver, gist
+        [ "$(bash -c "
+            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
+            GHE_REMOTE_VERSION=$ver;
+            echo foo/gist | fix_paths_for_ghe_version
+        ")" == "foo" ]
+    done
+
+)
+end_test

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -346,24 +346,24 @@ begin_test "ghe-backup missing directories or files on source appliance"
 end_test
 
 # acceptance criteria is less then 2 seconds for 100,000 lines
-begin_test "ghe-backup backup gist"
+begin_test "ghe-backup fix_paths_for_ghe_version performance tests - gists"
 (
     set -e
     timeout 2 bash -c "
-        source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-        GHE_REMOTE_VERSION=2.16.23;
+        source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+        GHE_REMOTE_VERSION=2.16.23
         seq 1 100000 | sed -e 's/$/ gist/' | fix_paths_for_ghe_version | grep -c gist
     "
 )
 end_test
 
 # acceptance criteria is less then 2 seconds for 100,000 lines
-begin_test "ghe-backup backup wiki"
+begin_test "ghe-backup fix_paths_for_ghe_version performance tests - wikis"
 (
     set -e
     timeout 2 bash -c "
-        source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-        GHE_REMOTE_VERSION=2.16.23;
+        source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+        GHE_REMOTE_VERSION=2.16.23
         seq 1 100000 | sed -e 's/$/ wiki/' | fix_paths_for_ghe_version | grep -c '^\.$'
     "
 )
@@ -378,15 +378,15 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
     for ver in 2.16.23 2.17.14 2.18.8 2.19.3 2.20.0 3.0.0; do
         echo == $ver, not gist
         [ "$(bash -c "
-            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-            GHE_REMOTE_VERSION=$ver;
+            source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+            GHE_REMOTE_VERSION=$ver
             echo foo/bar | fix_paths_for_ghe_version
         ")" == "foo" ]
 
         echo == $ver, gist
         [ "$(bash -c "
-            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-            GHE_REMOTE_VERSION=$ver;
+            source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+            GHE_REMOTE_VERSION=$ver
             echo foo/gist | fix_paths_for_ghe_version
         ")" == "foo/gist" ]
     done
@@ -395,15 +395,15 @@ begin_test "ghe-backup fix_paths_for_ghe_version newer/older"
     for ver in 2.0.0 2.15.123 2.16.22 2.17.13 2.18.7 2.19.2; do
         echo == $ver, not gist
         [ "$(bash -c "
-            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-            GHE_REMOTE_VERSION=$ver;
+            source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+            GHE_REMOTE_VERSION=$ver
             echo foo/bar | fix_paths_for_ghe_version
         ")" == "foo" ]
 
         echo == $ver, gist
         [ "$(bash -c "
-            source \"$TESTS_DIR\"/../share/github-backup-utils/ghe-backup-config;
-            GHE_REMOTE_VERSION=$ver;
+            source '$TESTS_DIR/../share/github-backup-utils/ghe-backup-config'
+            GHE_REMOTE_VERSION=$ver
             echo foo/gist | fix_paths_for_ghe_version
         ")" == "foo" ]
     done


### PR DESCRIPTION
#524 introduced a performance regression in `ghe-backup-repositories`.  This PR speeds up the code introduced in #524 by roughly 3000x.  It also fixes a future bug, in which GitHub Enterprise versions like 2.20.x and 3.x.y would have received the deprecated behavior.  Finally, the PR adds performance and correctness tests to verify the changes.

**Performance:** Prior to the PR, the `parse_paths` step took 80 seconds to process 10k lines, due to `parse_paths` forking and executing `awk`, `grep`, and sometimes `dirline` for each line of the file.  At one large customer, this added over three hours to `ghe-backup` invocations, just doing text processing in the shell.  We believe other customers will be affected as well, proportional to the number of repos, wikis, and gists they are backing up.

We eliminated the redundant calls to `version` (which invokes `awk`), which brought the 10k-line time down to 20 seconds.  Replacing the `grep` call with a shell-intrinsic string match brought the time under 10 seconds.  Still not good enough.

So ultimately we rewrote `parse_paths` as an inline Ruby script, to completely eliminate fork and exec calls.  Each 10k lines now takes around 0.03 seconds, which will remove all but ~3 seconds of the 3-hour overhead at the customer who reported the bug.