### PR TITLE
Add GHE_BACKUP_SKIP_PAGES and GHE_RESTORE_SKIP_PAGES config settings

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -48,3 +48,12 @@ GHE_NUM_SNAPSHOTS=10
 #
 # WARNING: do not enable this, only useful for debugging/development
 #GHE_BACKUP_FSCK=no
+
+# If set to 'yes', ghe-backup will omit the backup of Pages artifacts.
+#
+#GHE_BACKUP_SKIP_PAGES=no
+
+# If set to 'yes', ghe-restore will omit the restore of Pages artifacts
+# contained in the backup and will rebuild them instead.
+#
+#GHE_RESTORE_SKIP_PAGES=no

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -189,7 +189,7 @@ ghe-backup-es-hookshot || failures="$failures hookshot"
 echo "Backing up Git repositories ..."
 ghe-backup-repositories || failures="$failures repositories"
 
-if [ "$GHE_RESTORE_SKIP_PAGES" = "yes" ]; then
+if [ "$GHE_BACKUP_SKIP_PAGES" = "yes" ]; then
   echo "Skipping backup of GitHub Pages artifacts ..."
 else
   echo "Backing up GitHub Pages artifacts ..."

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -5,10 +5,9 @@
 #/ the MySQL database, instance settings, GitHub Pages data, etc.
 #/
 #/ OPTIONS:
-#/   -v | --verbose       Enable verbose output.
-#/   -h | --help          Show this message.
-#/        --version       Display version information.
-#/        --skip-pages    Skip backup of GitHub Pages artifacts.
+#/   -v | --verbose    Enable verbose output.
+#/   -h | --help       Show this message.
+#/        --version    Display version information.
 #/
 
 set -e
@@ -26,10 +25,6 @@ while true; do
       ;;
     -v|--verbose)
       export GHE_VERBOSE=true
-      shift
-      ;;
-    --skip-pages)
-      export GHE_SKIP_PAGES=true
       shift
       ;;
     -*)
@@ -194,11 +189,11 @@ ghe-backup-es-hookshot || failures="$failures hookshot"
 echo "Backing up Git repositories ..."
 ghe-backup-repositories || failures="$failures repositories"
 
-if [ -z "$GHE_SKIP_PAGES" ]; then
+if [ "$GHE_RESTORE_SKIP_PAGES" = "yes" ]; then
+  echo "Skipping backup of GitHub Pages artifacts ..."
+else
   echo "Backing up GitHub Pages artifacts ..."
   ghe-backup-pages || failures="$failures pages"
-else
-  echo "Skipping backup of GitHub Pages artifacts ..."
 fi
 
 echo "Backing up storage data ..."

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -5,9 +5,10 @@
 #/ the MySQL database, instance settings, GitHub Pages data, etc.
 #/
 #/ OPTIONS:
-#/   -v | --verbose    Enable verbose output.
-#/   -h | --help       Show this message.
-#/        --version    Display version information.
+#/   -v | --verbose       Enable verbose output.
+#/   -h | --help          Show this message.
+#/        --version       Display version information.
+#/        --skip-pages    Skip backup of GitHub Pages artifacts.
 #/
 
 set -e
@@ -25,6 +26,10 @@ while true; do
       ;;
     -v|--verbose)
       export GHE_VERBOSE=true
+      shift
+      ;;
+    --skip-pages)
+      export GHE_SKIP_PAGES=true
       shift
       ;;
     -*)
@@ -189,8 +194,12 @@ ghe-backup-es-hookshot || failures="$failures hookshot"
 echo "Backing up Git repositories ..."
 ghe-backup-repositories || failures="$failures repositories"
 
-echo "Backing up GitHub Pages ..."
-ghe-backup-pages || failures="$failures pages"
+if [ -z "$GHE_SKIP_PAGES" ]; then
+  echo "Backing up GitHub Pages artifacts ..."
+  ghe-backup-pages || failures="$failures pages"
+else
+  echo "Skipping backup of GitHub Pages artifacts ..."
+fi
 
 echo "Backing up storage data ..."
 ghe-backup-storage || failures="$failures storage"

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -271,8 +271,12 @@ if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.13.0)" ]; the
   if [ "$GHE_RESTORE_SKIP_PAGES" = "yes" ]; then
     echo "Skipping restore of GitHub Pages artifacts ..."
   else
-    echo "Restoring GitHub Pages artifacts ..."
-    ghe-restore-pages "$GHE_HOSTNAME" 1>&3
+    if [ -d "$GHE_RESTORE_SNAPSHOT_PATH/pages" ]; then
+        echo "Restoring GitHub Pages artifacts ..."
+        ghe-restore-pages "$GHE_HOSTNAME" 1>&3
+    else
+        echo "No GitHub Pages artifacts found in backup, skipping restore ..."
+    fi
   fi
 else
   echo "Restoring Git repositories and Gists ..."

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -14,7 +14,7 @@
 #/                        datastores. Settings are not restored by default to
 #/                        prevent overwriting different configuration on the
 #/                        restore host.
-#/        --skip-pages    Skip backup of GitHub Pages artifacts.
+#/        --skip-pages    Skip restore of GitHub Pages artifacts.
 #/   -v | --verbose       Enable verbose output.
 #/   -h | --help          Show this message.
 #/        --version       Display version information and exit.

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -9,21 +9,22 @@
 #/ <https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access>
 #/
 #/ OPTIONS:
-#/   -f | --force      Don't prompt for confirmation before restoring.
-#/   -c | --config     Restore appliance settings and license in addition to
-#/                     datastores. Settings are not restored by default to
-#/                     prevent overwriting different configuration on the
-#/                     restore host.
-#/   -v | --verbose    Enable verbose output.
-#/   -h | --help       Show this message.
-#/        --version    Display version information and exit.
-#/   -s <snapshot-id>  Restore from the snapshot with the given id. Available
-#/                     snapshots may be listed under the data directory.
-#/   <host>            The <host> is the hostname or IP of the GitHub Enterprise
-#/                     instance. The <host> may be omitted when the
-#/                     GHE_RESTORE_HOST config variable is set in backup.config.
-#/                     When a <host> argument is provided, it always overrides
-#/                     the configured restore host.
+#/   -f | --force         Don't prompt for confirmation before restoring.
+#/   -c | --config        Restore appliance settings and license in addition to
+#/                        datastores. Settings are not restored by default to
+#/                        prevent overwriting different configuration on the
+#/                        restore host.
+#/        --skip-pages    Skip backup of GitHub Pages artifacts.
+#/   -v | --verbose       Enable verbose output.
+#/   -h | --help          Show this message.
+#/        --version       Display version information and exit.
+#/   -s <snapshot-id>     Restore from the snapshot with the given id. Available
+#/                        snapshots may be listed under the data directory.
+#/   <host>               The <host> is the hostname or IP of the GitHub Enterprise
+#/                        instance. The <host> may be omitted when the
+#/                        GHE_RESTORE_HOST config variable is set in backup.config.
+#/                        When a <host> argument is provided, it always overrides
+#/                        the configured restore host.
 #/
 
 set -e
@@ -43,6 +44,10 @@ while true; do
       ;;
     -c|--config)
       restore_settings=true
+      shift
+      ;;
+    --skip-pages)
+      export GHE_SKIP_PAGES=true
       shift
       ;;
     -h|--help)
@@ -268,8 +273,12 @@ if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.13.0)" ]; the
   echo "Restoring Gists ..."
   ghe-restore-repositories-gist "$GHE_HOSTNAME"
 
-  echo "Restoring GitHub Pages ..."
-  ghe-restore-pages "$GHE_HOSTNAME" 1>&3
+  if [ -z "$GHE_SKIP_PAGES" ]; then
+    echo "Restoring GitHub Pages artifacts ..."
+    ghe-restore-pages "$GHE_HOSTNAME" 1>&3
+  else
+    echo "Skipping restore of GitHub Pages artifacts ..."
+  fi
 else
   echo "Restoring Git repositories and Gists ..."
   ghe-restore-repositories-rsync "$GHE_HOSTNAME" 1>&3

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -9,22 +9,21 @@
 #/ <https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access>
 #/
 #/ OPTIONS:
-#/   -f | --force         Don't prompt for confirmation before restoring.
-#/   -c | --config        Restore appliance settings and license in addition to
-#/                        datastores. Settings are not restored by default to
-#/                        prevent overwriting different configuration on the
-#/                        restore host.
-#/        --skip-pages    Skip restore of GitHub Pages artifacts.
-#/   -v | --verbose       Enable verbose output.
-#/   -h | --help          Show this message.
-#/        --version       Display version information and exit.
-#/   -s <snapshot-id>     Restore from the snapshot with the given id. Available
-#/                        snapshots may be listed under the data directory.
-#/   <host>               The <host> is the hostname or IP of the GitHub Enterprise
-#/                        instance. The <host> may be omitted when the
-#/                        GHE_RESTORE_HOST config variable is set in backup.config.
-#/                        When a <host> argument is provided, it always overrides
-#/                        the configured restore host.
+#/   -f | --force      Don't prompt for confirmation before restoring.
+#/   -c | --config     Restore appliance settings and license in addition to
+#/                     datastores. Settings are not restored by default to
+#/                     prevent overwriting different configuration on the
+#/                     restore host.
+#/   -v | --verbose    Enable verbose output.
+#/   -h | --help       Show this message.
+#/        --version    Display version information and exit.
+#/   -s <snapshot-id>  Restore from the snapshot with the given id. Available
+#/                     snapshots may be listed under the data directory.
+#/   <host>            The <host> is the hostname or IP of the GitHub Enterprise
+#/                     instance. The <host> may be omitted when the
+#/                     GHE_RESTORE_HOST config variable is set in backup.config.
+#/                     When a <host> argument is provided, it always overrides
+#/                     the configured restore host.
 #/
 
 set -e
@@ -44,10 +43,6 @@ while true; do
       ;;
     -c|--config)
       restore_settings=true
-      shift
-      ;;
-    --skip-pages)
-      export GHE_SKIP_PAGES=true
       shift
       ;;
     -h|--help)
@@ -273,11 +268,11 @@ if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.13.0)" ]; the
   echo "Restoring Gists ..."
   ghe-restore-repositories-gist "$GHE_HOSTNAME"
 
-  if [ -z "$GHE_SKIP_PAGES" ]; then
+  if [ "$GHE_RESTORE_SKIP_PAGES" = "yes" ]; then
+    echo "Skipping restore of GitHub Pages artifacts ..."
+  else
     echo "Restoring GitHub Pages artifacts ..."
     ghe-restore-pages "$GHE_HOSTNAME" 1>&3
-  else
-    echo "Skipping restore of GitHub Pages artifacts ..."
   fi
 else
   echo "Restoring Git repositories and Gists ..."

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -23,16 +23,7 @@ GHE_HOSTNAME="$1"
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
 # Find the pages to restore
-check_pages=$(cd $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/ && find pages -mindepth 5 -maxdepth 5 2> /dev/null)
-
-# Check if there were pages in backup, if no skip restore 
-if [[ $? -ne 0 ]]; then
-  echo "Skipping: No Pages artifact backup ..."
-  exit 0
-fi
-
-#  Otherwise Find the path
-pages_paths="$(echo "$check_pages" | cut -d / -f2-)"
+pages_paths=$(cd $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/ && find pages -mindepth 5 -maxdepth 5 | cut -d / -f2-)
 
 # No need to restore anything, early exit
 if [ -z "$pages_paths" ]; then

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -23,7 +23,17 @@ GHE_HOSTNAME="$1"
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
 # Find the pages to restore
-pages_paths=$(cd $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/ && find pages -mindepth 5 -maxdepth 5 | cut -d / -f2-)
+
+check_pages=$(cd $GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/ && find pages -mindepth 5 -maxdepth 5 2> /dev/null)
+
+# Check if there were pages in backup, if no skip restore 
+if [[ $? -ne 0 ]]; then
+  echo "Skipping: No Pages artifact backup ..."
+  exit 0
+fi
+
+#  Otherwise Find the path
+pages_paths="$(echo "$check_pages" | cut -d / -f2-)"
 
 # No need to restore anything, early exit
 if [ -z "$pages_paths" ]; then


### PR DESCRIPTION
If `GHE_BACKUP_SKIP_PAGES` is set to 'yes', `ghe-backup` will omit the backup of generated Pages artifacts.

If `GHE_RESTORE_SKIP_PAGE` is set to 'yes', `ghe-restore` will omit the restore of Pages artifacts contained in the backup and will rebuild them instead.