### PR TITLE
On restore failure, restart cron on target host

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -86,6 +86,19 @@ while true; do
   esac
 done
 
+start_cron () {
+  echo "Starting cron ..."
+  if $CLUSTER; then
+    if ! ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- sudo service cron start"; then
+      echo "* Warning: Failed to start cron on one or more nodes"
+    fi
+  else
+    if ! ghe-ssh "$GHE_HOSTNAME" -- "sudo service cron start"; then
+      echo "* Warning: Failed to start cron"
+    fi
+  fi
+}
+
 cleanup () {
   if [ -n "$1" ]; then
     update_restore_status "$1"
@@ -101,6 +114,10 @@ cleanup () {
     else
       ghe-ssh "$GHE_HOSTNAME" -- 'ghe-actions-start' 1>&3
     fi
+  fi
+
+  if ! $CRON_RUNNING; then
+    start_cron
   fi
 
   # Cleanup SSH multiplexing
@@ -249,6 +266,7 @@ update_restore_status () {
   fi
 }
 
+CRON_RUNNING=true
 # Update remote restore state file and setup failure trap
 trap "cleanup failed" EXIT
 update_restore_status "restoring"
@@ -314,7 +332,7 @@ else
     fi
   fi
 fi
-
+CRON_RUNNING=false
 
 # Restore settings and license if restoring to an unconfigured appliance or when
 # specified manually.
@@ -474,16 +492,8 @@ if ! $RESTORE_SETTINGS; then
 fi
 
 # Start cron. Timerd will start automatically as part of the config run.
-echo "Starting cron ..."
-if $CLUSTER; then
-  if ! ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- sudo service cron start"; then
-    echo "* Warning: Failed to start cron on one or more nodes"
-  fi
-else
-  if ! ghe-ssh "$GHE_HOSTNAME" -- "sudo service cron start"; then
-    echo "* Warning: Failed to start cron"
-  fi
-fi
+start_cron
+CRON_RUNNING=true
 
 # Clean up all stale replicas on configured instances.
 if ! $CLUSTER && $instance_configured; then


### PR DESCRIPTION
Manual backport of https://github.com/github/backup-utils/pull/883 to a release candidate for 3.3.2.

Corrects https://github.com/github/backup-utils/pull/894.