### PR TITLE
ghe-restore: fix import of authorized keys

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -260,6 +260,9 @@ bm_start "ghe-import-redis"
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-redis' < "$GHE_RESTORE_SNAPSHOT_PATH/redis.rdb" 1>&3
 bm_end "ghe-import-redis"
 
+echo "Restoring SSH authorized keys ..."
+ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-authorized-keys' < "$GHE_RESTORE_SNAPSHOT_PATH/authorized-keys.json" 1>&3
+
 # Unified and enhanced restore method to 2.13.0 and newer
 if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.13.0)" ]; then
   echo "Restoring Git repositories ..."
@@ -278,9 +281,6 @@ else
   ghe-restore-pages-rsync "$GHE_HOSTNAME" 1>&3
 fi
 
-
-echo "Restoring SSH authorized keys ..."
-ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-authorized-keys' < "$GHE_RESTORE_SNAPSHOT_PATH/authorized-keys.json" 1>&3
 
 echo "Restoring storage data ..."
 ghe-restore-storage "$GHE_HOSTNAME" 1>&3


### PR DESCRIPTION
**Summary**

`ghe-restore-*-rsync` scripts use _rsync over ssh_ hence need contents of `authorized_keys` restored and in place to work as expected.

**Context**

Problem manifested itself during restore of GHE, we observed `rsync` failing due to a mysterious 'unexplained error':

```
sudo -u github-backup ghe-restore --verbose 1.2.4.8
Checking for leaked keys in the backup snapshot that is being restored ...
* No leaked keys found
The authenticity of host '[1.2.4.8]:122 ([1.2.4.8]:122)' can't be established.
ECDSA key fingerprint is SHA256:N3NJ7ueSgq+8yTCc+0ySiHfPfn/nKleTfqnzthaRj1Q.
Are you sure you want to continue connecting (yes/no)? yes
Connect 1.2.4.8:122 OK (v2.20.19)
Starting restore of 1.2.4.8:122 with backup-utils v2.20.2 from snapshot 20201021T100026
Stopping cron and github-timerd ...
Restoring license ...
Restoring settings ...
--> Importing settings data /data/user/common/github.conf...
Oct 21 10:19:38 Preparing storage device...
Oct 21 10:19:38 Updating configuration...
Oct 21 10:19:39 Reloading system services...
Oct 21 10:20:14 Done!
Restoring management console password ...
Restoring SAML keys ...
Restoring CA certificates ...
--> Importing custom CA certificates...
--> Updating CA certificates...
--> Done.
Restoring UUID ...
Restoring MySQL database ...
Oct 21 10:20:31 --> Importing MySQL data...
Restoring Redis database ...
--> Stopping redis...
--> Importing redis data...
--> Starting redis...
Restoring Git repositories ...
* Adding network_path 6/nw/64/2e/92/48 to the list of networks to send
(..)
* Adding network_path 7/nw/7c/9d/0b/1134 to the list of networks to send
* Transferring repository networks to 1.2.4.8 ...
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: unexplained error (code 255) at io.c(226) [sender=3.1.1]
```

Upon closer examination we confirmed `ghe-restore` completing initial steps without issues:

```
Checking for leaked keys in the backup snapshot that is being restored ...
* No leaked keys found
Connect 1.2.4.8:122 OK (v2.20.19)
Starting restore of 1.2.4.8:122 with backup-utils v2.20.2 from snapshot 20201021T170026
Stopping cron and github-timerd ...
Restoring license ...
Restoring settings ...
--> Importing settings data /data/user/common/github.conf...
Oct 21 10:19:38 Preparing storage device...
Oct 21 10:19:38 Updating configuration...
Oct 21 10:19:39 Reloading system services...
Oct 21 10:20:14 Done!
Restoring management console password ...
Restoring SAML keys ...
Restoring CA certificates ...
--> Importing custom CA certificates...
--> Updating CA certificates...
--> Done.
Restoring UUID ...
Restoring MySQL database ...
Oct 21 10:20:31 --> Importing MySQL data...
Restoring Redis database ...
--> Stopping redis...
--> Importing redis data...
--> Starting redis...
Restoring Git repositories ...
```

and only failing later, when `ghe-restore-*-rsync` commands are called.

It turned out that `ghe-restore` resets `/home/admin/.ssh/authorized_keys` early in the process (`ghe-import-settings` called during _Restoring settings_ step) and that presents a problem for the `ghe-restore-*-rsync` commands (_ssh_ remote shell needs  `authorized_keys` for auth purposes).