### PR TITLE
Stop restore when a backup without Actions is being restored onto an appliance with Actions enabled

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -286,7 +286,7 @@ fi
 RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-version' | cut -d '.' -f 1,2)
 
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
-# mismatches in the secrets needed for Actions which ultimately results in Actions not working properly.
+# mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
 ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --list | grep "app.actions.enabled" | xargs)
 # Get the value of app.actions.enabled
 ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP#*=}

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -287,8 +287,8 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
-ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json app.actions.enabled | xargs)
-if [[ $ACTIONS_ENABLED_IN_BACKUP != "true" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --bool app.actions.enabled | xargs)
+if [[ $ACTIONS_ENABLED_IN_BACKUP != true ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1
 fi

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -285,17 +285,17 @@ fi
 # Get GHES release version in major.minor format
 RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-version' | cut -d '.' -f 1,2)
 
-
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly.
-ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --list | tr . _ | grep "app_actions_enabled" | awk -F"=" '{ print $2 }')
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --list | grep "app.actions.enabled" | xargs)
+# Get the value of app.actions.enabled
+ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP#*=}
 # If ACTIONS_ENABLED_IN_BACKUP is still empty, then set it to the default value of "false"
-ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP:-false}
+ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP:-"false"}
 if [[ $ACTIONS_ENABLED_IN_BACKUP == "false" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1
 fi
-
 
 # Make sure the GitHub appliance has Actions enabled if the snapshot contains Actions data.
 # If above is true, also check if ac is present in appliance then snapshot should also contains ac databases

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -287,7 +287,7 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
-ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --bool app.actions.enabled | xargs || false)
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --bool app.actions.enabled | xargs)
 if [[ $ACTIONS_ENABLED_IN_BACKUP != true ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -289,6 +289,8 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly.
 ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --list | tr . _ | grep "app_actions_enabled" | awk -F"=" '{ print $2 }')
+# If ACTIONS_ENABLED_IN_BACKUP is still empty, then set it to the default value of "false"
+ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP:-false}
 if [[ $ACTIONS_ENABLED_IN_BACKUP == "false" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -287,12 +287,10 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
-ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --list | grep "app.actions.enabled" | xargs)
-# Get the value of app.actions.enabled
-ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP#*=}
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json app.actions.enabled | xargs)
 # If ACTIONS_ENABLED_IN_BACKUP is still empty, then set it to the default value of "false"
 ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP:-"false"}
-if [[ $ACTIONS_ENABLED_IN_BACKUP == "false" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
+if [[ $ACTIONS_ENABLED_IN_BACKUP != "true" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1
 fi

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -288,8 +288,6 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
 ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json app.actions.enabled | xargs)
-# If ACTIONS_ENABLED_IN_BACKUP is still empty, then set it to the default value of "false"
-ACTIONS_ENABLED_IN_BACKUP=${ACTIONS_ENABLED_IN_BACKUP:-"false"}
 if [[ $ACTIONS_ENABLED_IN_BACKUP != "true" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -285,6 +285,16 @@ fi
 # Get GHES release version in major.minor format
 RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-version' | cut -d '.' -f 1,2)
 
+
+# If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
+# mismatches in the secrets needed for Actions which ultimately results in Actions not working properly.
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --list | tr . _ | grep "app_actions_enabled" | awk -F"=" '{ print $2 }')
+if [[ $ACTIONS_ENABLED_IN_BACKUP == "false" ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
+    echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
+    exit 1
+fi
+
+
 # Make sure the GitHub appliance has Actions enabled if the snapshot contains Actions data.
 # If above is true, also check if ac is present in appliance then snapshot should also contains ac databases
 if [ -d "$GHE_RESTORE_SNAPSHOT_PATH/mssql" ] || [ -d "$GHE_RESTORE_SNAPSHOT_PATH/actions" ]; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -287,7 +287,7 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
-ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --bool app.actions.enabled | xargs)
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --bool app.actions.enabled | xargs || false)
 if [[ $ACTIONS_ENABLED_IN_BACKUP != true ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -6,7 +6,7 @@
 . "$(dirname "$0")/testlib.sh"
 
 setup_test_data "$GHE_DATA_DIR/1"
-setup_actions_enabled_settings_for_restore true
+setup_actions_enabled_in_settings_json true
 
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"
@@ -289,7 +289,6 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
-  setup_actions_enabled_in_settings_json true
   enable_actions
 
   # enable maintenance mode and create required directories
@@ -316,7 +315,6 @@ begin_test "ghe-restore with Actions settings"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
-  setup_actions_enabled_in_settings_json true
   enable_actions
 
   required_files=(
@@ -438,7 +436,6 @@ begin_test "ghe-restore with Actions data"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
-  setup_actions_enabled_in_settings_json true
   enable_actions
 
   setup_maintenance_mode "configured"
@@ -710,10 +707,10 @@ begin_test "ghe-restore fails if Actions is disabled in the backup but enabled o
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
+  setup_actions_enabled_in_settings_json false
+  enable_actions
 
   setup_maintenance_mode "configured"
-
-  setup_actions_enabled_in_settings_json false
 
   ! ghe-restore -v -f localhost
 )

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -290,7 +290,6 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
-  setup_actions_enabled_settings_for_restore true
 
   # enable maintenance mode and create required directories
   setup_maintenance_mode
@@ -317,7 +316,6 @@ begin_test "ghe-restore with Actions settings"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
-  setup_actions_enabled_settings_for_restore true
 
   required_files=(
     "actions-config-db-login"
@@ -405,7 +403,6 @@ begin_test "ghe-restore stops and starts Actions"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
-  setup_actions_enabled_settings_for_restore true
 
   setup_maintenance_mode "configured"
 
@@ -440,7 +437,6 @@ begin_test "ghe-restore with Actions data"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
-  setup_actions_enabled_settings_for_restore true
 
   setup_maintenance_mode "configured"
 

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -289,8 +289,8 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
-  setup_actions_enabled_settings_for_restore true
   enable_actions
+  setup_actions_enabled_settings_for_restore true
 
   # enable maintenance mode and create required directories
   setup_maintenance_mode
@@ -317,6 +317,7 @@ begin_test "ghe-restore with Actions settings"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
+  setup_actions_enabled_settings_for_restore true
 
   required_files=(
     "actions-config-db-login"
@@ -404,6 +405,7 @@ begin_test "ghe-restore stops and starts Actions"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
+  setup_actions_enabled_settings_for_restore true
 
   setup_maintenance_mode "configured"
 
@@ -438,6 +440,7 @@ begin_test "ghe-restore with Actions data"
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
   enable_actions
+  setup_actions_enabled_settings_for_restore true
 
   setup_maintenance_mode "configured"
 

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -291,7 +291,6 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   setup_remote_metadata
   enable_actions
   setup_actions_enabled_settings_for_restore true
-  echo "$GHE_DATA_DIR/1/settings.json"
 
   # enable maintenance mode and create required directories
   setup_maintenance_mode

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -6,7 +6,7 @@
 . "$(dirname "$0")/testlib.sh"
 
 setup_test_data "$GHE_DATA_DIR/1"
-setup_actions_enabled_in_settings_json true
+setup_actions_enabled_settings_for_restore true
 
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"
@@ -707,7 +707,7 @@ begin_test "ghe-restore fails if Actions is disabled in the backup but enabled o
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
-  setup_actions_enabled_in_settings_json false
+  setup_actions_enabled_settings_for_restore false
   enable_actions
 
   setup_maintenance_mode "configured"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -291,6 +291,7 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   setup_remote_metadata
   enable_actions
   setup_actions_enabled_settings_for_restore true
+  echo "$GHE_DATA_DIR/1/settings.json"
 
   # enable maintenance mode and create required directories
   setup_maintenance_mode

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -289,6 +289,7 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
+  setup_actions_enabled_settings_for_restore true
   enable_actions
 
   # enable maintenance mode and create required directories

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -6,7 +6,7 @@
 . "$(dirname "$0")/testlib.sh"
 
 setup_test_data "$GHE_DATA_DIR/1"
-setup_actions_enabled_settings_for_restore false
+setup_actions_enabled_settings_for_restore true
 
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -6,6 +6,7 @@
 . "$(dirname "$0")/testlib.sh"
 
 setup_test_data "$GHE_DATA_DIR/1"
+setup_actions_enabled_settings_for_restore false
 
 # Make the current symlink
 ln -s 1 "$GHE_DATA_DIR/current"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -289,6 +289,7 @@ begin_test "ghe-restore invokes ghe-import-mssql"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
+  setup_actions_enabled_in_settings_json true
   enable_actions
 
   # enable maintenance mode and create required directories
@@ -315,6 +316,7 @@ begin_test "ghe-restore with Actions settings"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
+  setup_actions_enabled_in_settings_json true
   enable_actions
 
   required_files=(
@@ -436,6 +438,7 @@ begin_test "ghe-restore with Actions data"
   set -e
   rm -rf "$GHE_REMOTE_ROOT_DIR"
   setup_remote_metadata
+  setup_actions_enabled_in_settings_json true
   enable_actions
 
   setup_maintenance_mode "configured"

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -700,3 +700,17 @@ end_test
 #     verify_all_restored_data
 # )
 # end_test
+
+begin_test "ghe-restore fails if Actions is disabled in the backup but enabled on the appliance"
+(
+  set -e
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+
+  setup_maintenance_mode "configured"
+
+  setup_actions_enabled_in_settings_json false
+
+  ! ghe-restore -v -f localhost
+)
+end_test

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -597,11 +597,10 @@ cleanup_moreutils_parallel() {
 
 # setup_actions_enabled_in_settings_json writes settings for the Actions app to settings.json
 # it accepts true or false as first argument to enable or disable actions in settings.json
-setup_actions_enabled_in_settings_json() {
+setup_actions_enabled_settings_for_restore() {
   echo "
   [app \"actions\"]
 	  enabled = $1
 	  setup-failures-detected = false
-  " >> "$loc/settings.json"
+  " >> "$GHE_DATA_DIR/1/settings.json"
 }
-setup_actions_enabled_in_settings_json true

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -600,7 +600,7 @@ cleanup_moreutils_parallel() {
 setup_actions_enabled_settings_for_restore() {
   echo "
   [app \"actions\"]
-	  enabled = $1
-	  setup-failures-detected = false
-  " >> "$GHE_DATA_DIR/1/settings.json"
+	enabled = $1
+	setup-failures-detected = false
+  " > "$GHE_DATA_DIR/1/settings.json"
 }

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -598,9 +598,5 @@ cleanup_moreutils_parallel() {
 # setup_actions_enabled_in_settings_json writes settings for the Actions app to settings.json
 # it accepts true or false as first argument to enable or disable actions in settings.json
 setup_actions_enabled_settings_for_restore() {
-  echo "
-  [app \"actions\"]
-	enabled = $1
-	setup-failures-detected = false
-  " > "$GHE_DATA_DIR/1/settings.json"
+  git config -f "$GHE_DATA_DIR/1/settings.json" --bool app.actions.enabled $1
 }

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -600,7 +600,7 @@ cleanup_moreutils_parallel() {
 setup_actions_enabled_in_settings_json() {
   echo "
   [app \"actions\"]
-	  enabled = ${$1}
+	  enabled = $1
 	  setup-failures-detected = false
   " >> "$loc/settings.json"
 }

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -312,7 +312,7 @@ setup_test_data () {
     echo "fake ghe-export-authorized-keys data" > "$loc/authorized-keys.json"
     echo "fake ghe-export-ssh-host-keys data" > "$TRASHDIR/ssh-host-keys"
     tar -C $TRASHDIR -cf "$loc/ssh-host-keys.tar" ssh-host-keys
-    echo "[fake ghe-export-settings data]" > "$loc/settings.json"
+    echo "fake ghe-export-settings data" > "$loc/settings.json"
     echo "fake ghe-export-ssl-ca-certificates data" > "$loc/ssl-ca-certificates.tar"
     echo "fake license data" > "$loc/enterprise.ghl"
     echo "fake password hash data" > "$loc/manage-password"
@@ -594,3 +594,14 @@ cleanup_moreutils_parallel() {
     unlink "$ROOTDIR/test/bin/parallel"
   fi
 }
+
+# setup_actions_enabled_in_settings_json writes settings for the Actions app to settings.json
+# it accepts true or false as first argument to enable or disable actions in settings.json
+setup_actions_enabled_in_settings_json() {
+  echo "
+  [app \"actions\"]
+	  enabled = ${$1}
+	  setup-failures-detected = false
+  " >> "$loc/settings.json"
+}
+setup_actions_enabled_in_settings_json true

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -598,5 +598,7 @@ cleanup_moreutils_parallel() {
 # setup_actions_enabled_in_settings_json writes settings for the Actions app to settings.json
 # it accepts true or false as first argument to enable or disable actions in settings.json
 setup_actions_enabled_settings_for_restore() {
+  # Empty the file, it now contains "fake ghe-export-settings data"
+  > "$GHE_DATA_DIR/1/settings.json"
   git config -f "$GHE_DATA_DIR/1/settings.json" --bool app.actions.enabled $1
 }

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -599,6 +599,6 @@ cleanup_moreutils_parallel() {
 # it accepts true or false as first argument to enable or disable actions in settings.json
 setup_actions_enabled_settings_for_restore() {
   # Empty the file, it now contains "fake ghe-export-settings data"
-  > "$GHE_DATA_DIR/1/settings.json"
+  echo > "$GHE_DATA_DIR/1/settings.json"
   git config -f "$GHE_DATA_DIR/1/settings.json" --bool app.actions.enabled $1
 }

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -312,7 +312,7 @@ setup_test_data () {
     echo "fake ghe-export-authorized-keys data" > "$loc/authorized-keys.json"
     echo "fake ghe-export-ssh-host-keys data" > "$TRASHDIR/ssh-host-keys"
     tar -C $TRASHDIR -cf "$loc/ssh-host-keys.tar" ssh-host-keys
-    echo "fake ghe-export-settings data" > "$loc/settings.json"
+    echo "[fake ghe-export-settings data]" > "$loc/settings.json"
     echo "fake ghe-export-ssl-ca-certificates data" > "$loc/ssl-ca-certificates.tar"
     echo "fake license data" > "$loc/enterprise.ghl"
     echo "fake password hash data" > "$loc/manage-password"


### PR DESCRIPTION
When a backup without Actions is being restored onto an appliance with Actions enabled, one or more of the secrets/config values used for Actions will be mismatched. Some of the config values I just mentioned are located in places that are not touched by the backup being restored, therefore the (to-be-restored) appliance still has old, pre-restore data laying around (in the database and env variables).

@boxofyellow and I decided to  stop users from restoring backups without Actions onto appliances that do have Actions enabled.