### PR TITLE
Revert "Clear GitHub Connect settings when not restoring settings"

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -350,11 +350,6 @@ if is_external_database_target_or_snapshot && $SKIP_MYSQL; then
 else
   echo "Restoring MySQL database from ${backup_snapshot_strategy} backup snapshot on an appliance configured for ${appliance_strategy} backups ..."
   ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
-  # Clear GitHub Connect settings stored in the restored database
-  if ! $RESTORE_SETTINGS; then
-    echo "if [ -f /usr/local/share/enterprise/ghe-reset-gh-connect ]; then /usr/local/share/enterprise/ghe-reset-gh-connect -y; else ghe-reset-gh-connect -y; fi" |
-    ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
-  fi
 fi
 
 if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then

--- a/test/bin/ghe-reset-gh-connect
+++ b/test/bin/ghe-reset-gh-connect
@@ -1,1 +1,0 @@
-ghe-fake-true


### PR DESCRIPTION
Reverts github/backup-utils#770

Other than revert, do we want to call `ghe-reset-gh-connect-server-id` instead?