### PR TITLE
Only run ghe-nomad-cleanup in 3.0

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -408,11 +408,15 @@ echo "sudo restart -q memcached 2>/dev/null || true" |
 # config run to perform data migrations.
 if $CLUSTER; then
   echo "Configuring cluster ..."
-  ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- ghe-nomad-cleanup"
+  if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- ghe-nomad-cleanup"
+  fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-config-apply" 1>&3 2>&3
 elif $instance_configured; then
   echo "Configuring appliance ..."
-  ghe-ssh "$GHE_HOSTNAME" -- "ghe-nomad-cleanup"
+  if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "ghe-nomad-cleanup"
+  fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-config-apply" 1>&3 2>&3
 fi
 


### PR DESCRIPTION
Back-compat issue from https://github.com/github/backup-utils/pull/661: Only run ghe-nomad-cleanup in 3.0