### PR TITLE
Clarify moreutils-parallel requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository includes backup and recovery utilities for
 [GitHub Enterprise Server][1].
 
-**UPDATE**: The new parallel backup and restore beta feature will require [GNU awk](https://www.gnu.org/software/gawk) and [moreutils](https://joeyh.name/code/moreutils) to be installed.
+**UPDATE**: The new parallel backup and restore beta feature will require [GNU awk](https://www.gnu.org/software/gawk) and [moreutils](https://joeyh.name/code/moreutils) to be installed. Note that on some distributions/platforms, the `moreutils-parallel` package is separate from `moreutils` and must be installed on its own.
 
 **Note**: the [GitHub Enterprise Server version requirements][2] have
 changed starting with Backup Utilities v2.13.0, released on 27 March 2018.


### PR DESCRIPTION
On some *nix distributions, such as CentOS, `moreutils` is available through the package manager on the system (or through another repository like EPEL), however `moreutils-parallel` is provided as a package that must be installed separately.

If only `moreutils` is installed on CentOS, for example, Backup Utilities will still fail to run and complain that `parallel` cannot be found despite the `moreutils` package being installed.

This Pull Request clarifies that `moreutils-parallel` may need to be installed separately depending on platform/distribution in order to help address the confusion that may arise from the lack of information on the `moreutils` website that is linked in documentation.