### PR TITLE
Bump the hardcoded check values in the host check test to unbreak CI

### DIFF
--- a/test/test-ghe-host-check.sh
+++ b/test/test-ghe-host-check.sh
@@ -61,7 +61,8 @@ begin_test "ghe-host-check detects unsupported GitHub Enterprise Server versions
   ! GHE_TEST_REMOTE_VERSION=2.21.0 ghe-host-check
   ! GHE_TEST_REMOTE_VERSION=2.22.0 ghe-host-check
   ! GHE_TEST_REMOTE_VERSION=3.0.0 ghe-host-check
-  GHE_TEST_REMOTE_VERSION=3.1.0 ghe-host-check
+  ! GHE_TEST_REMOTE_VERSION=3.1.0 ghe-host-check
+  GHE_TEST_REMOTE_VERSION=3.2.0 ghe-host-check
   GHE_TEST_REMOTE_VERSION=$BACKUP_UTILS_VERSION ghe-host-check
   GHE_TEST_REMOTE_VERSION=$BACKUP_UTILS_VERSION ghe-host-check
   GHE_TEST_REMOTE_VERSION=$bu_version_major.$bu_version_minor.999 ghe-host-check


### PR DESCRIPTION
See title.  cc: @SteveCulver 