### PR TITLE
Fix: ghe-restore add force option when starting actions

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -93,7 +93,7 @@ cleanup () {
 
   if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Restarting Actions after restore ..."
-    ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start' 1>&3
+    ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start -f' 1>&3
   fi
 
   # Cleanup SSH multiplexing


### PR DESCRIPTION
# Why
The attempt to start github actions while the github instance is in maintance mode, cause the `ghe-restore` to exit with code 1.


# How
Add `-f` option to force the reload of github actions while the instance is in maintenance mode.

# Issue
https://github.com/github/backup-utils/issues/797