### PR TITLE
Backup and restore packages settings

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -116,6 +116,16 @@ if ghe-ssh "$host" -- ghe-config --true app.actions.enabled; then
   backup-secret "Actions Launch service private key" "actions-launch-app-app-private-key" "secrets.launch.azp-app-private-key"
 fi
 
+if ghe-ssh "$host" -- ghe-config --true app.packages.enabled; then
+  backup-secret "Packages aws access key" "packages-aws-access-key" "secrets.packages.aws-access-key"
+  backup-secret "Packages aws secret key" "packages-aws-secret-key" "secrets.packages.aws-secret-key"
+  backup-secret "Packages s3 bucket" "packages-s3-bucket" "secrets.packages.s3-bucket"
+  backup-secret "Packages storage service url" "packages-service-url" "secrets.packages.service-url"
+  backup-secret "Packages blob storage type" "packages-blob-storage-type" "secrets.packages.blob-storage-type"
+  backup-secret "Packages azure connection string" "packages-azure-connection-string" "secrets.packages.azure-connection-string"
+  backup-secret "Packages azure container name" "packages-azure-container-name" "secrets.packages.azure-container-name"
+fi
+
 if ghe-ssh "$host" -- "test -f $GHE_REMOTE_DATA_USER_DIR/common/idp.crt"; then
   echo "* Transferring SAML keys ..." 1>&3
   ghe-ssh $host -- sudo tar -C $GHE_REMOTE_DATA_USER_DIR/common/ -cf - "idp.crt saml-sp.p12" > saml-keys.tar

--- a/share/github-backup-utils/ghe-restore-packages
+++ b/share/github-backup-utils/ghe-restore-packages
@@ -22,9 +22,10 @@ GHE_HOSTNAME="$1"
 : ${GHE_RESTORE_SNAPSHOT:=current}
 
 # Path to snapshot dir we're restoring from
-GHE_RESTORE_SNAPSHOT_PATH="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
+export GHE_RESTORE_SNAPSHOT_PATH="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 
 port=$(ssh_port_part "$GHE_HOSTNAME")
+export port
 host=$(ssh_host_part "$GHE_HOSTNAME")
 
 # Perform a host-check and establish GHE_REMOTE_XXX variables.

--- a/share/github-backup-utils/ghe-restore-packages
+++ b/share/github-backup-utils/ghe-restore-packages
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#/ Usage: ghe-restore-packages <host>
+#/
+#/ Note: This script typically isn't called directly. It's invoked by the
+#/ ghe-restore command.
+set -e
+
+# Bring in the backup configuration
+# shellcheck source=share/github-backup-utils/ghe-backup-config
+. "$( dirname "${BASH_SOURCE[0]}" )/ghe-backup-config"
+
+# Show usage and bail with no arguments
+[ -z "$*" ] && print_usage
+
+bm_start "$(basename $0)"
+
+# Grab host arg
+GHE_HOSTNAME="$1"
+
+# The snapshot to restore should be set by the ghe-restore command but this lets
+# us run this script directly.
+: ${GHE_RESTORE_SNAPSHOT:=current}
+
+# Path to snapshot dir we're restoring from
+GHE_RESTORE_SNAPSHOT_PATH="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
+
+port=$(ssh_port_part "$GHE_HOSTNAME")
+host=$(ssh_host_part "$GHE_HOSTNAME")
+
+# Perform a host-check and establish GHE_REMOTE_XXX variables.
+ghe_remote_version_required "$host"
+
+# Restore Packages settings.
+ghe_verbose "Restoring Packages settings ..."
+
+restore-secret "Packages aws access key" "packages-aws-access-key" "secrets.packages.aws-access-key"
+restore-secret "Packages aws secret key" "packages-aws-secret-key" "secrets.packages.aws-secret-key"
+restore-secret "Packages s3 bucket" "packages-s3-bucket" "secrets.packages.s3-bucket"
+restore-secret "Packages storage service url" "packages-service-url" "secrets.packages.service-url"
+restore-secret "Packages blob storage type" "packages-blob-storage-type" "secrets.packages.blob-storage-type"
+restore-secret "Packages azure connection string" "packages-azure-connection-string" "secrets.packages.azure-connection-string"
+restore-secret "Packages azure container name" "packages-azure-container-name" "secrets.packages.azure-container-name"
+
+bm_end "$(basename $0)"

--- a/share/github-backup-utils/ghe-restore-settings
+++ b/share/github-backup-utils/ghe-restore-settings
@@ -33,6 +33,9 @@ echo "Restoring settings and applying configuration ..."
 # Restore external MySQL password if running external MySQL DB.
 restore-secret "external MySQL password" "external-mysql-password" "secrets.external.mysql"
 
+echo "Restoring packages settings ..."
+ghe-restore-packages "$GHE_HOSTNAME" 1>&3
+
 # work around issue importing settings with bad storage mode values
 ( cat "$GHE_RESTORE_SNAPSHOT_PATH/settings.json" && echo ) |
   sed 's/"storage_mode": "device"/"storage_mode": "rootfs"/' |


### PR DESCRIPTION
Adds packages settings to backup and restore. `ghe-restore -c` currently fails when packages is enabled

- Fixes https://github.com/github/c2c-package-registry/issues/4756