### PR TITLE
Fix redirection bug (SC2259) in test/testlib.sh

### DIFF
--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -146,7 +146,7 @@ report_failure () {
   printf "test: %-73s $msg\\n" "$desc ..."
   (
     sed 's/^/    /' <"$TRASHDIR/out" |
-    grep -a -v -e '^\+ end_test' -e '^+ set +x' <"$TRASHDIR/out" |
+    grep -a -v -e '^\+ end_test' -e '^+ set +x' - "$TRASHDIR/out" |
     sed 's/[+] test_status=/test failed. last command exited with /' |
     sed 's/^/    /'
   ) 1>&2


### PR DESCRIPTION
ShellCheck 0.7.2 says
> In test/testlib.sh line 149:
>    grep -a -v -e '^\+ end_test' -e '^+ set +x' <"$TRASHDIR/out" |
>                                                ^-- SC2259: This redirection overrides piped input. To use both, merge or pass filenames.
>
>For more information:
>  https://www.shellcheck.net/wiki/SC2259 -- This redirection overrides piped ...

so specify "$TRASHDIR/out" as the filename