### PR TITLE
Remove parallel beta reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository includes backup and recovery utilities for
 [GitHub Enterprise Server][1].
 
-**UPDATE**: The new parallel backup and restore beta feature will require [GNU awk](https://www.gnu.org/software/gawk) and [moreutils](https://joeyh.name/code/moreutils) to be installed. Note that on some distributions/platforms, the `moreutils-parallel` package is separate from `moreutils` and must be installed on its own.
+**Note**: The parallel backup and restore feature will require [GNU awk](https://www.gnu.org/software/gawk) and [moreutils](https://joeyh.name/code/moreutils) to be installed. Note that on some distributions/platforms, the `moreutils-parallel` package is separate from `moreutils` and must be installed on its own.
 
 **Note**: the [GitHub Enterprise Server version requirements][2] have
 changed starting with Backup Utilities v2.13.0, released on 27 March 2018.

--- a/backup.config-example
+++ b/backup.config-example
@@ -64,27 +64,23 @@ GHE_NUM_SNAPSHOTS=10
 
 # If set to 'yes', ghe-backup jobs will run in parallel. Defaults to 'no'.
 #
-# WARNING: this feature is in beta.
 #GHE_PARALLEL_ENABLED=yes
 
 # Sets the maximum number of jobs to run in parallel. Defaults to the number
 # of available processing units on the machine.
 #
-# WARNING: this feature is in beta.
 #GHE_PARALLEL_MAX_JOBS=2
 
 # Sets the maximum number of rsync jobs to run in parallel. Defaults to the
 # configured GHE_PARALLEL_MAX_JOBS, or the number of available processing 
 # units on the machine.
 #
-# WARNING: this feature is in beta.
 # GHE_PARALLEL_RSYNC_MAX_JOBS=3
 
 # When jobs are running in parallel wait as needed to avoid starting new jobs
 # when the system's load average is not below the specified percentage. Defaults to
 # unrestricted.
 #
-# WARNING: this feature is in beta.
 #GHE_PARALLEL_MAX_LOAD=50
 
 # When running an external mysql database, run this script to trigger a MySQL backup

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -8,7 +8,7 @@ storage and must have network connectivity with the GitHub Enterprise Server app
 Backup host software requirements are modest: Linux or other modern Unix operating
 system with [bash][1], [git][2], [OpenSSH][3] 5.6 or newer, and [rsync][4] v2.6.4 or newer.
 
-The new parallel backup and restore beta feature will require [GNU awk][10] and [moreutils][9] to be installed.
+The parallel backup and restore feature will require [GNU awk][10] and [moreutils][9] to be installed.
 
 We encourage the use of [Docker](docker.md) if your backup host doesn't meet these
 requirements, or if Docker is your preferred platform.


### PR DESCRIPTION
Per this issue opened --> https://github.com/github/backup-utils/issues/919 - removing references to beta for parallel backup feature since this has now been in production for a few years. 