### PR TITLE
Stop/Restart Actions in ghe-restore

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -91,6 +91,11 @@ cleanup () {
     update_restore_status "$1"
   fi
 
+  if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
+    echo "Restarting Actions after restore ..."
+    ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start' 1>&3
+  fi
+
   # Cleanup SSH multiplexing
   ghe-ssh --clean
 }
@@ -348,6 +353,9 @@ else
 fi
 
 if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
+  echo "Stopping Actions before restoring databases ..."
+  ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-stop' 1>&3
+
   echo "Restoring MSSQL databases ..."
   ghe-restore-mssql "$GHE_HOSTNAME" 1>&3
 

--- a/test/bin/ghe-actions-start
+++ b/test/bin/ghe-actions-start
@@ -1,0 +1,1 @@
+ghe-fake-true

--- a/test/bin/ghe-actions-start
+++ b/test/bin/ghe-actions-start
@@ -1,1 +1,1 @@
-ghe-fake-import
+ghe-fake-import-command

--- a/test/bin/ghe-actions-start
+++ b/test/bin/ghe-actions-start
@@ -1,1 +1,1 @@
-ghe-fake-true
+ghe-fake-import

--- a/test/bin/ghe-actions-stop
+++ b/test/bin/ghe-actions-stop
@@ -1,0 +1,1 @@
+ghe-fake-true

--- a/test/bin/ghe-actions-stop
+++ b/test/bin/ghe-actions-stop
@@ -1,1 +1,1 @@
-ghe-fake-import
+ghe-fake-import-command

--- a/test/bin/ghe-actions-stop
+++ b/test/bin/ghe-actions-stop
@@ -1,1 +1,1 @@
-ghe-fake-true
+ghe-fake-import

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -405,10 +405,6 @@ begin_test "ghe-restore stops and starts Actions"
 
   setup_maintenance_mode "configured"
 
-  output=$(ghe-restore -v -f localhost 2>&1)
-
-  echo "$output" | grep -q "ghe-actions-stop .* OK" "$TRASHDIR/restore-out"
-  
   # run ghe-restore and write output to file for asserting against
   if ! ghe-restore -v -f > "$TRASHDIR/restore-out" 2>&1; then
       cat "$TRASHDIR/restore-out"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -405,15 +405,10 @@ begin_test "ghe-restore stops and starts Actions"
 
   setup_maintenance_mode "configured"
 
-  # run ghe-restore and write output to file for asserting against
-  if ! ghe-restore -v -f > "$TRASHDIR/restore-out" 2>&1; then
-      cat "$TRASHDIR/restore-out"
-      : ghe-restore should have exited successfully
-      false
-  fi
+  output=$(ghe-restore -v -f localhost 2>&1)
 
-  grep -q "ghe-actions-stop .* OK" "$TRASHDIR/restore-out"
-  grep -q "ghe-actions-start .* OK" "$TRASHDIR/restore-out"
+  echo "$output" | grep -q "ghe-actions-stop .* OK"
+  echo "$output" | grep -q "ghe-actions-start .* OK"
 )
 
 begin_test "ghe-restore with Actions data"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -396,6 +396,30 @@ begin_test "ghe-restore with Actions settings"
 )
 end_test
 
+begin_test "ghe-restore stops and starts Actions"
+(
+  set -e
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+  enable_actions
+
+  setup_maintenance_mode "configured"
+
+  output=$(ghe-restore -v -f localhost 2>&1)
+
+  echo "$output" | grep -q "ghe-actions-stop .* OK" "$TRASHDIR/restore-out"
+  
+  # run ghe-restore and write output to file for asserting against
+  if ! ghe-restore -v -f > "$TRASHDIR/restore-out" 2>&1; then
+      cat "$TRASHDIR/restore-out"
+      : ghe-restore should have exited successfully
+      false
+  fi
+
+  grep -q "ghe-actions-stop .* OK" "$TRASHDIR/restore-out"
+  grep -q "ghe-actions-start .* OK" "$TRASHDIR/restore-out"
+)
+
 begin_test "ghe-restore with Actions data"
 (
   set -e


### PR DESCRIPTION
When Actions is enabled, `ghe-restore` needs to stop Actions service before performing the restoration and restart the service afterwards.