### PR TITLE
turn off posix for ghe-backup-config

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -13,7 +13,7 @@
 #
 #     . $( dirname "${BASH_SOURCE[0]}" )/../share/github-backup-utils/ghe-backup-config
 #
-
+set +o posix
 # Assume this script lives in share/github-backup-utils/ when setting the root
 GHE_BACKUP_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 


### PR DESCRIPTION
we use process substitution on line 125 which isn't supported with posix. We are explicitly turning posix off for this script.