### PR TITLE
Add `ghe-` prefix to repository backup script

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -88,7 +88,7 @@ should_use_gitbackups_for_repositories(){
 
 # check that the appliance supports using gitbackups for repositories
 can_use_gitbackups_for_repositories(){
-  ghe-ssh "$GHE_HOSTNAME" test -e /data/github/current/bin/backup-repositories
+  ghe-ssh "$GHE_HOSTNAME" test -e /data/github/current/bin/ghe-backup-repositories
 }
 
 # Exit early if the appliance is missing script to backup repositories using gitbackups

--- a/share/github-backup-utils/ghe-backup-repositories-gitbackups
+++ b/share/github-backup-utils/ghe-backup-repositories-gitbackups
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #/ Usage: ghe-backup-repositories-gitbackups
-#/ Take an online, incremental snapshot of all Git repository data using gitbackups.
+#/ Take an online, incremental snapshot of all Git repository, wiki, and gist data using gitbackups.
 #/
 #/ Note: This command typically isn't called directly. It's invoked by
 #/ ghe-backup.
@@ -12,6 +12,6 @@ set -e
 
 bm_start "$(basename $0)"
 
-echo "github-env ./bin/backup-repositories" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+echo "github-env ./bin/ghe-backup-repositories" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
 
 bm_end "$(basename $0)"


### PR DESCRIPTION
We are renaming the underlying Ruby script to add clarity to its use.