### PR TITLE
Add zstd to backup-utils

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,14 @@ jobs:
     - name: Install Dependencies (Linux)
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y devscripts debhelper moreutils fakeroot jq pigz help2man
+        sudo apt-get install -y devscripts debhelper moreutils fakeroot jq pigz help2man zstd
         wget "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz"
         tar --xz -xvf "shellcheck-latest.linux.x86_64.tar.xz"
         sudo cp shellcheck-latest/shellcheck /usr/bin/shellcheck
       if: matrix.os != 'macos-latest'
     - name: Install Dependencies (macOS)
       run: |
-        brew install gnu-tar shellcheck jq pigz coreutils gnu-sed gnu-getopt wget
+        brew install gnu-tar shellcheck jq pigz coreutils gnu-sed gnu-getopt wget zstd
         brew install moreutils gawk
       if: matrix.os == 'macos-latest'
     - name: Get Sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -q -y update && \
     git \
     moreutils \
     gawk \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./ /backup-utils/

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,7 +9,8 @@ RUN apk --update --no-cache add \
     bash \
     gawk \
     procps \
-    coreutils
+    coreutils \ 
+    zstd
 
 COPY ./ /backup-utils/
 WORKDIR /backup-utils

--- a/share/github-backup-utils/ghe-backup-es-audit-log
+++ b/share/github-backup-utils/ghe-backup-es-audit-log
@@ -50,7 +50,7 @@ for index in $indices; do
     ln $GHE_DATA_DIR/current/audit-log/$index_name.gz.size $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz.size
   else
     ghe_verbose "* Performing audit log export for index: $index_name"
-    echo "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:9201/$index_name\" | gzip" | ghe-ssh "$host" -- /bin/bash > $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz
+    echo "/usr/local/share/enterprise/ghe-es-dump-json \"http://localhost:9201/$index_name\" | zstd" | ghe-ssh "$host" -- /bin/bash > $GHE_SNAPSHOT_DIR/audit-log/$index_name.zst
     echo $index_size > $GHE_SNAPSHOT_DIR/audit-log/$index_name.gz.size
   fi
 done

--- a/share/github-backup-utils/ghe-backup-mysql-logical
+++ b/share/github-backup-utils/ghe-backup-mysql-logical
@@ -17,8 +17,8 @@ ghe_remote_version_required "$GHE_HOSTNAME"
 
 echo "Backing up MySQL database using logical backup strategy ..."
 
-echo "set -o pipefail; ghe-export-mysql | pigz" |
-ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > "$GHE_SNAPSHOT_DIR/mysql.sql.gz"
+echo "set -o pipefail; ghe-export-mysql | zstd" |
+ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > "$GHE_SNAPSHOT_DIR/mysql.sql.zst"
 
 if is_external_database_target; then
   echo "LOGICAL_EXTERNAL_BACKUP" > "$GHE_SNAPSHOT_DIR/logical-external-database-backup-sentinel"

--- a/share/github-backup-utils/ghe-backup-repositories
+++ b/share/github-backup-utils/ghe-backup-repositories
@@ -129,7 +129,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- zstd -c $remote_routes_list | zstd -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-backup-storage
+++ b/share/github-backup-utils/ghe-backup-storage
@@ -98,7 +98,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- zstd -c $remote_routes_list | zstd -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-restore-es-audit-log
+++ b/share/github-backup-utils/ghe-restore-es-audit-log
@@ -61,7 +61,7 @@ if [ -s "$tmp_list" ]; then
   if $CLUSTER || [ -n "$configured" ]; then
     for index in $(cat $tmp_list | sed 's/\.gz$//g'); do
       ghe_verbose "* Restoring $index"
-      echo "export PATH=\$PATH:/usr/local/share/enterprise && sudo gzip -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/audit-log/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
+      echo "export PATH=\$PATH:/usr/local/share/enterprise && sudo zstd -dc $GHE_REMOTE_DATA_USER_DIR/elasticsearch-restore/audit-log/$index | ghe-es-load-json 'http://localhost:9201/$index'" |
       ghe-ssh "$GHE_HOSTNAME" -- /bin/bash 1>&3
     done
   else

--- a/share/github-backup-utils/ghe-restore-mysql-binary
+++ b/share/github-backup-utils/ghe-restore-mysql-binary
@@ -52,7 +52,7 @@ if [ "$(cat $snapshot_dir/mysql-binary-backup-sentinel)" = "NO_ADDITIONAL_COMPRE
   IMPORT_MYSQL=ghe-import-mysql-xtrabackup
   GHE_RESTORE_HOST=$ghe_mysql_master
 else
-  IMPORT_MYSQL="unpigz | ghe-import-mysql-xtrabackup"
+  IMPORT_MYSQL="unzstd | ghe-import-mysql-xtrabackup"
   GHE_RESTORE_HOST=$ghe_mysql_master
 fi
 

--- a/share/github-backup-utils/ghe-restore-mysql-legacy
+++ b/share/github-backup-utils/ghe-restore-mysql-legacy
@@ -35,7 +35,7 @@ snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 ssh_config_file_opt=
 
 # legacy mode
-IMPORT_MYSQL="unpigz | ghe-import-mysql"
+IMPORT_MYSQL="unzstd | ghe-import-mysql"
 GHE_RESTORE_HOST=$GHE_HOSTNAME
 
 cleanup() {

--- a/share/github-backup-utils/ghe-restore-mysql-logical
+++ b/share/github-backup-utils/ghe-restore-mysql-logical
@@ -32,7 +32,7 @@ snapshot_dir="$GHE_DATA_DIR/$GHE_RESTORE_SNAPSHOT"
 ssh_config_file_opt=
 
 # legacy mode
-IMPORT_MYSQL="unpigz | ghe-import-mysql-mysqldump"
+IMPORT_MYSQL="unzstd | ghe-import-mysql-mysqldump"
 GHE_RESTORE_HOST=$GHE_HOSTNAME
 
 cleanup() {

--- a/share/github-backup-utils/ghe-restore-pages
+++ b/share/github-backup-utils/ghe-restore-pages
@@ -113,7 +113,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- zstd -c $remote_routes_list | zstd -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories
+++ b/share/github-backup-utils/ghe-restore-repositories
@@ -125,7 +125,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- zstd -c $remote_routes_list | zstd -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 

--- a/share/github-backup-utils/ghe-restore-repositories-gist
+++ b/share/github-backup-utils/ghe-restore-repositories-gist
@@ -115,7 +115,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Transferring routes"
-ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- zstd -c $remote_routes_list | zstd -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Transferring routes"
 

--- a/share/github-backup-utils/ghe-restore-storage
+++ b/share/github-backup-utils/ghe-restore-storage
@@ -108,7 +108,7 @@ ghe-ssh "$GHE_HOSTNAME" -- cat $remote_routes_list | ghe_debug
 bm_end "$(basename $0) - Generating routes"
 
 bm_start "$(basename $0) - Fetching routes"
-ghe-ssh "$GHE_HOSTNAME" -- gzip -c $remote_routes_list | gzip -d > $routes_list
+ghe-ssh "$GHE_HOSTNAME" -- zstd -c $remote_routes_list | zstd -d > $routes_list
 cat $routes_list | ghe_debug
 bm_end "$(basename $0) - Fetching routes"
 


### PR DESCRIPTION
This PR replaces `gzip` with `zstd`.

### Testing

Tested on `gheboot 3.7`
- Populate some data into the appliance using `ghes-populator`
```
./ghes-populator \
create \
--dry-run=false \
--number-of-comments-per-issue=1 \
--number-of-issues-per-repository=5 \
--number-of-repositories-per-user=5 \
--number-of-organizations=1 \
--number-of-sample-repositories=20 \
--number-of-workers-for-populating=5 \
--number-of-users-per-organization=50 \
--number-of-users=50 \
--ghes-url="https://daxamin-0ce2ce8fe5dd4c0ac.qaboot.net" \
--ghes-username="ghe-admin" \
--ghes-password="XXXX" \
--ghes-token="XXXX"
```
- Install `zstd` on gheboot
    - `wget http://ftp.de.debian.org/debian/pool/main/libz/libzstd/zstd_1.3.8+dfsg-3+deb10u2_amd64.deb`
    - `sudo apt install ./zstd_1.3.8+dfsg-3+deb10u2_amd64.deb`
- Take backup `./ghe.backup` after configuring `backup.config`
- Restore using the snapshot `./ghe-restore daxamin-0ce2ce8fe5dd4c0ac.qaboot.net`

### Related items
https://github.com/github/ghes/issues/997