### PR TITLE
Take full mssql backup if Actions backup job has interfered

### DIFF
--- a/share/github-backup-utils/ghe-backup-mssql
+++ b/share/github-backup-utils/ghe-backup-mssql
@@ -14,8 +14,7 @@ set -e
 backup_dir="$GHE_SNAPSHOT_DIR/mssql"
 last_mssql=
 backup_command=
-take_full=
-take_diff=
+backup_type=
 full_expire=
 diff_expire=
 tran_expire=
@@ -53,23 +52,23 @@ find_timestamp() {
   echo $datetime_part
 }
 
-ensure_same_dbs() {
+actions_dbs() {
   all_dbs=$(echo 'set -o pipefail; ghe-mssql-console -y -n -q "SET NOCOUNT ON; SELECT name FROM sys.databases"' | ghe-ssh "$GHE_HOSTNAME" /bin/bash)
-
-  remotes=()
   for db in $all_dbs; do
     if [[ ! "$db" =~ ^(master|tempdb|model|msdb)$ ]] && [[ "$db" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-      remotes+=("$db")
+      echo "$db"
     fi
   done
+}
 
+ensure_same_dbs() {
   locals=()
   while read -r file; do
     filename=$(basename "$file")
     locals+=("$filename")
   done < <(find "$1" \( -name "*.bak" -o -name "*.diff" -o -name "*.log" \))
 
-  for remote in "${remotes[@]}"; do
+  for remote in $(actions_dbs); do
     remaining_locals=()
     for local in "${locals[@]}"; do
       if ! [[ "$local" == "$remote"* ]]; then
@@ -90,13 +89,69 @@ ensure_same_dbs() {
   fi
 }
 
+no_conflicting_backups_exist_db() {
+  backups_dir=$1
+  db=$2
+  ghe_verbose "Checking if the backup job has ran for '$db' since the last backup-utils backup..."
+
+  latest_full_backup=$(find "$backups_dir" -type f -name "$db*.bak" | egrep '[0-9]{8}T[0-9]{6}' | sort | tail -n 1)
+  latest_full_backup_file="${latest_full_backup##*/}"
+
+  ghe_verbose "Found latest full backup file '$latest_full_backup_file' for '$db'"
+
+  backup_info=$(echo "set -o pipefail; ghe-mssql-console -y -n -q \"
+SET NOCOUNT ON;
+SELECT s.backup_set_id
+FROM   msdb.dbo.backupset s
+JOIN   msdb.dbo.backupmediafamily f
+ON     s.media_set_id = f.media_set_id
+WHERE s.database_name = '$db' AND f.physical_device_name LIKE '%$latest_full_backup_file'
+\"" | ghe-ssh "$GHE_HOSTNAME" /bin/bash)
+  read -r latest_full_backup_id <<< "$backup_info"
+
+  if [ -z "$latest_full_backup_id" ]; then
+    # For now, if we can't find a record of the full backup we have (e.g. backup logs are being cleared) assume that it's ok
+    ghe_verbose "No backup record found in DB for '$latest_full_backup_file'"
+    return 0
+  fi
+
+  ghe_verbose "Backup $latest_full_backup_file found in DB records with ID $latest_full_backup_id. Checking for conflicts since then..."
+
+  # Actions has a built-in backup mechanism to ensure transaction logs are pruned, if it detects backup-utils is not running.
+  # In the rare case this mechanism runs while backup-utils is actually being used, it can cause a break in the LSN chain of backup-utils backups.
+  conflicting_backups=$(echo "set -o pipefail; ghe-mssql-console -y -n -q \"
+SET NOCOUNT ON;
+SELECT f.physical_device_name
+FROM   msdb.dbo.backupset s
+JOIN   msdb.dbo.backupmediafamily f
+ON     s.media_set_id = f.media_set_id
+WHERE s.database_name = '$db' AND s.backup_set_id > $latest_full_backup_id AND f.physical_device_name LIKE '%backups/internal%'
+\"" | ghe-ssh "$GHE_HOSTNAME" /bin/bash)
+
+  if [ -n "$conflicting_backups" ]; then
+    ghe_verbose "Found conflicting backup(s):"
+    for file in $conflicting_backups; do
+      ghe_verbose "  $file"
+    done
+    return 1
+  fi
+}
+
+no_conflicting_backups_exist() {
+  backups_dir=$1
+  for db in $(actions_dbs); do
+    if ! no_conflicting_backups_exist_db "$backups_dir" "$db"; then
+      return 1
+    fi
+  done
+}
+
 last_mssql=$GHE_DATA_DIR/current/mssql
 
 if [ ! -d $last_mssql ] \
   || [ -z "$(find $last_mssql -type f -name '*.bak' | head -n 1)" ]; then
   ghe_verbose "Taking first full backup"
-  take_full=1
-  backup_command='ghe-export-mssql'
+  backup_type="full"
 else
   ensure_same_dbs "$last_mssql"
 
@@ -128,25 +183,29 @@ else
   ghe_verbose "current $current, full expire $full_expire, \
 diff expire $diff_expire, tran expire $tran_expire"
 
-  # Determine the type of backup to take
+  # Determine the type of backup to take based on expiry time
   if [ $current -gt $full_expire ]; then
-    ghe_verbose "Taking full backup"
-    take_full=1
-    backup_command='ghe-export-mssql'
+    backup_type='full'
   elif [ $current -gt $diff_expire ]; then
-    ghe_verbose "Taking diff backup"
-    take_diff=1
-    backup_command='ghe-export-mssql -d'
+    backup_type='diff'
   elif [ $current -gt $tran_expire ]; then
-    ghe_verbose "Taking transaction backup"
-    backup_command='ghe-export-mssql -t'
+    backup_type='transaction'
   fi
+
+  # Upgrade to a full backup if the diff/transaction backup might not be restorable due to other backup mechanisms
+  if [ "$backup_type" == 'diff' ] || [ "$backup_type" == 'transaction' ]; then
+    ghe_verbose "Checking for conflicting backups to ensure a $backup_type backup is sufficient."
+    if ! no_conflicting_backups_exist "$last_mssql"; then
+      ghe_verbose "Found conflicting backups from another backup mechanism. A full backup will be performed to ensure restorability."
+      backup_type='full'
+    fi
+  fi  
 fi
 
 # Make sure root backup dir exists if this is the first run
 mkdir -p "$backup_dir"
 
-# Create hard links to save disk space and time
+# Use hard links to "copy" over previous applicable backups to the new snapshot folder to save disk space and time
 if [ -d $last_mssql ]; then
   for p in $last_mssql/*
   do
@@ -156,15 +215,18 @@ if [ -d $last_mssql ]; then
     extension="${filename##*.}"
     transfer=
 
-    if [ $extension = "bak" ] && [ -z $take_full ]; then
+    # Copy full backups unless we're taking a new full backup
+    if [ $extension = "bak" ] && [ "$backup_type" != 'full' ]; then
       transfer=1
     fi
 
-    if [ $extension = "diff" ] && [ -z $take_full ] && [ -z $take_diff ]; then
+    # Copy diff backups unless we're taking a new full or diff backup
+    if [ $extension = "diff" ] && [ "$backup_type" != 'full' ] && [ "$backup_type" != 'diff' ]; then
       transfer=1
     fi
 
-    if [ $extension = "log" ] && [ -z $take_full ] && [ -z $take_diff ]; then
+    # Copy transaction log backups unless we're taking a new full or diff backup
+    if [ $extension = "log" ] && [ "$backup_type" != 'full' ] && [ "$backup_type" != 'diff' ]; then
       transfer=1
     fi
 
@@ -175,7 +237,16 @@ if [ -d $last_mssql ]; then
   done
 fi
 
-if [ -n "$backup_command" ]; then
+if [ -n "$backup_type" ]; then
+  ghe_verbose "Taking $backup_type backup"
+
+  backup_command='ghe-export-mssql'
+  if [ "$backup_type" = "diff" ]; then
+    backup_command='ghe-export-mssql -d'
+  elif [ "$backup_type" = "transaction" ]; then
+    backup_command='ghe-export-mssql -t'
+  fi
+
   bm_start "$(basename $0)"
   ghe-ssh "$GHE_HOSTNAME" -- "$backup_command" || failures="$failures mssql"
   bm_end "$(basename $0)"


### PR DESCRIPTION
Actions now has an internal mechanism named `TransactionLogMaintenanceJob` which tries to detect if backup-utils is not running, and if so takes its own backups to prevent runaway transaction log growth.

In rare cases where this job does take a backup and then backup-utils runs again (e.g. `backup-utils` temporarily turned off), the diff or transaction log backup may have the wrong full backup base. That is, the new diff/transaction backup may be based on the full backup that `TransactionLogMaintenanceJob` took rather than the last backup-utils full backup. In such a case, the set of backup-utils files does not represent a complete LSN chain and may not be restorable.

This PR attempts to fix this issue by detecting if the internal Actions job run since the last completed backup-utils full backup. If so (and a diff/transaction backup is due to run) the backup will be "upgraded" to a full backup to reset the chain and ensure the backup-utils snapshot is restorable.