### PR TITLE
Allow specifying base branch for release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -31,6 +31,7 @@ GH_REPO = ENV['GH_REPO'] || 'backup-utils'
 GH_OWNER = ENV['GH_OWNER'] || 'github'
 GH_AUTHOR = ENV['GH_AUTHOR']
 DEB_PKG_NAME = 'github-backup-utils'
+GH_BASE_BRANCH = ENV['GH_BASE_BRANCH'] || 'master'
 
 CHANGELOG_TMPL = '''<%= package_name %> (<%= package_version %>) UNRELEASED; urgency=medium
 
@@ -136,7 +137,7 @@ def beautify_changes(changes)
 end
 
 def changelog
-  changes = `git log --pretty=oneline origin/stable...origin/master --reverse --grep "Merge pull request" | sort -t\# -k2`.lines.map(&:strip)
+  changes = `git log --pretty=oneline origin/stable...origin/#{GH_BASE_BRANCH} --reverse --grep "Merge pull request" | sort -t\# -k2`.lines.map(&:strip)
   raise 'Building the changelog failed' if $CHILD_STATUS != 0
 
   changes
@@ -232,8 +233,8 @@ end
 
 def update_stable_branch
   `git checkout --quiet stable`
-  unless (out = `git merge --quiet --ff-only origin/master`)
-    warn "Merging master into stable failed:\n\n#{out}"
+  unless (out = `git merge --quiet --ff-only origin/#{GH_BASE_BRANCH}`)
+    warn "Merging #{GH_BASE_BRANCH} into stable failed:\n\n#{out}"
   end
   unless (out = `git push --quiet origin stable`)
     warn "Failed pushing the stable branch:\n\n#{out}"
@@ -245,7 +246,7 @@ def create_release_pr(version, release_body)
     'title': "Bump version: #{version}",
     'body': release_body,
     'head': "release-#{version}",
-    'base': 'master'
+    'base': GH_BASE_BRANCH
   }.to_json
   res = post("/repos/#{GH_OWNER}/#{GH_REPO}/pulls", body)
   raise "Creating release PR failed (#{res.code})" unless res.is_a? Net::HTTPSuccess
@@ -328,9 +329,9 @@ def attach_assets_to_release(upload_url, release_id, files)
 end
 
 def clean_up(version)
-  `git checkout --quiet master`
+  `git checkout --quiet #{GH_BASE_BRANCH}`
   `git fetch --quiet origin --prune`
-  `git pull --quiet origin master --prune`
+  `git pull --quiet origin #{GH_BASE_BRANCH} --prune`
   `git branch --quiet -D release-#{version} >/dev/null 2>&1`
   `git push --quiet origin :release-#{version} >/dev/null 2>&1`
   `git branch --quiet -D tmp-packging >/dev/null 2>&1`
@@ -382,6 +383,7 @@ if $PROGRAM_NAME == __FILE__
       puts "Repo: #{GH_REPO}"
       puts "Author: #{GH_AUTHOR}"
       puts "Token: #{ENV['GH_RELEASE_TOKEN'] && 'set' || 'unset'}"
+      puts "Base branch: #{GH_BASE_BRANCH}"
       puts 'Changelog:'
       if release_changes.empty?
         puts ' => No new bug fixes, enhancements or features.'
@@ -429,7 +431,7 @@ if $PROGRAM_NAME == __FILE__
 
     puts 'Creating release...'
     release_title = "GitHub Enterprise Server Backup Utilities v#{version}"
-    res = create_release "v#{version}", 'master', release_title, release_body, true
+    res = create_release "v#{version}", GH_BASE_BRANCH, release_title, release_body, true
 
     # Tidy up before building tarball and deb pkg
     clean_up version


### PR DESCRIPTION
The previous version of `script/release` only knew how to release from the `master` branch.  The `master` branch currently has some PRs on it that are ready for a major release, but not for a patch release.  To support releasing only the bug fix in #541, we created a branch `rc2.19.2` and changed `script/release` how to release from that instead.  Set the `GH_BASE_BRANCH` variable in the environment to pick a base branch; `master` is the default.

The [2.19.2 release](https://github.com/github/backup-utils/releases/tag/v2.19.2) was generated with this version of the script.