### PR TITLE
Prevent GitHub Connect jobs running until config has been reset

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -446,6 +446,14 @@ echo "Restarting memcached ..." 1>&3
 echo "sudo restart -q memcached 2>/dev/null || true" |
   ghe-ssh "$GHE_HOSTNAME" -- /bin/sh
 
+# Prevent GitHub Connect jobs running before we've had a chance to reset
+# the configuration by setting the last run date to now.
+if ! $RESTORE_SETTINGS; then
+  echo "Setting last run date for GitHub Connect jobs ..." 1>&3
+  echo "now=$(date +%s.0000000); ghe-redis-cli mset timer:UpdateConnectInstallationInfo \$now timer:UploadEnterpriseServerUserAccountsJob \$now timer:UploadConnectMetricsJob \$now timer:GitHubConnectPushNewContributionsJob \$now" |
+    ghe-ssh "$GHE_HOSTNAME" -- /bin/sh 1>&3
+fi
+
 # When restoring to a host that has already been configured, kick off a
 # config run to perform data migrations.
 if $CLUSTER; then


### PR DESCRIPTION
It has been discovered that when restoring a backup without configuration (ie without `-c|--config`) the four GitHub Connect-related background jobs are running as soon as `timerd` starts as part of the `ghe-config-apply` that runs.

This is happening before the GitHub Connect clean-up code has had a chance to remove the original host information. This leads to the hostname of the original instance changing on GitHub to match the destination instance. It can also lead to inaccurate license usage and user contributions from the destination host being uploaded and associated with the original host.

This PR resolves that by preventing the GitHub Connect-related jobs from running on start up by setting their last execution time to being the time of the restore. These jobs run hourly or weekly which gives us plenty of time to reset the GitHub Connect information which happens immediately after the `ghe-config-apply` has finished.