### PR TITLE
Move GitHub Connect reset to after ghe-config-apply

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -350,11 +350,6 @@ if is_external_database_target_or_snapshot && $SKIP_MYSQL; then
 else
   echo "Restoring MySQL database from ${backup_snapshot_strategy} backup snapshot on an appliance configured for ${appliance_strategy} backups ..."
   ghe-restore-mysql "$GHE_HOSTNAME" 1>&3
-  # Clear GitHub Connect settings stored in the restored database
-  if ! $RESTORE_SETTINGS; then
-    echo "if [ -f /usr/local/share/enterprise/ghe-reset-gh-connect ]; then /usr/local/share/enterprise/ghe-reset-gh-connect -y; fi" |
-    ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
-  fi
 fi
 
 if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
@@ -458,6 +453,13 @@ elif $instance_configured; then
     ghe-ssh "$GHE_HOSTNAME" -- "/usr/local/share/enterprise/ghe-nomad-cleanup" 1>&3 2>&3
   fi
   ghe-ssh "$GHE_HOSTNAME" -- "ghe-config-apply" 1>&3 2>&3
+fi
+
+# Clear GitHub Connect settings stored in the restored database.
+# This needs to happen after `ghe-config-apply` to ensure all migrations have run.
+if ! $RESTORE_SETTINGS; then
+  echo "if [ -f /usr/local/share/enterprise/ghe-reset-gh-connect ]; then /usr/local/share/enterprise/ghe-reset-gh-connect -y; fi" |
+  ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
 fi
 
 # Start cron. Timerd will start automatically as part of the config run.


### PR DESCRIPTION
During testing, I discovered that the GitHub Connect reset logic I introduced in https://github.com/github/backup-utils/pull/770 fails when restoring a pre-3.0 snapshot to a 3.0 or later instance.

The reason for the failure is because the reset logic uses Rails functionality which comes with the assumption all migrations have happened and thus the database structure matches what the Rails code expects.

This PR fixes this by moving the GitHub Connect reset step to _after_ `ghe-config-apply` has been run and this ensures all the migrations have run too.

/cc @domofactor 