### PR TITLE
Always default port to 122

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -52,37 +52,8 @@ options="
 port=$(ssh_port_part "$host")
 hostname=$(ssh_host_part "$host")
 
-set +e
+# ghe-negotiate-version verifies if the target is a Github Enterprise Server instance
 output=$(echo "ghe-negotiate-version backup-utils $BACKUP_UTILS_VERSION" | ghe-ssh -o BatchMode=no $options $host -- /bin/sh 2>&1)
-rc=$?
-set -e
-
-if [ $rc -ne 0 ]; then
-  case $rc in
-  255)
-    if echo "$output" | grep -i "port 22: Network is unreachable\|port 22: connection refused\|port 22: no route to host\|ssh_exchange_identification: Connection closed by remote host\|Connection timed out during banner exchange\|port 22: Connection timed out" >/dev/null; then
-      exec "$(basename $0)" "$hostname:122"
-    fi
-
-    echo "$output" 1>&2
-    echo "Error: ssh connection with '$host' failed" 1>&2
-    echo "Note that your SSH key needs to be setup on $host as described in:" 1>&2
-    echo "* https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access" 1>&2
-    ;;
-  101)
-    echo "Error: couldn't read GitHub Enterprise Server fingerprint on '$host' or this isn't a GitHub appliance." 1>&2
-    ;;
-  1)
-    if [ "${port:-22}" -eq 22 ] && echo "$output" | grep "use port 122" >/dev/null; then
-      exec "$(basename $0)" "$hostname:122"
-    else
-      echo "$output" 1>&2
-    fi
-    ;;
-
-  esac
-  exit $rc
-fi
 
 CLUSTER=false
 if ghe-ssh "$host" -- \

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -334,7 +334,12 @@ ssh_host_part() {
 # This is used primarily to break hostspecs with non-standard ports down for
 # rsync commands.
 ssh_port_part() {
-  [ "${1##*:}" = "$1" ] && echo 22 || echo "${1##*:}"
+  if [ "${1##*:}" != "$1" ] && [ "${1##*:}" -ne "122" ]; then
+    echo "Error: SSH port has to be 122 connecting to Github Enterprise Server, current value is ${1##*:} for $1." 1>&2
+    exit 1
+  fi
+
+  echo 122
 }
 
 # Usage: ghe_remote_logger <message>...

--- a/test/test-ghe-backup-config.sh
+++ b/test/test-ghe-backup-config.sh
@@ -89,10 +89,10 @@ end_test
 begin_test "ghe-backup-config ssh_port_part"
 (
   set -e
-  [ "$(ssh_port_part 'github.example.com')" = "22" ]
-  [ "$(ssh_port_part 'github.example.com:22')" = "22" ]
-  [ "$(ssh_port_part 'github.example.com:5000')" = "5000" ]
-  [ "$(ssh_port_part 'git@github.example.com:5000')" = "5000" ]
+  [ "$(ssh_port_part 'github.example.com')" = "122" ]
+  [ ! "$(ssh_port_part 'github.example.com:22' 2>/dev/null)" ]
+  [ ! "$(ssh_port_part 'github.example.com:5000' 2>/dev/null)" ]
+  [ "$(ssh_port_part 'git@github.example.com:122')" = "122" ]
 )
 end_test
 

--- a/test/test-ghe-restore-external-database.sh
+++ b/test/test-ghe-restore-external-database.sh
@@ -60,7 +60,7 @@ begin_test "ghe-restore allows restore of external DB snapshot to external DB in
   fi
 
   # verify connect to right host
-  check_restore_output_for "Connect 127.0.0.1:22 OK"
+  check_restore_output_for "Connect 127.0.0.1:122 OK"
 
   # verify stale servers were cleared
   check_restore_output_for "Cleaning up stale nodes ..."
@@ -156,7 +156,7 @@ begin_test "ghe-restore allows restore of external DB snapshot to non-external D
   check_restore_output_for "Skipping MySQL restore."
 
   # verify connect to right host
-  check_restore_output_for "Connect 127.0.0.1:22 OK"
+  check_restore_output_for "Connect 127.0.0.1:122 OK"
 
   # verify stale servers were cleared
   check_restore_output_for "Cleaning up stale nodes ..."
@@ -182,7 +182,7 @@ begin_test "ghe-restore allows restore of non external DB snapshot to external D
   check_restore_output_for "Skipping MySQL restore."
 
   # verify connect to right host
-  check_restore_output_for "Connect 127.0.0.1:22 OK"
+  check_restore_output_for "Connect 127.0.0.1:122 OK"
 
   # verify stale servers were cleared
   check_restore_output_for "Cleaning up stale nodes ..."

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -215,7 +215,7 @@ begin_test "ghe-restore with host arg and config value"
   rm "$GHE_BACKUP_CONFIG_TEMP"
 
   # verify host arg overrides configured restore host
-  echo "$output" | grep -q 'Connect localhost:22 OK'
+  echo "$output" | grep -q 'Connect localhost:122 OK'
 
   # Verify all the data we've restored is as expected
   verify_all_restored_data
@@ -239,7 +239,7 @@ begin_test "ghe-restore with host arg"
   output="$(ghe-restore -f localhost)" || false
 
   # verify host arg overrides configured restore host
-  echo "$output" | grep -q 'Connect localhost:22 OK'
+  echo "$output" | grep -q 'Connect localhost:122 OK'
 
   # Verify all the data we've restored is as expected
   verify_all_restored_data

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -56,7 +56,7 @@ begin_test "ghe-restore into configured vm"
   cat "$TRASHDIR/restore-out"
 
   # verify connect to right host
-  grep -q "Connect 127.0.0.1:22 OK" "$TRASHDIR/restore-out"
+  grep -q "Connect 127.0.0.1:122 OK" "$TRASHDIR/restore-out"
 
   # verify stale servers were cleared
   grep -q "Cleaning up stale nodes ..." "$TRASHDIR/restore-out"
@@ -141,7 +141,7 @@ begin_test "ghe-restore -c into unconfigured vm"
   fi
 
   # verify connect to right host
-  grep -q "Connect 127.0.0.1:22 OK" "$TRASHDIR/restore-out"
+  grep -q "Connect 127.0.0.1:122 OK" "$TRASHDIR/restore-out"
 
   # verify attempt to clear stale servers was not made
   grep -q "Cleaning up stale nodes ..." "$TRASHDIR/restore-out" && {
@@ -175,7 +175,7 @@ begin_test "ghe-restore into unconfigured vm"
   ! grep -q "ghe-config-apply OK" "$TRASHDIR/restore-out"
 
   # verify connect to right host
-  grep -q "Connect 127.0.0.1:22 OK" "$TRASHDIR/restore-out"
+  grep -q "Connect 127.0.0.1:122 OK" "$TRASHDIR/restore-out"
 
   # verify attempt to clear stale servers was not made
   grep -q "Cleaning up stale nodes ..." "$TRASHDIR/restore-out" && {

--- a/test/test-ghe-ssh-config.sh
+++ b/test/test-ghe-ssh-config.sh
@@ -20,7 +20,7 @@ begin_test "ghe-ssh-config returns config for multiple nodes"
   # Confirm multiplexing enabled
   echo "$output" | grep -q "ControlMaster=auto"
   # Confirm ControlPath returns correct hash for admin@host1:122
-  echo "$output" | grep -q ".ghe-sshmux-84f6bdcf"
+  echo "$output" | grep -q ".ghe-sshmux-7cb77002"
 )
 end_test
 


### PR DESCRIPTION
## Context
For Github enterprise server the SSH port is always exposed as 122. In `backup-utils`, there are [some logics](https://github.com/github/backup-utils/blob/d792b23737f5e026d76a27f08c7523202c393506/bin/ghe-host-check#L55-L81) unnecessarily check connection ports and default to 22 first if not set and then it will failback to 122 after expected unsuccessful connection. Instead, we just default to 122. If port is set incorrect in `backup.config`, `backup-utils` should bail out.