### PR TITLE
don't exit restoration if a node fails to cleanup Nomad

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -507,7 +507,7 @@ fi
 if $CLUSTER; then
   echo "Configuring cluster ..."
   if [ "$GHE_VERSION_MAJOR" -eq "3" ]; then
-    ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-nomad-cleanup" 1>&3 2>&3
+    ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-nomad-cleanup" 1>&3 2>&3 || true
   elif [ "$GHE_VERSION_MAJOR" -eq "2" ] && [ "$GHE_VERSION_MINOR" -eq "22" ]; then
     ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- /usr/local/share/enterprise/ghe-nomad-cleanup" 1>&3 2>&3
   fi


### PR DESCRIPTION
In cluster environments, it's more important that we continue on with the restoration process if the Nomad cleanup fails on e.g. a single node in the cluster.