### PR TITLE
Revert logic for host check

### DIFF
--- a/bin/ghe-host-check
+++ b/bin/ghe-host-check
@@ -52,8 +52,38 @@ options="
 port=$(ssh_port_part "$host")
 hostname=$(ssh_host_part "$host")
 
+set +e
 # ghe-negotiate-version verifies if the target is a Github Enterprise Server instance
 output=$(echo "ghe-negotiate-version backup-utils $BACKUP_UTILS_VERSION" | ghe-ssh -o BatchMode=no $options $host -- /bin/sh 2>&1)
+rc=$?
+set -e
+
+if [ $rc -ne 0 ]; then
+  case $rc in
+  255)
+    if echo "$output" | grep -i "port 22: Network is unreachable\|port 22: connection refused\|port 22: no route to host\|ssh_exchange_identification: Connection closed by remote host\|Connection timed out during banner exchange\|port 22: Connection timed out" >/dev/null; then
+      exec "$(basename $0)" "$hostname:122"
+    fi
+
+    echo "$output" 1>&2
+    echo "Error: ssh connection with '$host' failed" 1>&2
+    echo "Note that your SSH key needs to be setup on $host as described in:" 1>&2
+    echo "* https://enterprise.github.com/help/articles/adding-an-ssh-key-for-shell-access" 1>&2
+    ;;
+  101)
+    echo "Error: couldn't read GitHub Enterprise Server fingerprint on '$host' or this isn't a GitHub appliance." 1>&2
+    ;;
+  1)
+    if [ "${port:-22}" -eq 22 ] && echo "$output" | grep "use port 122" >/dev/null; then
+      exec "$(basename $0)" "$hostname:122"
+    else
+      echo "$output" 1>&2
+    fi
+    ;;
+
+  esac
+  exit $rc
+fi
 
 CLUSTER=false
 if ghe-ssh "$host" -- \


### PR DESCRIPTION
Revert the changes to `ghe-host-check` to make the error more verbose and clear.

Thanks @charmian01 for validating the change.

Resolves: https://github.com/github/backup-utils/issues/858
Resolves: https://github.com/github/backup-utils/issues/861