### PR TITLE
Drop 16.04 from OS tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-18.04', 'ubuntu-16.04', 'macos-latest']
+        os: ['ubuntu-20.04', 'ubuntu-18.04', 'macos-latest']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
16.04 went EOL in April of this year, and will no longer be supported in workflows on 2021-09-20
https://github.com/actions/virtual-environments/issues/3287