### PR TITLE
Fix CI builds that broke due to the new 3.1.0 release

### DIFF
--- a/test/test-ghe-host-check.sh
+++ b/test/test-ghe-host-check.sh
@@ -58,7 +58,9 @@ begin_test "ghe-host-check detects unsupported GitHub Enterprise Server versions
   ! GHE_TEST_REMOTE_VERSION=11.340.36 ghe-host-check
   # hardcode until https://github.com/github/backup-utils/issues/675 is resolved
   ! GHE_TEST_REMOTE_VERSION=2.20.0 ghe-host-check
-  GHE_TEST_REMOTE_VERSION=2.21.0 ghe-host-check
+  ! GHE_TEST_REMOTE_VERSION=2.21.0 ghe-host-check
+  GHE_TEST_REMOTE_VERSION=2.22.0 ghe-host-check
+  GHE_TEST_REMOTE_VERSION=3.0.0 ghe-host-check
   GHE_TEST_REMOTE_VERSION=$BACKUP_UTILS_VERSION ghe-host-check
   GHE_TEST_REMOTE_VERSION=$BACKUP_UTILS_VERSION ghe-host-check
   GHE_TEST_REMOTE_VERSION=$bu_version_major.$bu_version_minor.999 ghe-host-check


### PR DESCRIPTION
While reviewing #726 I noticed that the latest bump to 3.1.0.rc1 broke the version negotiation tests.  backup-utils 3.1.0 requires GHES 2.22.0 or later, so fix the tests to expect that version or newer.