### PR TITLE
Add ghe-export-mssql to ghe-backup

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -207,6 +207,11 @@ if is_binary_backup; then
 fi
 bm_end "ghe-export-mysql"
 
+echo "Backing up MSSQL databases ..."
+bm_start "ghe-export-mssql"
+ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-mssql' || failures="$failures mssql"
+bm_end "ghe-export-mssql"
+
 echo "Backing up Redis database ..."
 ghe-backup-redis > redis.rdb || failures="$failures redis"
 


### PR DESCRIPTION
Following ADR https://github.com/github/enterprise2/pull/19035, this PR adds MSSQL backup to the GHES backup workflow.