### PR TITLE
Fix the way we connect to mysql master using ssh forwarding for binary backups

### DIFF
--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -42,7 +42,8 @@ ssh_config_file_opt=""
 if $CLUSTER ; then
   ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
   if [ -z $ghe_mysql_master ]; then
-    ghe_mysql_master=$GHE_HOSTNAME
+    echo "Something is wrong with configuration: cluster.mysql-master not found" >&2
+    exit 2
   else
     tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
     ssh_config_file="$tempdir/ssh_config"

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -39,26 +39,26 @@ is_binary_backup_feature_on(){
 }
 
 ssh_config_file_opt=
-if $CLUSTER ; then
-  ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
-  if [ -z $ghe_mysql_master ]; then
-    echo "Something is wrong with configuration: cluster.mysql-master not found" >&2
-    exit 2
-  else
-    tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
-    ssh_config_file="$tempdir/ssh_config"
-    ssh_config_file_opt="-F $ssh_config_file"
-    ghe-ssh-config "$GHE_HOSTNAME" "$ghe_mysql_master" > "$ssh_config_file"
-    port=$(ssh_port_part "$GHE_HOSTNAME")
-    ghe_mysql_master=$ghe_mysql_master${port:+:$port}
-  fi
-else
-  ghe_mysql_master=$GHE_HOSTNAME
-fi
-
 if is_binary_backup_feature_on; then
   # Feature "mysql.backup.binary" is on, which means new backup scripts are available
   if is_binary_backup; then
+    if $CLUSTER ; then
+      ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
+      if [ -z $ghe_mysql_master ]; then
+        echo "Something is wrong with configuration: cluster.mysql-master not found" >&2
+        exit 2
+      else
+        tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
+        ssh_config_file="$tempdir/ssh_config"
+        ssh_config_file_opt="-F $ssh_config_file"
+        ghe-ssh-config "$GHE_HOSTNAME" "$ghe_mysql_master" > "$ssh_config_file"
+        port=$(ssh_port_part "$GHE_HOSTNAME")
+        ghe_mysql_master=$ghe_mysql_master${port:+:$port}
+      fi
+    else
+      ghe_mysql_master=$GHE_HOSTNAME
+    fi
+
     # Check if the decompress needed by looking into the sentinel file 
     # In 2.19.5 we compress the binary backup twice
     if [ "$(cat $snapshot_dir/mysql-binary-backup-sentinel)" = "NO_ADDITIONAL_COMPRESSION" ]; then

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -38,7 +38,7 @@ is_binary_backup_feature_on(){
   ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
 }
 
-ssh_config_file_opt=""
+ssh_config_file_opt=
 if $CLUSTER ; then
   ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
   if [ -z $ghe_mysql_master ]; then
@@ -48,7 +48,6 @@ if $CLUSTER ; then
     tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
     ssh_config_file="$tempdir/ssh_config"
     ssh_config_file_opt="-F $ssh_config_file"
-    opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
     ghe-ssh-config "$GHE_HOSTNAME" "$ghe_mysql_master" > "$ssh_config_file"
     port=$(ssh_port_part "$GHE_HOSTNAME")
     ghe_mysql_master=$ghe_mysql_master${port:+:$port}

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -44,6 +44,7 @@ if $CLUSTER ; then
   if [ -z $ghe_mysql_master ]; then
     ghe_mysql_master=$GHE_HOSTNAME
   else
+    tempdir=$(mktemp -d -t backup-utils-restore-XXXXXX)
     ssh_config_file="$tempdir/ssh_config"
     ssh_config_file_opt="-F $ssh_config_file"
     opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -38,11 +38,16 @@ is_binary_backup_feature_on(){
   ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
 }
 
-if ghe-ssh "$GHE_HOSTNAME" test -f /etc/github/cluster ; then
+ssh_config_file_opt=""
+if $CLUSTER ; then
   ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
   if [ -z $ghe_mysql_master ]; then
     ghe_mysql_master=$GHE_HOSTNAME
   else
+    ssh_config_file="$tempdir/ssh_config"
+    ssh_config_file_opt="-F $ssh_config_file"
+    opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
+    ghe-ssh-config "$GHE_HOSTNAME" "$ghe_mysql_master" > "$ssh_config_file"
     port=$(ssh_port_part "$GHE_HOSTNAME")
     ghe_mysql_master=$ghe_mysql_master${port:+:$port}
   fi
@@ -79,16 +84,16 @@ else
 fi
 
 cleanup() {
-  ghe-ssh "$GHE_RESTORE_HOST" -- "sudo rm -rf $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz"
+  ghe-ssh $ssh_config_file_opt "$GHE_RESTORE_HOST" -- "sudo rm -rf $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz"
 }
 trap 'cleanup' INT TERM EXIT
 
-ghe-ssh "$GHE_RESTORE_HOST" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/tmp'" 1>&3
+ghe-ssh $ssh_config_file_opt "$GHE_RESTORE_HOST" -- "sudo mkdir -p '$GHE_REMOTE_DATA_USER_DIR/tmp'" 1>&3
 
 # Transfer MySQL data from the snapshot to the GitHub instance.
-cat $snapshot_dir/mysql.sql.gz | ghe-ssh "$GHE_RESTORE_HOST" -- "sudo dd of=$GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz >/dev/null 2>&1"
+cat $snapshot_dir/mysql.sql.gz | ghe-ssh $ssh_config_file_opt "$GHE_RESTORE_HOST" -- "sudo dd of=$GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz >/dev/null 2>&1"
 
 # Import the database
-echo "cat $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz | $IMPORT_MYSQL" | ghe-ssh "$GHE_RESTORE_HOST" -- /bin/bash 1>&3
+echo "cat $GHE_REMOTE_DATA_USER_DIR/tmp/mysql.sql.gz | $IMPORT_MYSQL" | ghe-ssh $ssh_config_file_opt "$GHE_RESTORE_HOST" -- /bin/bash 1>&3
 
 bm_end "$(basename $0)"


### PR DESCRIPTION
We tried to fix the issue customer uses binary backup restore by connecting to non-Sql master instance in #548 , however, the host where customer runs might not have hostname resolved like the ghes instances. We need to use ssh forwarding to connect to other ghes instances.