### PR TITLE
Leaked host key check: Avoid false positives from FIPS mode

### DIFF
--- a/share/github-backup-utils/ghe-detect-leaked-ssh-keys
+++ b/share/github-backup-utils/ghe-detect-leaked-ssh-keys
@@ -69,6 +69,7 @@ if [ -L "$GHE_DATA_DIR/current" ]; then
 fi
 
 leaked_keys_found=false
+leaked_keys_skippedcheck=false
 current_bkup=false
 for tar_file in $ssh_tars; do
   for key in $keys; do
@@ -79,7 +80,9 @@ for tar_file in $ssh_tars; do
       else
         fingerprint=$(ssh-keygen -lf $TEMPDIR/$key | cut -d ' ' -f 2)
       fi
-      if echo "$FINGERPRINT_BLACKLIST" | grep -q "$fingerprint"; then
+      if [ -z "$fingerprint" ]; then
+        leaked_keys_skippedcheck=true
+      elif echo "$FINGERPRINT_BLACKLIST" | grep -q "$fingerprint"; then
         leaked_keys_found=true
         if [ "$current_dir" == "$(dirname "$tar_file")" ]; then
           current_bkup=true
@@ -126,7 +129,11 @@ if $leaked_keys_found; then
     echo
   fi
 else
-  echo "* No leaked keys found"
+  if $leaked_keys_skippedcheck; then
+    echo "* No result - check not performed since host key fingerprint was empty"
+  else
+    echo "* No leaked keys found"
+  fi
 fi
 
 # Cleanup temp dir


### PR DESCRIPTION
Enabling FIPS (Federal Information Processing Standards) mode on the backup server
may cause `ssh-keygen`'s MD5-based fingerprint generation to fail.

A "fingerprint_one_key: sshkey_fingerprint failed" message is written to stderr
whilst nothing is written to stdout, so the `fingerprint` variable is blank.

A grep search for an empty string succeeds, so `ghe-detect-leaked-ssh-keys`
reports that a leaked hostkey was found.

This change detects this condition and the final output says if the hostkey check was skipped.

closes: #749 