### PR TITLE
Update Dockerfile to buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 RUN apt-get -q -y update && \
     apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN apt-get -q -y update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Stretch is reaching end of life, so this moves the Dockerfile base ahead to `buster`