### PR TITLE
remove ghe-service-ensure-mysql

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -273,7 +273,7 @@ fi
 # These services will not have been started on appliances that have not been
 # configured yet.
 if ! $CLUSTER; then
-  echo "sudo ghe-service-ensure-mysql && sudo ghe-service-ensure-elasticsearch" |
+  echo "sudo ghe-service-ensure-elasticsearch" |
   ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
 fi
 

--- a/test/bin/ghe-service-ensure-elasticsearch
+++ b/test/bin/ghe-service-ensure-elasticsearch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Usage: ghe-service-ensure-mysql
-# Emulates the remote GitHub ghe-service-ensure-mysql command. Tests use this
+# Usage: ghe-service-ensure-elasticsearch
+# Emulates the remote GitHub ghe-service-ensure-elasticsearch command. Tests use this
 # to assert that the command was executed.
 set -e
 echo "ghe-service-ensure-elasticsearch OK"

--- a/test/bin/ghe-service-ensure-mysql
+++ b/test/bin/ghe-service-ensure-mysql
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Usage: ghe-service-ensure-mysql
-# Emulates the remote GitHub ghe-service-ensure-mysql command. Tests use this
-# to assert that the command was executed.
-set -e
-echo "ghe-service-ensure-mysql OK"


### PR DESCRIPTION
Remove `ghe-service-ensure-mysql `, as this file is deleted from https://github.com/github/enterprise2/pull/23694.

This cause lots of test failing in enterprise2
```
  The certificate file is empty.
    sudo: ghe-service-ensure-mysql: command not found
    ++<test-migration.sh:1> kill 20336
    +<test-migration.sh:77 lib.sh:293 end_test()> test_status=1
```