### PR TITLE
Clear GitHub Connect settings when not restoring settings

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -345,6 +345,10 @@ if is_external_database_target_or_snapshot && $SKIP_MYSQL; then
 else
   echo "Restoring MySQL database from ${backup_snapshot_strategy} backup snapshot on an appliance configured for ${appliance_strategy} backups ..."
   ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
+  # Clear GitHub Connect settings stored in the restored database
+  if ! $RESTORE_SETTINGS; then
+    ghe-ssh "$GHE_HOSTNAME" -- "/usr/local/share/enterprise/ghe-reset-gh-connect -y"
+  fi
 fi
 
 if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -347,7 +347,7 @@ else
   ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
   # Clear GitHub Connect settings stored in the restored database
   if ! $RESTORE_SETTINGS; then
-    ghe-ssh "$GHE_HOSTNAME" -- "/usr/local/share/enterprise/ghe-reset-gh-connect -y"
+    ghe-ssh "$GHE_HOSTNAME" -- "[ -x '/usr/local/share/enterprise/ghe-reset-gh-connect' ] && /usr/local/share/enterprise/ghe-reset-gh-connect -y"
   fi
 fi
 

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -347,7 +347,8 @@ else
   ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
   # Clear GitHub Connect settings stored in the restored database
   if ! $RESTORE_SETTINGS; then
-    ghe-ssh "$GHE_HOSTNAME" -- "[ -x '/usr/local/share/enterprise/ghe-reset-gh-connect' ] && /usr/local/share/enterprise/ghe-reset-gh-connect -y"
+    echo "if [ -f /usr/local/share/enterprise/ghe-reset-gh-connect ]; then /usr/local/share/enterprise/ghe-reset-gh-connect -y; else ghe-reset-gh-connect -y; fi" |
+    ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
   fi
 fi
 

--- a/test/bin/ghe-reset-gh-connect
+++ b/test/bin/ghe-reset-gh-connect
@@ -1,0 +1,1 @@
+ghe-fake-true


### PR DESCRIPTION
At the moment, when a backup it restored _without_ any settings, ie without using the `--config` flag, the GitHub Connect settings are still restored. This is because they're stored in the MySQL database and there's nothing in place to clear them or prevent them from being restored.

This leads to a problem where the restored instance will have all the same settings and GitHub Connect-specific unique ID as the original host and will start competing with the original instance if both are active. This can result in one instance being kicked off GitHub Connect, or confusing license sync information, if both remain connected.

This PR resolves this problem by calling a new script immediately after the MySQL database has been restored. This script will be added to all currently supported versions of GHES.