### PR TITLE
Backport 3.3.2 simplify redirects

### DIFF
--- a/share/github-backup-utils/ghe-rsync
+++ b/share/github-backup-utils/ghe-rsync
@@ -21,8 +21,8 @@ else
 fi
 
 ignoreout='^(file has vanished: |rsync warning: some files vanished before they could be transferred)'
-rsync_version_check=`rsync --version | egrep "version 2.[0-9]*.[0-9]*"`
-if [ -z "$rsync_version_check" ]; then
+rsync_version_check=`rsync --version | egrep "version 3.[0-9]*.[0-9]*"`
+if [ ! -z "$rsync_version_check" ]; then
   # rsync >= 3.x sends errors to stderr. so, we need to redirect to stdout before the pipe
   rsync "${parameters[@]}" $GHE_EXTRA_RSYNC_OPTS 2>&1 | (egrep -v "$ignoreout" || true)
 else


### PR DESCRIPTION
Manual backport of https://github.com/github/backup-utils/pull/881 to a release candidate for 3.3.2.