### PR TITLE
Output MySQL backup strategy for clarity during backup and restore

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -180,7 +180,11 @@ ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-ssh-host-keys' > ssh-host-keys.tar ||
 failures="$failures ssh-host-keys"
 bm_end "ghe-export-ssh-host-keys"
 
-echo "Backing up MySQL database ..."
+if is_binary_backup_feature_on; then
+  echo "Backing up MySQL database using binary backup ..."
+else
+  echo "Backing up MySQL database using logical backup ..."
+fi
 ghe-backup-mysql || failures="$failures mysql"
 
 commands=("

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -181,9 +181,9 @@ failures="$failures ssh-host-keys"
 bm_end "ghe-export-ssh-host-keys"
 
 if is_binary_backup_feature_on; then
-  echo "Backing up MySQL database using binary backup ..."
+  echo "Backing up MySQL database using binary backup strategy ..."
 else
-  echo "Backing up MySQL database using logical backup ..."
+  echo "Backing up MySQL database using logical backup strategy ..."
 fi
 ghe-backup-mysql || failures="$failures mysql"
 

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -255,7 +255,19 @@ if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
   ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft"
   fi
 
-echo "Restoring MySQL database ..."
+if is_binary_backup_feature_on; then
+  appliance_strategy="binary"
+else
+  appliance_strategy="logical"
+fi
+
+if is_binary_backup "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"; then
+  backup_snapshot_strategy="binary"
+else
+  backup_snapshot_strategy="logical"
+fi
+
+echo "Restoring MySQL database from ${backup_snapshot_strategy} backup snapshot on an appliance configured for ${appliance_strategy} backups ..."
 ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
 
 commands=("
@@ -318,7 +330,7 @@ if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.12.9)" ]; the
     echo \"Restoring Audit logs ...\"
     ghe-restore-es-audit-log \"$GHE_HOSTNAME\" 1>&3")
   fi
-  
+
   commands+=("
   echo \"Restoring hookshot logs ...\"
   ghe-restore-es-hookshot \"$GHE_HOSTNAME\" 1>&3")

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -385,3 +385,8 @@ fix_paths_for_ghe_version() {
 is_binary_backup_feature_on(){
   ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
 }
+
+# Check if the backup is binary by looking up the sentinel file
+is_binary_backup(){
+  test -f "$1/mysql-binary-backup-sentinel"
+}

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -381,3 +381,7 @@ fix_paths_for_ghe_version() {
   # GHES), then don't modify lines with "gist" in them.
   sed $GIST_FILTER -e 's/\/$//; s/^[^\/]*$/./; s/\/[^\/]*$//'
 }
+
+is_binary_backup_feature_on(){
+  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
+}

--- a/share/github-backup-utils/ghe-backup-mysql
+++ b/share/github-backup-utils/ghe-backup-mysql
@@ -15,11 +15,6 @@ bm_start "$(basename $0)"
 # Perform a host-check and establish the remote version in GHE_REMOTE_VERSION.
 ghe_remote_version_required "$GHE_HOSTNAME"
 
-# if we are going to take a binary backup
-is_binary_backup_feature_on(){
-  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
-}
-
 export_command="ghe-export-mysql"
 if ! is_binary_backup_feature_on; then
   # binary backup is already compressed

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -28,18 +28,13 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # The directory holding the snapshot to restore
 snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 
-# Check if the backup is binary by looking up the sentinel file
-is_binary_backup(){
-  test -f $snapshot_dir/mysql-binary-backup-sentinel
-}
-
 if is_binary_backup_feature_on; then
   echo "Appliance is configured for binary backups."
 else
   echo "Appliance is configured for logical backups."
 fi
 
-if is_binary_backup; then
+if is_binary_backup $snapshot_dir; then
   echo "Backup being restored is a binary backup."
 else
   echo "Backup being restored is a logical backup."
@@ -48,7 +43,7 @@ fi
 ssh_config_file_opt=
 if is_binary_backup_feature_on; then
   # Feature "mysql.backup.binary" is on, which means new backup scripts are available
-  if is_binary_backup; then
+  if is_binary_backup $snapshot_dir; then
     if $CLUSTER ; then
       ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
       if [ -z $ghe_mysql_master ]; then
@@ -81,7 +76,7 @@ if is_binary_backup_feature_on; then
   fi
 else
   # We do not allow to restore binary backup without "mysql.backup.binary" set
-  if is_binary_backup; then
+  if is_binary_backup $snapshot_dir; then
     echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2
     exit 2
   else

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -33,6 +33,18 @@ is_binary_backup(){
   test -f $snapshot_dir/mysql-binary-backup-sentinel
 }
 
+if is_binary_backup_feature_on; then
+  echo "Appliance is configured for binary backups."
+else
+  echo "Appliance is configured for logical backups."
+fi
+
+if is_binary_backup; then
+  echo "Backup being restored is a binary backup."
+else
+  echo "Backup being restored is a logical backup."
+fi
+
 ssh_config_file_opt=
 if is_binary_backup_feature_on; then
   # Feature "mysql.backup.binary" is on, which means new backup scripts are available

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -31,7 +31,7 @@ snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 ssh_config_file_opt=
 if is_binary_backup_feature_on; then
   # Feature "mysql.backup.binary" is on, which means new backup scripts are available
-  if is_binary_backup $snapshot_dir; then
+  if is_binary_backup "$snapshot_dir"; then
     if $CLUSTER ; then
       ghe_mysql_master=$(ghe-ssh "$GHE_HOSTNAME" ghe-config "cluster.mysql-master")
       if [ -z $ghe_mysql_master ]; then
@@ -64,7 +64,7 @@ if is_binary_backup_feature_on; then
   fi
 else
   # We do not allow to restore binary backup without "mysql.backup.binary" set
-  if is_binary_backup $snapshot_dir; then
+  if is_binary_backup "$snapshot_dir"; then
     echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2
     exit 2
   else

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -28,14 +28,9 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # The directory holding the snapshot to restore
 snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 
-# Check if the backup is binary by looking up the sentinel file 
+# Check if the backup is binary by looking up the sentinel file
 is_binary_backup(){
-  test -f $snapshot_dir/mysql-binary-backup-sentinel 
-}
-
-# if mysql.backup.binary feature flag is on
-is_binary_backup_feature_on(){
-  ghe-ssh "$GHE_HOSTNAME" ghe-config --true "mysql.backup.binary"
+  test -f $snapshot_dir/mysql-binary-backup-sentinel
 }
 
 ssh_config_file_opt=
@@ -59,7 +54,7 @@ if is_binary_backup_feature_on; then
       ghe_mysql_master=$GHE_HOSTNAME
     fi
 
-    # Check if the decompress needed by looking into the sentinel file 
+    # Check if the decompress needed by looking into the sentinel file
     # In 2.19.5 we compress the binary backup twice
     if [ "$(cat $snapshot_dir/mysql-binary-backup-sentinel)" = "NO_ADDITIONAL_COMPRESSION" ]; then
       IMPORT_MYSQL=ghe-import-mysql-xtrabackup
@@ -73,9 +68,9 @@ if is_binary_backup_feature_on; then
     GHE_RESTORE_HOST=$GHE_HOSTNAME
   fi
 else
-  # We do not allow to restore binary backup without "mysql.backup.binary" set 
+  # We do not allow to restore binary backup without "mysql.backup.binary" set
   if is_binary_backup; then
-    echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2  
+    echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2
     exit 2
   else
     # legacy mode

--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -28,18 +28,6 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 # The directory holding the snapshot to restore
 snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 
-if is_binary_backup_feature_on; then
-  echo "Appliance is configured for binary backups."
-else
-  echo "Appliance is configured for logical backups."
-fi
-
-if is_binary_backup $snapshot_dir; then
-  echo "Backup being restored is a binary backup."
-else
-  echo "Backup being restored is a logical backup."
-fi
-
 ssh_config_file_opt=
 if is_binary_backup_feature_on; then
   # Feature "mysql.backup.binary" is on, which means new backup scripts are available


### PR DESCRIPTION
Adds some verbosity around logical vs binary backups as configured on the appliance, as well as if the snapshot itself in the restore process is binary vs logical

Backup output with binary backups not set:
```
$ ./backup-utils/bin/ghe-backup 
Starting backup of 10.0.1.171 with backup-utils v2.21 in snapshot 20200514T035830
Connect 10.0.1.171:122 OK (v2.21.0)
Backing up GitHub settings ...
Backing up SSH authorized keys ...
Backing up SSH host keys ...
Backing up MySQL database using logical backup strategy ...
```

Backup output with binary backups set:
```
$ ./backup-utils/bin/ghe-backup 
Starting backup of 10.0.1.171 with backup-utils v2.21 in snapshot 20200514T035902
Connect 10.0.1.171:122 OK (v2.21.0)
Backing up GitHub settings ...
Backing up SSH authorized keys ...
Backing up SSH host keys ...
Backing up MySQL database using binary backup strategy ...
```

Restore output against logical appliance with logical backup:
```
$ ./bin/ghe-restore -s 20200514T045636 10.0.1.171
Checking for leaked keys in the backup snapshot that is being restored ...
* No leaked keys found
Connect 10.0.1.171:122 OK (v2.21.0)

WARNING: All data on GitHub Enterprise appliance 10.0.1.171 (v2.21.0)
         will be overwritten with data from snapshot 20200514T045636.
Please verify that this is the correct restore host before continuing.
Type 'yes' to continue: yes

Starting restore of 10.0.1.171:122 with backup-utils v2.21 from snapshot 20200514T045636
Stopping cron and github-timerd ...
Restoring UUID ...
Restoring MySQL database from logical backup snapshot on an appliance configured for logical backups ...
```

Restore output against binary appliance with logical backup:
```
$ ./bin/ghe-restore -s 20200514T045636 10.0.1.171
Checking for leaked keys in the backup snapshot that is being restored ...
* No leaked keys found
Connect 10.0.1.171:122 OK (v2.21.0)

WARNING: All data on GitHub Enterprise appliance 10.0.1.171 (v2.21.0)
         will be overwritten with data from snapshot 20200514T045636.
Please verify that this is the correct restore host before continuing.
Type 'yes' to continue: yes

Starting restore of 10.0.1.171:122 with backup-utils v2.21 from snapshot 20200514T045636
Stopping cron and github-timerd ...
Restoring UUID ...
Restoring MySQL database from logical backup snapshot on an appliance configured for binary backups ...
```