### PR TITLE
fix(docker): add coreutils to get flags for date

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,7 +8,8 @@ RUN apk --update --no-cache add \
     git \
     bash \
     gawk \
-    procps
+    procps \
+    coreutils
 
 WORKDIR /backup-utils
 ADD https://github.com/github/backup-utils/archive/stable.tar.gz /


### PR DESCRIPTION
The busybox version of date doesn't support the `-d` flag, the suggested [workaround](https://github.com/gliderlabs/docker-alpine/issues/40#issuecomment-107122371) is to simply install the coreutils package. This change is only relevant for administrators that want to backup GHES hosts that are utilizing GH Actions - https://github.com/github/backup-utils/blob/78feb70e327d011e2a24e3b8308b5ff82e2546d8/share/github-backup-utils/ghe-backup-mssql#L45.