### PR TITLE
Set a 2 minute timeout on starting cron

### DIFF
--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -89,11 +89,11 @@ done
 start_cron () {
   echo "Starting cron ..."
   if $CLUSTER; then
-    if ! ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- sudo service cron start"; then
+    if ! ghe-ssh "$GHE_HOSTNAME" -- "ghe-cluster-each -- sudo timeout 120s service cron start"; then
       echo "* Warning: Failed to start cron on one or more nodes"
     fi
   else
-    if ! ghe-ssh "$GHE_HOSTNAME" -- "sudo service cron start"; then
+    if ! ghe-ssh "$GHE_HOSTNAME" -- "sudo timeout 120s service cron start"; then
       echo "* Warning: Failed to start cron"
     fi
   fi


### PR DESCRIPTION
If `service cron start` hangs, we don't really want to wait around forever or terminate the entire restore this late in the process.

Adding a 2 minute timeout onto `service cron start` would allow the restore to continue if a service hang occurs, and also log the Warning. 
