### PR TITLE
Add additional requirements to run in docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -24,7 +24,7 @@ github/backup-utils ghe-backup
 
 It is also possible to specify a `-e GHE_BACKUP_CONFIG` flag and volume mount in
 a local `backup.config` file rather than specify the variables individually at
-run time:
+run time, as long as `GHE_HOSTNAME` and `GHE_EXTRA_SSH_OPTS` variables are configured :
 
 ```
 $ docker run -it  -e "GHE_BACKUP_CONFIG=/mnt/backup.config" \


### PR DESCRIPTION
For the second example, @droidpl found that `GHE_EXTRA_SSH_OPTS` is a mandatory variable in the `backup.config` file or we'll run into SSH issues.

Either have this in the backup.config file or add `-e "GHE_EXTRA_SSH_OPTS=-i /ghe-ssh/id_rsa -o UserKnownHostsFile=/ghe-ssh/known_hosts" \`