### PR TITLE
Cleanup nomad container when restore for 2.22

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -49,9 +49,9 @@ fi
 
 if "$CLUSTER"; then
   node_version_list=$(ghe-ssh "$host" ghe-cluster-each -- ghe-version)
-  echo "$node_version_list" 1>&2
-  distinct_versions=$(echo "$node_version_list" | awk '{split($0, a, ":"); print a[2]}' | uniq | wc -l)
+  distinct_versions=$(echo "$node_version_list" | awk '{split($0, a, ":"); print a[2]}' | awk '{print $4}' | uniq | wc -l)
   if [ "$distinct_versions" -ne 1 ]; then
+    echo "$node_version_list" 1>&2
     echo "Error: Not all nodes are running the same version! Please ensure all nodes are running the same version before using backup-utils." 1>&2
     exit 1
   fi

--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -41,22 +41,6 @@ done
 # $GHE_HOSTNAME configured in backup.config when not present.
 host="${1:-$GHE_HOSTNAME}"
 
-CLUSTER=false
-if ghe-ssh "$host" -- \
-  "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/cluster' ]"; then
-  CLUSTER=true
-fi
-
-if "$CLUSTER"; then
-  node_version_list=$(ghe-ssh "$host" ghe-cluster-each -- ghe-version)
-  distinct_versions=$(echo "$node_version_list" | awk '{split($0, a, ":"); print a[2]}' | awk '{print $4}' | uniq | wc -l)
-  if [ "$distinct_versions" -ne 1 ]; then
-    echo "$node_version_list" 1>&2
-    echo "Error: Not all nodes are running the same version! Please ensure all nodes are running the same version before using backup-utils." 1>&2
-    exit 1
-  fi
-fi
-
 # Options to pass to SSH during connection check
 options="
   -o PasswordAuthentication=no
@@ -98,6 +82,23 @@ if [ $rc -ne 0 ]; then
 
   esac
   exit $rc
+fi
+
+CLUSTER=false
+if ghe-ssh "$host" -- \
+  "[ -f '$GHE_REMOTE_ROOT_DIR/etc/github/cluster' ]"; then
+  CLUSTER=true
+fi
+
+# ensure all nodes in the cluster are running the same version
+if "$CLUSTER"; then
+  node_version_list=$(ghe-ssh "$host" ghe-cluster-each -- ghe-version)
+  distinct_versions=$(echo "$node_version_list" | awk '{split($0, a, ":"); print a[2]}' | awk '{print $4}' | uniq | wc -l)
+  if [ "$distinct_versions" -ne 1 ]; then
+    echo "$node_version_list" 1>&2
+    echo "Error: Not all nodes are running the same version! Please ensure all nodes are running the same version before using backup-utils." 1>&2
+    exit 1
+  fi
 fi
 
 version=$(echo "$output" | grep "GitHub Enterprise" | awk '{print $NF}')

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -410,7 +410,7 @@ if $CLUSTER; then
   echo "Configuring cluster ..."
   if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-nomad-cleanup" 1>&3 2>&3
-  elif [ "$GHE_VERSION_MAJOR" -eq "2" ] &&   [ "$GHE_VERSION_MINOR" -eq "22" ]; then
+  elif [ "$GHE_VERSION_MAJOR" -eq "2" ] && [ "$GHE_VERSION_MINOR" -eq "22" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- /usr/local/share/enterprise/ghe-nomad-cleanup" 1>&3 2>&3
   fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-config-apply" 1>&3 2>&3
@@ -418,7 +418,7 @@ elif $instance_configured; then
   echo "Configuring appliance ..."
   if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-nomad-cleanup" 1>&3 2>&3
-  elif [ "$GHE_VERSION_MAJOR" -eq "2" ] &&   [ "$GHE_VERSION_MINOR" -eq "22" ]; then
+  elif [ "$GHE_VERSION_MAJOR" -eq "2" ] && [ "$GHE_VERSION_MINOR" -eq "22" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "/usr/local/share/enterprise/ghe-nomad-cleanup" 1>&3 2>&3
   fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-config-apply" 1>&3 2>&3

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -410,12 +410,16 @@ if $CLUSTER; then
   echo "Configuring cluster ..."
   if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-nomad-cleanup" 1>&3 2>&3
+  elif [ "$GHE_VERSION_MAJOR" -eq "2" ] &&   [ "$GHE_VERSION_MINOR" -eq "22" ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- /usr/local/share/enterprise/ghe-nomad-cleanup" 1>&3 2>&3
   fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-config-apply" 1>&3 2>&3
 elif $instance_configured; then
   echo "Configuring appliance ..."
   if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-nomad-cleanup" 1>&3 2>&3
+  elif [ "$GHE_VERSION_MAJOR" -eq "2" ] &&   [ "$GHE_VERSION_MINOR" -eq "22" ]; then
+    ghe-ssh "$GHE_HOSTNAME" -- "/usr/local/share/enterprise/ghe-nomad-cleanup" 1>&3 2>&3
   fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-config-apply" 1>&3 2>&3
 fi

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -28,7 +28,7 @@ GHE_RESTORE_SNAPSHOT_PATH="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 echo "Restoring license ..."
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-import-license' < "$GHE_RESTORE_SNAPSHOT_PATH/enterprise.ghl" 1>&3
 
-echo "Restoring settings ..."
+echo "Restoring settings and applying configuration ..."
 
 # Restore external MySQL password if running external MySQL DB.
 restore-secret "external MySQL password" "external-mysql-password" "secrets.external.mysql"

--- a/test/bin/ghe-cluster-each
+++ b/test/bin/ghe-cluster-each
@@ -16,10 +16,17 @@ for _ in "$@"; do
         shift
         shift
         ;;
+    --)
+      if [ "$1" = "--" ]; then
+        shift
+        COMMAND="$*"
+      fi
+      break
+      ;;
   esac
 done
 
-if [ "$2" == "ghe-version" ]; then
+if [ "$COMMAND" == "ghe-version" ]; then
   if [ -z "$DIFFERENT_VERSIONS" ]; then
     echo "fake-uuid: GitHub Enterprise Server 3.1.0 lxc 2020-12-16 5e97c07602"
     echo "fake-uuid1: GitHub Enterprise Server 3.1.0 lxc 2020-12-16 5e97c07602"
@@ -32,7 +39,7 @@ if [ "$2" == "ghe-version" ]; then
   exit 0
 fi
 
-if [ "$2" == "/usr/local/share/enterprise/ghe-nomad-cleanup" ]; then
+if [ "$COMMAND" == "/usr/local/share/enterprise/ghe-nomad-cleanup" ]; then
   echo "nomad cleanup"
   exit 0
 fi

--- a/test/bin/ghe-cluster-each
+++ b/test/bin/ghe-cluster-each
@@ -4,6 +4,8 @@
 # to assert that the command was executed.
 set -e
 
+SHOW_UUID=false
+
 for _ in "$@"; do
   case "$1" in
     -u)
@@ -16,6 +18,13 @@ for _ in "$@"; do
         shift
         shift
         ;;
+    --)
+      if [ "$1" = "--" ]; then
+        shift
+        COMMAND="$*"
+      fi
+      break
+      ;;
   esac
 done
 
@@ -32,21 +41,23 @@ if [ "$2" == "ghe-version" ]; then
   exit 0
 fi
 
-if $SHOW_UUID; then
-  CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
+CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
 
-  hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
 
-  if [ -z "$hosts" ]; then
-    # Mimic `ghe-cluster-each $role -u`
+if [ -z "$hosts" ]; then
+  # Mimic `ghe-cluster-each $role -u`
+  if $SHOW_UUID; then
     echo "fake-uuid
-  fake-uuid1
-  fake-uuid2
-  "
-  else
-    for hostname in $hosts; do
-      [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
-      echo $hostname
-    done
+fake-uuid1
+fake-uuid2
+"
+[ -n "$COMMAND" ] && echo "$COMMAND"
   fi
+else
+  for hostname in $hosts; do
+    [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
+    $SHOW_UUID && echo $hostname
+    [ -n "$COMMAND" ] && echo "$COMMAND"
+  done
 fi

--- a/test/bin/ghe-cluster-each
+++ b/test/bin/ghe-cluster-each
@@ -28,7 +28,7 @@ for _ in "$@"; do
   esac
 done
 
-if [ "$2" == "ghe-version" ]; then
+if [ "$COMMAND" == "ghe-version" ]; then
   if [ -z "$DIFFERENT_VERSIONS" ]; then
     echo "fake-uuid: GitHub Enterprise Server 3.1.0 lxc 2020-12-16 5e97c07602"
     echo "fake-uuid1: GitHub Enterprise Server 3.1.0 lxc 2020-12-16 5e97c07602"
@@ -43,7 +43,7 @@ fi
 
 CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
 
-hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2) || true
 
 if [ -z "$hosts" ]; then
   # Mimic `ghe-cluster-each $role -u`

--- a/test/bin/ghe-cluster-each
+++ b/test/bin/ghe-cluster-each
@@ -4,8 +4,6 @@
 # to assert that the command was executed.
 set -e
 
-SHOW_UUID=false
-
 for _ in "$@"; do
   case "$1" in
     -u)
@@ -18,17 +16,10 @@ for _ in "$@"; do
         shift
         shift
         ;;
-    --)
-      if [ "$1" = "--" ]; then
-        shift
-        COMMAND="$*"
-      fi
-      break
-      ;;
   esac
 done
 
-if [ "$COMMAND" == "ghe-version" ]; then
+if [ "$2" == "ghe-version" ]; then
   if [ -z "$DIFFERENT_VERSIONS" ]; then
     echo "fake-uuid: GitHub Enterprise Server 3.1.0 lxc 2020-12-16 5e97c07602"
     echo "fake-uuid1: GitHub Enterprise Server 3.1.0 lxc 2020-12-16 5e97c07602"
@@ -41,23 +32,26 @@ if [ "$COMMAND" == "ghe-version" ]; then
   exit 0
 fi
 
-CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
+if [ "$2" == "/usr/local/share/enterprise/ghe-nomad-cleanup" ]; then
+  echo "nomad cleanup"
+  exit 0
+fi
 
-hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2) || true
+if $SHOW_UUID; then
+  CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
 
-if [ -z "$hosts" ]; then
-  # Mimic `ghe-cluster-each $role -u`
-  if $SHOW_UUID; then
+  hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+
+  if [ -z "$hosts" ]; then
+    # Mimic `ghe-cluster-each $role -u`
     echo "fake-uuid
-fake-uuid1
-fake-uuid2
-"
-[ -n "$COMMAND" ] && echo "$COMMAND"
+  fake-uuid1
+  fake-uuid2
+  "
+  else
+    for hostname in $hosts; do
+      [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
+      echo $hostname
+    done
   fi
-else
-  for hostname in $hosts; do
-    [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
-    $SHOW_UUID && echo $hostname
-    [ -n "$COMMAND" ] && echo "$COMMAND"
-  done
 fi

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -535,7 +535,7 @@ setup_test_data "$GHE_DATA_DIR/1"
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"
 
-begin_test "ghe-restore cluster"
+begin_test "ghe-restore cluster with matching node versions"
 (
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
@@ -595,6 +595,32 @@ begin_test "ghe-restore cluster"
 
   # Verify all the data we've restored is as expected
   verify_all_restored_data
+)
+end_test
+
+begin_test "ghe-restore cluster with different node versions should fail at ghe-host-check"
+(
+  set -e
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_moreutils_parallel
+  setup_remote_metadata
+  setup_remote_cluster
+  echo "cluster" > "$GHE_DATA_DIR/current/strategy"
+
+  # set that versions should not match for this test
+  DIFFERENT_VERSIONS=1
+  export DIFFERENT_VERSIONS
+
+  # set as configured, enable maintenance mode and create required directories
+  setup_maintenance_mode "configured"
+
+  # set restore host environ var
+  GHE_RESTORE_HOST=127.0.0.1
+  export GHE_RESTORE_HOST
+
+  ! output=$(ghe-restore -v -f 2>&1)
+
+  echo "$output" | grep -q "Error: Not all nodes are running the same version! Please ensure all nodes are running the same version before using backup-utils."
 )
 end_test
 


### PR DESCRIPTION
We have containerized services since 2.22 and restore could fail with `ghe-config-apply` if nomad gets into a bad state (due to previous failed restore or etc). Cleanup nomad container before config apply will make restore more resilient to unexpected failures.

Also in this PR, we added clearer message for restore settings since it might take a while.