### PR TITLE
Fix restoring the password pepper for already configured instances

### DIFF
--- a/share/github-backup-utils/ghe-restore-mysql
+++ b/share/github-backup-utils/ghe-restore-mysql
@@ -27,7 +27,7 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 export GHE_RESTORE_SNAPSHOT
 
 # The directory holding the snapshot to restore
-snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
+GHE_RESTORE_SNAPSHOT_PATH="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 
 if is_external_database_snapshot; then
   if [ -n "$EXTERNAL_DATABASE_RESTORE_SCRIPT" ]; then
@@ -40,7 +40,7 @@ if is_external_database_snapshot; then
     bm_end "$(basename $0)"
     exit 0
   else
-    if is_binary_backup "$snapshot_dir"; then
+    if is_binary_backup "$GHE_RESTORE_SNAPSHOT_PATH"; then
       echo "Error: Restore of a binary backup to appliance with an external database configured is not supported."
       echo "Please provide a custom external database restore script with EXTERNAL_DATABASE_RESTORE_SCRIPT"
       exit 1
@@ -63,18 +63,22 @@ if is_external_database_snapshot; then
 fi
 
 if is_binary_backup_feature_on; then
+  # Always restore the password pepper here since it is tied to the MySQL data.
+  restore-secret "password pepper" "password-pepper" "secrets.github.user-password-secrets"
   # Feature "mysql.backup.binary" is on, which means new backup scripts are available
-  if is_binary_backup "$snapshot_dir"; then
+  if is_binary_backup "$GHE_RESTORE_SNAPSHOT_PATH"; then
     ghe-restore-mysql-binary $GHE_HOSTNAME
   else
     ghe-restore-mysql-logical $GHE_HOSTNAME
   fi
 else
   # We do not allow to restore binary backup without "mysql.backup.binary" set
-  if is_binary_backup "$snapshot_dir"; then
+  if is_binary_backup "$GHE_RESTORE_SNAPSHOT_PATH"; then
     echo "To restore from a binary backup, you have to set ghe-config \"mysql.backup.binary\" to true" >&2
     exit 2
   else
+    # Always restore the password pepper here since it is tied to the MySQL data.
+    restore-secret "password pepper" "password-pepper" "secrets.github.user-password-secrets"
     if is_default_external_database_snapshot; then
       ghe-restore-mysql-logical $GHE_HOSTNAME
     else

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -40,8 +40,6 @@ restore-secret "external MySQL password" "external-mysql-password" "secrets.exte
 
 # Restore management console password hash if present.
 restore-secret "management console password" "manage-password" "secrets.manage"
-# Restore password pepper if present
-restore-secret "password pepper" "password-pepper" "secrets.github.user-password-secrets"
 
 # Restore SAML keys if present.
 if [ -f "$GHE_RESTORE_SNAPSHOT_PATH/saml-keys.tar" ]; then


### PR DESCRIPTION
We normally skip settings restore when restoring into an already configured instance. This is to not overwrite / reset settings
unexpectedly. This is fine for all settings, except for the password pepper.

The password pepper is associated with the MySQL data and GitHub passwords used there, so it needs to be restored always together with the MySQL restore.

This moves the pepper restore to always be done together with the MySQL restore. We always here update the variable used here since the `restore-secret` function expects $GHE_RESTORE_SNAPSHOT_PATH to be set. We had a differently named variable in the MySQL restore with the same value, so that variable was renamed to match the `restore-secret` expectation so it can find the backed up password pepper.