### PR TITLE
Bug fix: Be more specific in restore routes globbing

### DIFF
--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -120,7 +120,7 @@ cat $tmp_list | ghe_debug
 bm_end "$(basename $0) - Transferring network list"
 
 bm_start "$(basename $0) - Generating routes"
-echo "cat $remote_tmp_list | github-env ./bin/dgit-cluster-restore-routes > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
+echo "cat $remote_tmp_list | github-env ./bin/dgit-cluster-restore-routes | grep 'git-server-' > $remote_routes_list" | ghe-ssh "$GHE_HOSTNAME" -- /bin/bash
 ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -144,7 +144,7 @@ fi
 # One rsync invocation per server available.
 bm_start "$(basename $0) - Restoring repository networks"
 rsync_commands=()
-for file_list in $tempdir/*.rsync; do
+for file_list in $tempdir/git-server-*.rsync; do
   if $CLUSTER; then
     server=$(basename $file_list .rsync)
   else


### PR DESCRIPTION
In some cases, unexpected or debugging output from repository route listing commands could lead to incorrect `.rsync` files being created. This leads to an eventual restore failure, as the system will then attempt to connect to invalid hostnames.

This tightens up or filters a few identified places to be more specific that we are looking for records that start with `git-server-` to prevent the unwanted input.

