### PR TITLE
change amd64.deb to all.deb

### DIFF
--- a/script/release
+++ b/script/release
@@ -447,7 +447,7 @@ if $PROGRAM_NAME == __FILE__
     puts 'Attaching Debian pkg and tarball to release...'
     base_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
     attach_assets_to_release res['upload_url'], res['id'], ["#{base_dir}/dist/#{DEB_PKG_NAME}-v#{version}.tar.gz"]
-    attach_assets_to_release res['upload_url'], res['id'], ["#{base_dir}/dist/#{DEB_PKG_NAME}_#{version}_amd64.deb"]
+    attach_assets_to_release res['upload_url'], res['id'], ["#{base_dir}/dist/#{DEB_PKG_NAME}_#{version}_all.deb"]
 
     puts 'Publishing release...'
     publish_release res['id']

--- a/test/test-ghe-host-check.sh
+++ b/test/test-ghe-host-check.sh
@@ -59,8 +59,9 @@ begin_test "ghe-host-check detects unsupported GitHub Enterprise Server versions
   # hardcode until https://github.com/github/backup-utils/issues/675 is resolved
   ! GHE_TEST_REMOTE_VERSION=2.20.0 ghe-host-check
   ! GHE_TEST_REMOTE_VERSION=2.21.0 ghe-host-check
-  GHE_TEST_REMOTE_VERSION=2.22.0 ghe-host-check
+  ! GHE_TEST_REMOTE_VERSION=2.22.0 ghe-host-check
   GHE_TEST_REMOTE_VERSION=3.0.0 ghe-host-check
+  GHE_TEST_REMOTE_VERSION=3.1.0 ghe-host-check
   GHE_TEST_REMOTE_VERSION=$BACKUP_UTILS_VERSION ghe-host-check
   GHE_TEST_REMOTE_VERSION=$BACKUP_UTILS_VERSION ghe-host-check
   GHE_TEST_REMOTE_VERSION=$bu_version_major.$bu_version_minor.999 ghe-host-check


### PR DESCRIPTION
# Context
During 3.2.0 release we found that due to change in https://github.com/github/backup-utils/pull/732, deb file suffix should be changed from  `amd64.deb` to `all.deb` as architecture is changed to `all`, this changes the deb file we ship as release.