### PR TITLE
Compress remote_routes_list on the source instance

### DIFF
--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -128,7 +128,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -96,7 +96,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -113,7 +113,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -125,7 +125,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -115,7 +115,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Transferring routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Transferring routes"
 

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -105,7 +105,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 


### PR DESCRIPTION
There was a case where `$remote_routes_list` in `ghe-backup-storage` gets more than 140MB on a GitHub Enterprise Server instance that has tons of storage objects in the `/data/user/storage` directory. We found that out when a user enabled `GHE_DEBUG` and sent GitHub Support a huge output log file. This PR is to reduce the network traffic by `gzip` ing `$remote_routes_list` on the source instance, then `gzip -d` on the backup server.