### PR TITLE
fix bug in is_service_external

### DIFF
--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -417,7 +417,7 @@ is_service_external(){
     "mysql")
       if [ -n "$config_file" ]; then
         enabled=$(GIT_CONFIG="$config_file" git config mysql.external.enabled)
-        [ "$enabled" ];
+        [ "$enabled" = true ];
       else
         ghe-ssh "$GHE_HOSTNAME" -- ghe-config --true "mysql.external.enabled"
       fi

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -417,7 +417,7 @@ is_service_external(){
     "mysql")
       if [ -n "$config_file" ]; then
         enabled=$(GIT_CONFIG="$config_file" git config mysql.external.enabled)
-        [ "$enabled" == "true" ];
+        [ "$enabled" ];
       else
         ghe-ssh "$GHE_HOSTNAME" -- ghe-config --true "mysql.external.enabled"
       fi


### PR DESCRIPTION
Seems `is_service_external` is not returning correctly for external database when parsing `settings.json`