### PR TITLE
Fix compat issue with ghe-actions-start during maintenance mode

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -93,7 +93,14 @@ cleanup () {
 
   if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Restarting Actions after restore ..."
-    ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start' 1>&3
+    # In GHES 3.3+, ghe-actions-start no longer has a -f (force) flag. In GHES 3.2 and below, we must provide the
+    # force flag to make sure it can start in maintenance mode. Use it conditionally based on whether it exists
+    # in the --help output
+    if ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start --help' | grep -q force ; then
+      ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start -f' 1>&3
+    else
+      ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start' 1>&3
+    fi
   fi
 
   # Cleanup SSH multiplexing


### PR DESCRIPTION
Issue: https://github.com/github/backup-utils/issues/797

The problem occurs when using a newer version of backup-utils (3.2+ that includes [this change](https://github.com/github/backup-utils/pull/769/files)) with an older version of GHES (pre-3.3 so it doesn't include [this change](https://github.com/github/enterprise2/pull/26845)) .

We get the following error:
```
Restarting Actions after restore ...
Maintenance mode is set. Skip starting Actions.
```

This change makes it so we use `ghe-actions-start -f` in pre-3.3 builds so that it starts and succeeds even in maintenance mode, and `ghe-actions-start` in 3.3+ builds. We can't use `ghe-actions-start -f` everywhere like the [initial PR](https://github.com/GuyMauve/backup-utils/pull/1) for this issue, since in 3.3+ builds, the `-f` option has been removed and it will fail like so:
```
admin@rdelany-r31isulu4-service-bpdev-us-east-1-github-net-primary:~$ ghe-actions-start -f
Unrecognized argument: -f
...
```