### PR TITLE
Separate ghe-backup-mysql out of ghe-backup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
         - brew install moreutils
         - brew install shellcheck
         - brew install jq
-        - brew install coreutils
         - brew install pigz
       script: make test
     - os: linux

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -174,24 +174,8 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-ssh-host-keys' > ssh-host-keys.tar ||
 failures="$failures ssh-host-keys"
 bm_end "ghe-export-ssh-host-keys"
 
-# if we are going to take a binary backup
-is_binary_backup(){
-  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
-}
-
 echo "Backing up MySQL database ..."
-bm_start "ghe-export-mysql"
-export_command="ghe-export-mysql"
-if ! is_binary_backup; then
-  # binary backup is already compressed
-  export_command+=" | pigz"
-fi
-echo "set -o pipefail; $export_command" |
-ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz || failures="$failures mysql"
-if is_binary_backup; then
-  echo "NO_ADDITIONAL_COMPRESSION" > mysql-binary-backup-sentinel
-fi
-bm_end "ghe-export-mysql"
+ghe-backup-mysql || failures="$failures mysql"
 
 echo "Backing up Redis database ..."
 ghe-backup-redis > redis.rdb || failures="$failures redis"

--- a/share/github-backup-utils/ghe-backup-mysql
+++ b/share/github-backup-utils/ghe-backup-mysql
@@ -28,7 +28,7 @@ fi
 echo "set -o pipefail; $export_command" |
 ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > "$GHE_SNAPSHOT_DIR/mysql.sql.gz"
 if is_binary_backup_feature_on; then
-  echo "NO_ADDITIONAL_COMPRESSION" > mysql-binary-backup-sentinel
+  echo "NO_ADDITIONAL_COMPRESSION" > "$GHE_SNAPSHOT_DIR/mysql-binary-backup-sentinel"
 fi
 
 bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-backup-mysql
+++ b/share/github-backup-utils/ghe-backup-mysql
@@ -26,7 +26,7 @@ if ! is_binary_backup_feature_on; then
   export_command+=" | pigz"
 fi
 echo "set -o pipefail; $export_command" |
-ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > "$GHE_SNAPSHOT_DIR/mysql.sql.gz"
 if is_binary_backup_feature_on; then
   echo "NO_ADDITIONAL_COMPRESSION" > mysql-binary-backup-sentinel
 fi

--- a/share/github-backup-utils/ghe-backup-mysql
+++ b/share/github-backup-utils/ghe-backup-mysql
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#/ Usage: ghe-backup-mysql <host>
+#/ Backup MySQL from a GitHub instance.
+#/
+#/ Note: This script typically isn't called directly. It's invoked by the
+#/ ghe-backup command.
+set -e
+
+# Bring in the backup configuration
+# shellcheck source=share/github-backup-utils/ghe-backup-config
+. "$( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config"
+
+# Show usage and bail with no arguments
+[ -z "$*" ] && print_usage
+
+bm_start "$(basename $0)"
+
+# Grab host arg
+GHE_HOSTNAME="$1"
+
+# Perform a host-check and establish the remote version in GHE_REMOTE_VERSION.
+ghe_remote_version_required "$GHE_HOSTNAME"
+
+# if we are going to take a binary backup
+is_binary_backup_feature_on(){
+  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
+}
+
+export_command="ghe-export-mysql"
+if ! is_binary_backup_feature_on; then
+  # binary backup is already compressed
+  export_command+=" | pigz"
+fi
+echo "set -o pipefail; $export_command" |
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz
+if is_binary_backup_feature_on; then
+  echo "NO_ADDITIONAL_COMPRESSION" > mysql-binary-backup-sentinel
+fi
+
+bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-backup-mysql
+++ b/share/github-backup-utils/ghe-backup-mysql
@@ -10,13 +10,7 @@ set -e
 # shellcheck source=share/github-backup-utils/ghe-backup-config
 . "$( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config"
 
-# Show usage and bail with no arguments
-[ -z "$*" ] && print_usage
-
 bm_start "$(basename $0)"
-
-# Grab host arg
-GHE_HOSTNAME="$1"
 
 # Perform a host-check and establish the remote version in GHE_REMOTE_VERSION.
 ghe_remote_version_required "$GHE_HOSTNAME"


### PR DESCRIPTION
Separate `ghe-backup-mysql` out of `ghe-backup` so we can isolate the mysql backup restore tests.

###Usage:
```
./share/github-backup-utils/ghe-backup-mysql
```

/cc @ryansimmen @omgitsads 