### PR TITLE
Bump version: 3.0.0.rc1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,10 @@
 github-backup-utils (3.0.0.rc1) UNRELEASED; urgency=medium
 
+
+ -- Michael Dang <dangmh@github.com>  Thu, 14 Jan 2021 21:17:53 +0000
+
+github-backup-utils (3.0.0.rc1) UNRELEASED; urgency=medium
+
  -- Michael Dang <dangmh@github.com>  Wed, 13 Jan 2021 23:23:59 +0000
 
 github-backup-utils (2.22.0) UNRELEASED; urgency=medium

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,16 @@
 github-backup-utils (3.0.0.rc1) UNRELEASED; urgency=medium
 
+  * Cleanup nomad container when restore for 2.22 #670
+  * Use ghe-cluster-nomad-cleanup for cluster mode #663
+  * Only run ghe-nomad-cleanup in 3.0 #662
+  * Revert backup-utils gitHub env and a few more fixes #661
+  * Note how to test filesystem symlink / hardlink support #660
+  * stop github-timerd based on its running environment #659
+  * Backup and restore password pepper #656
+  * github-env -> github-env-dispatch #654
+  * Rename redis-cli to ghe-redis-cli #639
 
  -- Michael Dang <dangmh@github.com>  Thu, 14 Jan 2021 21:17:53 +0000
-
-github-backup-utils (3.0.0.rc1) UNRELEASED; urgency=medium
-
- -- Michael Dang <dangmh@github.com>  Wed, 13 Jan 2021 23:23:59 +0000
 
 github-backup-utils (2.22.0) UNRELEASED; urgency=medium
 

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -42,7 +42,7 @@ export GHE_BACKUP_CONFIG GHE_DATA_DIR GHE_REMOTE_DATA_DIR GHE_REMOTE_ROOT_DIR
 
 # The default remote appliance version. This may be set in the environment prior
 # to invoking tests to emulate a different remote vm version.
-: ${GHE_TEST_REMOTE_VERSION:=3.0.0}
+: ${GHE_TEST_REMOTE_VERSION:=3.0.0.rc1}
 export GHE_TEST_REMOTE_VERSION
 
 # Source in the backup config and set GHE_REMOTE_XXX variables based on the


### PR DESCRIPTION
Includes general improvements & bug fixes and support for GitHub Enterprise Server v3.0.0.rc1

/cc @github/backup-utils