### PR TITLE
Make some of the actions setting best effort

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -26,16 +26,51 @@ echo "* Transferring license data ..." 1>&3
 ghe-ssh "$host" -- "sudo cat '$GHE_REMOTE_LICENSE_FILE'" > enterprise.ghl
 
 # Function to backup a secret setting to a file.
-#   backup-secret <description> <file-name> <setting-name>
+#   backup-secret <description> <file-name> <setting-name> 
 backup-secret() {
-  echo "* Transferring $1 ..." 1>&3
-  ghe-ssh "$host" -- ghe-config "$3" > "$2+" || (
-    echo "Warning: $1 not set" >&2
+
+  best_effort=false
+  label=""
+  file=""
+  setting=""
+  count=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --best-effort)
+        shift 1
+        best_effort=true
+        ;;
+      *)
+        case $count in
+          0)
+            label=$1
+            ;;
+          1)
+            file=$1
+            ;;
+          2)
+            setting=$1
+            ;;
+          *)
+            >&2 echo "To many arguments"
+            ;;
+        esac
+        count=$((count+1))
+        shift 1
+    esac
+  done
+
+  echo "* Transferring $label ..." 1>&3
+  ghe-ssh "$host" -- ghe-config "$setting" > "$file+" || (
+    if  [ "$best_effort" = "false" ]; then
+      echo "Warning: $label not set" >&2
+    fi
   )
-  if [ -n "$(cat "$2+")" ]; then
-    mv "$2+" "$2"
+  if [ -n "$(cat "$file+")" ]; then
+    mv "$file+" "$file"
   else
-    unlink "$2+"
+    unlink "$file+"
   fi
 }
 
@@ -51,19 +86,19 @@ fi
 if ghe-ssh "$host" -- ghe-config --true app.actions.enabled; then
   backup-secret "Actions configuration database login" "actions-config-db-login" "secrets.actions.ConfigurationDatabaseSqlLogin"
   backup-secret "Actions configuration database password" "actions-config-db-password" "secrets.actions.ConfigurationDatabaseSqlPassword"
-  backup-secret "Actions framework access token key secret" "actions-framework-access-token" "secrets.actions.FrameworkAccessTokenKeySecret"
+  backup-secret "Actions framework access token key secret" "actions-framework-access-token" "secrets.actions.FrameworkAccessTokenKeySecret" --best-effort
   backup-secret "Actions Url signing HMAC key primary" "actions-url-signing-hmac-key-primary" "secrets.actions.UrlSigningHmacKeyPrimary"
   backup-secret "Actions Url signing HMAC key secondary" "actions-url-signing-hmac-key-secondary" "secrets.actions.UrlSigningHmacKeySecondary"
   backup-secret "Actions OAuth S2S signing cert" "actions-oauth-s2s-signing-cert" "secrets.actions.OAuthS2SSigningCert"
   backup-secret "Actions OAuth S2S signing key" "actions-oauth-s2s-signing-key" "secrets.actions.OAuthS2SSigningKey"
   backup-secret "Actions OAuth S2S signing cert thumbprint" "actions-oauth-s2s-signing-cert-thumbprint" "secrets.actions.OAuthS2SSigningCertThumbprint"
   backup-secret "Actions primary encryption cert thumbprint" "actions-primary-encryption-cert-thumbprint" "secrets.actions.PrimaryEncryptionCertificateThumbprint"
-  backup-secret "Actions AAD cert thumbprint" "actions-aad-cert-thumbprint" "secrets.actions.AADCertThumbprint"
-  backup-secret "Actions delegated auth cert thumbprint" "actions-delegated-auth-cert-thumbprint" "secrets.actions.DelegatedAuthCertThumbprint"
-  backup-secret "Actions runtime service principal cert" "actions-runtime-service-principal-cert" "secrets.actions.RuntimeServicePrincipalCertificate"
+  backup-secret "Actions AAD cert thumbprint" "actions-aad-cert-thumbprint" "secrets.actions.AADCertThumbprint" --best-effort
+  backup-secret "Actions delegated auth cert thumbprint" "actions-delegated-auth-cert-thumbprint" "secrets.actions.DelegatedAuthCertThumbprint" --best-effort
+  backup-secret "Actions runtime service principal cert" "actions-runtime-service-principal-cert" "secrets.actions.RuntimeServicePrincipalCertificate" --best-effort
   backup-secret "Actions S2S encryption cert" "actions-s2s-encryption-cert" "secrets.actions.S2SEncryptionCertificate"
   backup-secret "Actions secondary encryption cert thumbprint" "actions-secondary-encryption-cert-thumbprint" "secrets.actions.SecondaryEncryptionCertificateThumbprint"
-  backup-secret "Actions service principal cert" "actions-service-principal-cert" "secrets.actions.ServicePrincipalCertificate"
+  backup-secret "Actions service principal cert" "actions-service-principal-cert" "secrets.actions.ServicePrincipalCertificate" --best-effort
   backup-secret "Actions SPS validation cert thumbprint" "actions-sps-validation-cert-thumbprint" "secrets.actions.SpsValidationCertThumbprint"
 
   backup-secret "Actions Launch secrets encryption/decryption" "actions-launch-secrets-private-key" "secrets.launch.actions-secrets-private-key"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -449,19 +449,14 @@ begin_test "ghe-backup takes backup of Actions settings"
   required_secrets=(
     "secrets.actions.ConfigurationDatabaseSqlLogin"
     "secrets.actions.ConfigurationDatabaseSqlPassword"
-    "secrets.actions.FrameworkAccessTokenKeySecret"
     "secrets.actions.UrlSigningHmacKeyPrimary"
     "secrets.actions.UrlSigningHmacKeySecondary"
     "secrets.actions.OAuthS2SSigningCert"
     "secrets.actions.OAuthS2SSigningKey"
     "secrets.actions.OAuthS2SSigningCertThumbprint"
     "secrets.actions.PrimaryEncryptionCertificateThumbprint"
-    "secrets.actions.AADCertThumbprint"
-    "secrets.actions.DelegatedAuthCertThumbprint"
-    "secrets.actions.RuntimeServicePrincipalCertificate"
     "secrets.actions.S2SEncryptionCertificate"
     "secrets.actions.SecondaryEncryptionCertificateThumbprint"
-    "secrets.actions.ServicePrincipalCertificate"
     "secrets.actions.SpsValidationCertThumbprint"
 
     "secrets.launch.actions-secrets-private-key"
@@ -481,6 +476,15 @@ begin_test "ghe-backup takes backup of Actions settings"
     "secrets.launch.azp-app-private-key"
   )
 
+  # these 5 were removed in later versions, so we extract them as best effort
+  # - secrets.actions.FrameworkAccessTokenKeySecret
+  # - secrets.actions.AADCertThumbprint
+  # - secrets.actions.DelegatedAuthCertThumbprint
+  # - secrets.actions.RuntimeServicePrincipalCertificate
+  # - secrets.actions.ServicePrincipalCertificate
+  # add one, to make sure it still gets copied
+  required_secrets+=("secrets.actions.FrameworkAccessTokenKeySecret")
+
   for secret in "${required_secrets[@]}"; do
     ghe-ssh "$GHE_HOSTNAME" -- ghe-config "$secret" "foo"
   done
@@ -490,19 +494,14 @@ begin_test "ghe-backup takes backup of Actions settings"
   required_files=(
     "actions-config-db-login"
     "actions-config-db-password"
-    "actions-framework-access-token"
     "actions-url-signing-hmac-key-primary"
     "actions-url-signing-hmac-key-secondary"
     "actions-oauth-s2s-signing-cert"
     "actions-oauth-s2s-signing-key"
     "actions-oauth-s2s-signing-cert-thumbprint"
     "actions-primary-encryption-cert-thumbprint"
-    "actions-aad-cert-thumbprint"
-    "actions-delegated-auth-cert-thumbprint"
-    "actions-runtime-service-principal-cert"
     "actions-s2s-encryption-cert"
     "actions-secondary-encryption-cert-thumbprint"
-    "actions-service-principal-cert"
     "actions-sps-validation-cert-thumbprint"
 
     "actions-launch-secrets-private-key"
@@ -520,9 +519,24 @@ begin_test "ghe-backup takes backup of Actions settings"
     "actions-launch-app-app-private-key"
   )
 
+  # Add the one options file we included tests for
+  required_files+=("actions-framework-access-token")
+
   for file in "${required_files[@]}"; do
     [ "$(cat "$GHE_DATA_DIR/current/$file")" = "foo" ]
   done
+
+  other_best_effort_files=(
+    "actions-aad-cert-thumbprint"
+    "actions-delegated-auth-cert-thumbprint"
+    "actions-runtime-service-principal-cert"
+    "actions-service-principal-cert"
+  )
+
+  for file in "${other_best_effort_files[@]}"; do
+    [ ! -f "$GHE_DATA_DIR/current/$file" ]
+  done
+
 )
 end_test
 


### PR DESCRIPTION
Fixes https://github.com/github/enterprise-releases/issues/2722
These 5 settings were removed but since backup utils needs to support older versions we need to leave them here so that they will get copied when present
- secrets.actions.FrameworkAccessTokenKeySecret
- secrets.actions.AADCertThumbprint
- secrets.actions.DelegatedAuthCertThumbprint
- secrets.actions.RuntimeServicePrincipalCertificate
- secrets.actions.ServicePrincipalCertificate