### PR TITLE
refactor: ghe-cluster-each --print, --ip, --uuid flags

### DIFF
--- a/share/github-backup-utils/ghe-backup-git-hooks
+++ b/share/github-backup-utils/ghe-backup-git-hooks
@@ -43,7 +43,7 @@ if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-backup-pages
+++ b/share/github-backup-utils/ghe-backup-pages
@@ -43,7 +43,7 @@ if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "pages-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "pages-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -74,7 +74,7 @@ if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -47,7 +47,7 @@ if [ "$GHE_BACKUP_STRATEGY" = "cluster" ]; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "storage-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "storage-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-cluster-find-nodes
+++ b/share/github-backup-utils/ghe-cluster-find-nodes
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#/ Usage: ghe-cluster-nodes <host> <prefix>
+#/ Usage: ghe-cluster-find-nodes <host> <prefix>
 #/
 #/ Finds all nodes of the cluster using the config on <host>.
 #/ If it is a 2.8 and later cluster version the results are returned as
@@ -28,7 +28,7 @@ prefix="$2"
 role=$(echo "$prefix" | cut -d '-' -f1)
 
 if ghe-ssh "$GHE_HOSTNAME" test -f $GHE_REMOTE_ROOT_DIR/etc/github/cluster; then
-  node_uuids=$(ghe-ssh "$GHE_HOSTNAME" ghe-cluster-each -r "$role" -u)
+  node_uuids=$(ghe-ssh "$GHE_HOSTNAME" ghe-cluster-nodes -r "$role" -u | cut -f 2)
   hostnames=''
   for uuid in $node_uuids; do
     hostnames+="$prefix-$uuid "

--- a/share/github-backup-utils/ghe-restore-git-hooks
+++ b/share/github-backup-utils/ghe-restore-git-hooks
@@ -42,7 +42,7 @@ if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -56,7 +56,7 @@ if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "pages-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "pages-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -61,7 +61,7 @@ if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -60,7 +60,7 @@ if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $ssh_config_file"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -60,7 +60,7 @@ if $CLUSTER; then
   ssh_config_file="$tempdir/ssh_config"
   ssh_config_file_opt="-F $tempdir/ssh_config"
   opts="$opts -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no"
-  hostnames=$(ghe-cluster-nodes "$GHE_HOSTNAME" "storage-server")
+  hostnames=$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "storage-server")
   ghe-ssh-config "$GHE_HOSTNAME" "$hostnames" > "$ssh_config_file"
 fi
 

--- a/test/bin/ghe-cluster-each
+++ b/test/bin/ghe-cluster-each
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
-# Usage: ghe-config
-# Emulates the remote GitHub ghe-config command. Tests use this
+# Usage: ghe-cluster-each
+# Emulates the remote GitHub ghe-cluster-each command. Tests use this
 # to assert that the command was executed.
 set -e
 
 for _ in "$@"; do
   case "$1" in
-    -u)
-      SHOW_UUID=true
-      shift
-      ;;
-    -r|--role)
-        # fake change last save timestamp every 1s
-        ROLE=$2
-        shift
-        shift
-        ;;
     --)
       if [ "$1" = "--" ]; then
         shift
@@ -42,23 +32,4 @@ fi
 if [ "$COMMAND" == "/usr/local/share/enterprise/ghe-nomad-cleanup" ]; then
   echo "nomad cleanup"
   exit 0
-fi
-
-if $SHOW_UUID; then
-  CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
-
-  hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
-
-  if [ -z "$hosts" ]; then
-    # Mimic `ghe-cluster-each $role -u`
-    echo "fake-uuid
-  fake-uuid1
-  fake-uuid2
-  "
-  else
-    for hostname in $hosts; do
-      [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
-      echo $hostname
-    done
-  fi
 fi

--- a/test/bin/ghe-cluster-nodes
+++ b/test/bin/ghe-cluster-nodes
@@ -19,12 +19,12 @@ done
 
 CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
 
-hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+hosts=$(git config -f "$CONFIG" --get-regexp cluster.*.hostname | cut -d ' ' -f2)
 
 if $PRINT_UUIDS; then
   CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
 
-  hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+  hosts=$(git config -f "$CONFIG" --get-regexp cluster.*.hostname | cut -d ' ' -f2)
 
   if [ -z "$hosts" ]; then
     # Mimic `ghe-cluster-each $role -u`
@@ -34,8 +34,8 @@ if $PRINT_UUIDS; then
   "
   else
     for hostname in $hosts; do
-      [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
-      echo $hostname
+      [ -n "$ROLE" ] && [ "$(git config -f "$CONFIG" cluster."$hostname"."$ROLE"-server)" != "true" ] && continue
+      echo "$hostname"
     done
   fi
 fi

--- a/test/bin/ghe-cluster-nodes
+++ b/test/bin/ghe-cluster-nodes
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Usage: ghe-cluster-nodes
+# Emulates the remote GitHub ghe-cluster-nodes command. Tests use this
+# to assert that the command was executed.
+set -e
+
+for _ in "$@"; do
+  case "$1" in
+    -r|--role)
+        ROLE=$2
+        shift
+        ;;
+    -u|--uuid)
+        PRINT_UUIDS=true
+        shift
+        ;;
+  esac
+done
+
+CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
+
+hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+
+if $PRINT_UUIDS; then
+  CONFIG="$GHE_REMOTE_DATA_USER_DIR/common/cluster.conf"
+
+  hosts=$(git config -f $CONFIG --get-regexp cluster.*.hostname | cut -d ' ' -f2)
+
+  if [ -z "$hosts" ]; then
+    # Mimic `ghe-cluster-each $role -u`
+    echo "fake-uuid
+  fake-uuid1
+  fake-uuid2
+  "
+  else
+    for hostname in $hosts; do
+      [ -n "$ROLE" ] && [ "$(git config -f $CONFIG cluster.$hostname.$ROLE-server)" != "true" ] && continue
+      echo $hostname
+    done
+  fi
+fi

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -265,7 +265,7 @@ begin_test "ghe-backup cluster"
 
   if ! ghe-backup -v > "$TRASHDIR/backup-out" 2>&1; then
     cat "$TRASHDIR/backup-out"
-    : ghe-restore should have exited successfully
+    : ghe-backup should have exited successfully
     false
   fi
 

--- a/test/test-ghe-cluster-find-nodes.sh
+++ b/test/test-ghe-cluster-find-nodes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ghe-cluster-nodes command tests
+# ghe-cluster-find-nodes command tests
 
 # Bring in testlib
 # shellcheck source=test/testlib.sh
@@ -14,25 +14,25 @@ export GHE_DATA_DIR GHE_REMOTE_DATA_DIR
 mkdir -p "$GHE_REMOTE_DATA_USER_DIR/common"
 echo "fake-uuid" > "$GHE_REMOTE_DATA_USER_DIR/common/uuid"
 
-begin_test "ghe-cluster-nodes should return both uuids for git-server"
+begin_test "ghe-cluster-find-nodes should return both uuids for git-server"
 (
   set -e
   setup_remote_cluster
 
-  output="$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")"
+  output="$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")"
   echo "$output"
   [ "git-server-fake-uuid git-server-fake-uuid1 git-server-fake-uuid2 " = "$output" ]
 )
 end_test
 
-begin_test "ghe-cluster-nodes should return one uuid for a single node"
+begin_test "ghe-cluster-find-nodes should return one uuid for a single node"
 (
   set -e
 
   # Ensure not a cluster
   rm -rf "$GHE_REMOTE_ROOT_DIR/etc/github/cluster"
 
-  output="$(ghe-cluster-nodes "$GHE_HOSTNAME" "git-server")"
+  output="$(ghe-cluster-find-nodes "$GHE_HOSTNAME" "git-server")"
   echo "$output"
   [ "git-server-fake-uuid" = "$output" ]
 )


### PR DESCRIPTION
Refactor `ghe-cluster-each` calls to instead use `ghe-cluster-nodes` as appropriate. As part of our 3.7 release, certain flags are being removed. This PR refactors `backup-utils` to use the new method instead.

/cc @donal 