### PR TITLE
Fix is_default_external_database_snapshot function

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -462,7 +462,7 @@ is_external_database_snapshot(){
 # This file exists if this is a backup for an external database AND the backup was
 # taken via our logical backup strategy.
 is_default_external_database_snapshot(){
-  is_external_database_snapshot && test -f "$1/logical-external-database-backup-sentinel"
+  is_external_database_snapshot && test -f "$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT/logical-external-database-backup-sentinel"
 }
 
 prompt_for_confirmation(){


### PR DESCRIPTION
This function tries to access an argument ($1) but no invocations of this
function pass in an argument. The implementation has been changed to rely on
variables from the environment which allow it correctly find the appropriate
sentinel file.