### PR TITLE
In legacy mode we should use ghe-import-mysql

### DIFF
--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -79,7 +79,7 @@ else
     exit 2
   else
     # legacy mode
-    IMPORT_MYSQL="unpigz | ghe-import-mysql-mysqldump"
+    IMPORT_MYSQL="unpigz | ghe-import-mysql"
     GHE_RESTORE_HOST=$GHE_HOSTNAME
   fi
 fi


### PR DESCRIPTION
Regression found by @lildude 

In legacy mode we should use `ghe-import-mysql` since  `ghe-import-mysql-mysqldump` doesn't exist for 2.18 / 2.19.4 or earlier

/cc @lildude @oakeyc @DanRigby @ipmsteven 