### PR TITLE
Update instructions on granting backup host access to GHES

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,4 +42,4 @@
 [1]: https://github.com/github/backup-utils/releases
 [2]: https://github.com/github/backup-utils/releases/tag/v2.11.4
 [3]: https://github.com/github/enterprise-backup-site/blob/master/backup.config-example
-[4]: https://docs.github.com/en/enterprise-server/admin/configuration/configuring-your-enterprise/accessing-the-administrative-shell-ssh
+[4]: https://docs.github.com/enterprise-server/admin/configuration/configuring-your-enterprise/accessing-the-administrative-shell-ssh


### PR DESCRIPTION
**What is changing?**

This is a minor update to the _Getting Started_ steps that configure the backup host SSH access to the GitHub Enterprise Server instance. 

**Why?**

The prior instructions pointed to an article about setting up a regular GitHub user access to repos using the SSH protocol, whereas the configuration required is for administrative shell access to the GHES instance.