### PR TITLE
Clarifying backwards compatibility for Restore operations

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -61,6 +61,8 @@ snapshot of GitHub Enterprise Server 2.11, the target GitHub Enterprise Server a
 be running GitHub Enterprise Server 2.12.x or 2.13.x. You can't restore a snapshot from
 2.10 to 2.13, because that's three releases ahead.
 
+**Note**: You _cannot_ restore a backup created from a newer verison of GitHub Enterprise Server to an older version. For example, an attempt to restore a snapshot of GitHub Enterprise Server 2.21 to a GitHub Enterprise Server 2.20 environment will fail with an error of `Error: Snapshot can not be restored to an older release of GitHub Enterprise Server.`.
+
 [1]: https://www.gnu.org/software/bash/
 [2]: https://git-scm.com/
 [3]: https://www.openssh.com/


### PR DESCRIPTION
The Backup Utils documentation clearly outlines `n+2` support for restoring backups to *newer* versions of GitHub Enterprise Server,  and clarifies that backups can be created from `n-2` versions of GitHub Enterprise Server compared to Backup Utils. However, there is no clarification [outside of code](https://github.com/github/backup-utils/blob/master/bin/ghe-host-check#L111-L120) that a backup cannot be *restored* to an older version of GitHub Enterprise Server than it was created from.

This Pull Request adds explicit clarification in the documentation that a backup cannot be restored to an older version of GitHub Enterprise Server than it was created from.