### PR TITLE
Fix debian package versioning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-github-backup-utils (3.1.0.rc1) UNRELEASED; urgency=medium
+github-backup-utils (3.1.0~rc1) UNRELEASED; urgency=medium
 
   * Update repository backups to use ghe-gc-* for lock file management #188
   * A faster way to restore storage blobs (clusters) #212


### PR DESCRIPTION
version number 3.0.1.rc1 is bigger than 3.0.1 official release,
so we should use ~ for it

$ dpkg --compare-versions 3.0.1.rc1 gt 3.0.1
$ echo $?
0

note: gt means "greater than"