### PR TITLE
Add -u to date command in ghe-backup-mssql to fix daylight savings bug

### DIFF
--- a/share/github-backup-utils/ghe-backup-mssql
+++ b/share/github-backup-utils/ghe-backup-mssql
@@ -42,7 +42,7 @@ add_minute() {
     echo "$(date -v +$2M -ujf'%Y%m%dT%H%M%S' $1 +%Y%m%dT%H%M%S)"
   else
     dt=$1
-    echo "$(date '+%Y%m%dT%H%M%S' -d "${dt:0:8} ${dt:9:2}:${dt:11:2}:${dt:13:2} $2 minutes")"
+    echo "$(date -u '+%Y%m%dT%H%M%S' -d "${dt:0:8} ${dt:9:2}:${dt:11:2}:${dt:13:2} $2 minutes")"
   fi
 }
 


### PR DESCRIPTION
Resolves https://github.com/github/c2c-actions-platform/issues/3436

This bug happened when the backup timestamp of the "spring forward" hour of daylight savings time in certain timezones, so it was considered an invalid date.

Adding the `-u` flag to the `date` command forces it to assume UTC even if the `TZ` environment variable is set, which fixes the issue (UTC doesn't have daylight savings)

Example of reproing the error and showing the fix with a few simple bash commands:
```
build@ip-10-212-4-85:~$ dt=20210328T020053
build@ip-10-212-4-85:~$ export TZ=Europe/Amsterdam
build@ip-10-212-4-85:~$ echo "$(date '+%Y%m%dT%H%M%S' -d "${dt:0:8} ${dt:9:2}:${dt:11:2}:${dt:13:2} 20 minutes")"
date: invalid date '20210328 02:00:53 20 minutes'

build@ip-10-212-4-85:~$ echo "$(date -u '+%Y%m%dT%H%M%S' -d "${dt:0:8} ${dt:9:2}:${dt:11:2}:${dt:13:2} 20 minutes")"
20210328T022053
```

Example with a another valid date showing that both commands will return the same output when the date is fully valid in both timezones:
```
build@rdelany-r31isulu4:~$ dt=20210428T020053
build@rdelany-r31isulu4:~$ export TZ=Europe/Amsterdam
build@rdelany-r31isulu4:~$ echo "$(date '+%Y%m%dT%H%M%S' -u -d "${dt:0:8} ${dt:9:2}:${dt:11:2}:${dt:13:2} 20 minutes")"
20210428T022053
build@rdelany-r31isulu4:~$ echo "$(date -u '+%Y%m%dT%H%M%S' -d "${dt:0:8} ${dt:9:2}:${dt:11:2}:${dt:13:2} 20 minutes")"
20210428T022053
```

Slack thread with some context from last time we helped a customer through this issue: https://github.slack.com/archives/CNS9X1LHJ/p1628523918244700?thread_ts=1628261157.138800&cid=CNS9X1LHJ