### PR TITLE
Backup and restore password pepper

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -40,6 +40,7 @@ backup-secret() {
 }
 
 backup-secret "management console password" "manage-password" "secrets.manage"
+backup-secret "password pepper" "password-pepper" "secrets.github.user-password-secrets"
 
 # Backup external MySQL password if running external MySQL DB.
 if is_service_external 'mysql'; then

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -40,6 +40,8 @@ restore-secret "external MySQL password" "external-mysql-password" "secrets.exte
 
 # Restore management console password hash if present.
 restore-secret "management console password" "manage-password" "secrets.manage"
+# Restore password pepper if present
+restore-secret "password pepper" "password-pepper" "secrets.github.user-password-secrets"
 
 # Restore SAML keys if present.
 if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/saml-keys.tar" ]; then

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -121,6 +121,17 @@ begin_test "ghe-backup without management console password"
 )
 end_test
 
+begin_test "ghe-backup without password pepper"
+(
+  set -e
+
+  git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.github.user-password-secrets ""
+  ghe-backup
+
+  [ ! -f "$GHE_DATA_DIR/current/password-pepper" ]
+)
+end_test
+
 begin_test "ghe-backup empty hookshot directory"
 (
   set -e

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -197,6 +197,10 @@ setup_test_data () {
   mkdir -p "$GHE_REMOTE_DATA_USER_DIR/common"
   git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.manage "fake password hash data"
 
+  # Create a fake password pepper file
+  mkdir -p "$GHE_REMOTE_DATA_USER_DIR/common"
+  git config -f "$GHE_REMOTE_DATA_USER_DIR/common/secrets.conf" secrets.github.user-password-secrets "fake password pepper data"
+
   # Create some fake hooks in the remote data directory
   mkdir -p "$loc/git-hooks/environments/tarballs"
   mkdir -p "$loc/git-hooks/repos"
@@ -311,6 +315,7 @@ setup_test_data () {
     echo "fake ghe-export-ssl-ca-certificates data" > "$loc/ssl-ca-certificates.tar"
     echo "fake license data" > "$loc/enterprise.ghl"
     echo "fake password hash data" > "$loc/manage-password"
+    echo "fake password pepper data" > "$loc/password-pepper"
     echo "rsync" > "$loc/strategy"
     echo "$GHE_REMOTE_VERSION" >  "$loc/version"
   fi
@@ -414,6 +419,9 @@ verify_all_backedup_data() {
 
   # verify manage-password file was backed up
   [ "$(cat "$GHE_DATA_DIR/current/manage-password")" = "fake password hash data" ]
+
+  # verify password pepper file was backed up
+  [ "$(cat "$GHE_DATA_DIR/current/password-pepper")" = "fake password pepper data" ]
 
   # check that ca certificates were backed up
   [ "$(cat "$GHE_DATA_DIR/current/ssl-ca-certificates.tar")" = "fake ghe-export-ssl-ca-certificates data" ]


### PR DESCRIPTION
For built in authentication an upcoming release will have a password pepper (see https://en.wikipedia.org/wiki/Pepper_(cryptography)). This needs to be backed up and restored to ensure passwords keep working across backup / restore cycles.