### PR TITLE
Get and use latest shellcheck for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y devscripts debhelper moreutils fakeroot jq pigz
-        wget "https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz"
-        tar --xz -xvf "shellcheck-v0.7.0.linux.x86_64.tar.xz"
-        sudo cp shellcheck-v0.7.0/shellcheck /usr/bin/shellcheck
+        wget "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz"
+        tar --xz -xvf "shellcheck-latest.linux.x86_64.tar.xz"
+        sudo cp shellcheck-latest/shellcheck /usr/bin/shellcheck
       if: matrix.os != 'macos-latest'
     - name: Install Dependencies (macOS)
       run: |

--- a/test/test-shellcheck.sh
+++ b/test/test-shellcheck.sh
@@ -9,10 +9,10 @@ BASE_PATH=$(cd "$(dirname "$0")/../" && pwd)
 begin_test "shellcheck: reports no errors or warnings"
 (
   set -e
-  # We manually install Shellcheck 0.7.0 on Linux builds as other options
+  # We manually install the latest Shellcheck on Linux builds as other options
   # are too old.
-  if [ -x "$BASE_PATH/shellcheck-v0.7.0/shellcheck" ]; then
-    shellcheck() { "$BASE_PATH/shellcheck-v0.7.0/shellcheck" "$@"; }
+  if [ -x "$BASE_PATH/shellcheck-latest/shellcheck" ]; then
+    shellcheck() { "$BASE_PATH/shellcheck-latest/shellcheck" "$@"; }
   fi
 
   if ! type shellcheck 1>/dev/null 2>&1; then


### PR DESCRIPTION
Now we use shellcheck 0.7.0 on Ubuntu hosts for the test, but also use 0.7.2 or later on macOS host via brew. So, not specifying the version and always fetch & run the latest version of shellcheck on Ubuntu host is better.

We don't have a reason to stick to 0.7.0, IMHO.