### PR TITLE
Fix broken macOS tests (except parallel restore)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Install Dependencies (macOS)
       run: |
         brew install gnu-tar shellcheck jq pigz coreutils gnu-sed gnu-getopt
-        brew unlink parallel
         brew install moreutils gawk
       if: matrix.os == 'macos-latest'
     - name: Get Sources

--- a/test/bin/systemctl
+++ b/test/bin/systemctl
@@ -1,0 +1,1 @@
+ghe-fake-true

--- a/test/test-ghe-restore-parallel.sh
+++ b/test/test-ghe-restore-parallel.sh
@@ -2,6 +2,12 @@
 # ghe-restore command tests run in parallel
 set -e
 
+# Currently disabled on macOS due to rsync issues
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  echo "Skipping $(basename "$0") tests as they are temporarily disabled on macOS: https://github.com/github/backup-utils/issues/841"
+  exit 0
+fi
+
 export GHE_PARALLEL_ENABLED=yes
 
 # use temp dir to fix rsync file issues in parallel execution:


### PR DESCRIPTION
Fixes long-broken macOS test run by:
1. Skipping `brew unlink parallel`, which is failing and now appears to be unnecessary
2. Adding a missing test stub for `systemctl`
3. Temporarily disabling parallel restore tests, which have remaining rsync issues documented in https://github.com/github/backup-utils/issues/841