### PR TITLE
Check for .tar.xz instead of .tar.gz when publishing Debian package

### DIFF
--- a/script/package-deb
+++ b/script/package-deb
@@ -26,6 +26,6 @@ git checkout -q "$PKG_HEAD"
 
 debuild -uc -us 1>&2
 cd ..
-files=$(ls -1 *.deb *.tar.gz *.dsc *.changes)
+files=$(ls -1 *.deb *.tar.xz *.dsc *.changes)
 mv $files ../
 for f in $files; do echo "dist/$f"; done


### PR DESCRIPTION
In #726 we moved to a more modern Debian package format but failed to take into account the necessary changes to the package-deb script, which now needed to expect a `.tar.xz` instead of a `.tar.gz`.

cc: @SteveCulver 