### PR TITLE
Adding Possible Go Refactor for Backup Tools Using Cobra Framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require a code review from a member
+# of the <REPLACE_WITH_TEAM_NAME_RESPONSIBLE_FOR_PR>
+# TODO MAKE A TEAM FOR PR EXAMPLE: * @github/backuputils-admin
+# REPLACE @github/backuputils-admin WITH CORRECT TEAM AND UNCOMMENT LINE BELOW
+#* @github/backuputils-admin

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,22 @@
+---
+name: 'Go ghe'
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/petalmd/dockerfile-pre-commit
+    rev: master  # Use the revision rev you want to point at
+    hooks:
+      - id: dockerlint
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: master  # or other specific tag
+    hooks:
+       - id: yamlfmt
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: master
+    hooks:
+      - id: go-fmt
+      - id: go-vet
+      - id: go-lint
+      - id: go-imports
+      - id: go-cyclo
+        args: [-over=15]
+      - id: validate-toml
+      - id: golangci-lint
+      - id: go-critic
+      - id: go-build
+      - id: go-mod-tidy
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.9.0
+    hooks:
+    -   id: shellcheck
+        args: ["--severity=warning"]  # Optionally only show errors and warnings

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+shell=bash

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,0 +1,61 @@
+###############
+# CACHE IMAGE #
+###############
+ARG GO_IMAGE=golang:1.18.10-alpine3.17
+ARG BASE_IMAGE=alpine:3.17
+
+FROM ${GO_IMAGE} AS cache
+LABEL org.opencontainers.image.source https://github.com/github/backup-utils
+
+# Add the keys
+ARG GITHUB_ID
+ENV GITHUB_ID=$GITHUB_ID
+ARG GITHUB_TOKEN
+ENV GITHUB_TOKEN=$GITHUB_TOKEN
+
+# Install Git
+RUN apk add git
+
+# TODO: ENCRYPT THE GITHUB_ID AND GITHUB_TOKEN
+# Make Git Configuration in case repository is ever marked private
+
+RUN --mount=type=secret,id=TOKEN \
+    echo "machine github.com login x password $(head -n 1 /run/secrets/TOKEN)" > ~/.netrc && \
+    git config \
+    --global \
+    url."https://${GITHUB_ID}:${TOKEN}@github.com/".insteadOf \
+    "https://github.com/"
+    
+RUN git config \
+    --global \
+    url."https://${GITHUB_ID}:${GITHUB_TOKEN}@github.com/".insteadOf \
+    "https://github.com/"
+
+WORKDIR /src
+COPY go.mod go.sum /src/
+RUN go mod download
+
+##############
+# BASE IMAGE #
+##############
+FROM cache as backup-utils
+COPY . /bin
+WORKDIR /bin
+
+# Setup Git Terminal Prompt & Go Build
+RUN go build .
+
+###############
+# FINAL IMAGE #
+###############
+FROM ${BASE_IMAGE}
+LABEL org.opencontainers.image.source https://github.com/github/backup-utils
+
+# TODO: NEED TO ADD A USER SIMILAR TO THE FOLLOWING UBUNTU BLOCK
+RUN addgroup -g 1001 backupuser && \
+    adduser -S -u 1001 -G backupuser backupuser
+
+USER appuser
+
+COPY --from=backup-utils /bin/backup-utils bin
+ENTRYPOINT [ "bin/backup-utils" ]

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -1,0 +1,21 @@
+package backup
+
+// TODO: NEEDS TO BE BUILT OUT, IMPLEMENTED, TESTED, AND RELEASED
+
+import (
+
+	"github.com/spf13/cobra"
+)
+
+func NewBackUpCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Backup your GitHub Enterprise Application",
+	}
+
+	// Universal Base Commands
+	// EXAMPLE:
+	//cmd.AddCommand(repositories.NewBackUpRepositoriesCommand())
+
+	return cmd
+}

--- a/cmd/hostcheck/hostcheck.go
+++ b/cmd/hostcheck/hostcheck.go
@@ -1,0 +1,23 @@
+package hostcheck
+
+// TODO: NEEDS TO BE BUILT OUT, IMPLEMENTED, TESTED, AND RELEASED
+// MAKE IMPLEMENTATION IN pkg/restore/restore.go
+// IMPORT ./pkg/restore
+
+import (
+
+	"github.com/spf13/cobra"
+)
+
+func NewHostCheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hostcheck",
+		Short: "Check the host configuration of your GitHub Enterprise Application",
+	}
+
+	// Universal Base Commands
+	// EXAMPLE:
+	//cmd.AddCommand(config.NewHostCheckConfigCommand())
+
+	return cmd
+}

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -1,0 +1,21 @@
+package restore
+
+// TODO: NEEDS TO BE BUILT OUT, IMPLEMENTED, TESTED, AND RELEASED
+
+import (
+
+	"github.com/spf13/cobra"
+)
+
+func NewRestoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore",
+		Short: "Restore your GitHub Enterprise Application",
+	}
+
+	// Universal Base Commands
+	// EXAMPLE:
+	//cmd.AddCommand(repositories.NewRestoreRepositoriesCommand())
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/github/backup-utils/pkg/log"
+	"github.com/spf13/cobra"
+
+	"github.com/github/backup-utils/cmd/backup"
+	"github.com/github/backup-utils/cmd/hostcheck"
+	"github.com/github/backup-utils/cmd/restore"
+)
+
+func NewGHECommand() *cobra.Command {
+	var debug bool
+	cmd := &cobra.Command{
+		Use:	"ghe",
+		Short:  "GitHub Enterprise CLI Tool To BackUp and Restore GHES",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			log.Init(debug, os.Stderr)
+		},			
+	}
+	
+	// Persistent Global Flags
+	cmd.PersistentFlags().BoolVar(&debug, "debug", false, "specify debug level")
+	
+	// Persistent Global Commands
+	cmd.AddCommand(backup.NewBackUpCmd())
+	cmd.AddCommand(hostcheck.NewHostCheckCmd())
+	cmd.AddCommand(restore.NewRestoreCmd())
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/github/backup-utils
+
+go 1.18
+
+require github.com/spf13/cobra v1.6.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/github/backup-utils/cmd"
+)
+
+func main() {
+	if err := cmd.NewGHECommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/pkg/.gitkeep
+++ b/pkg/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for future notes

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -1,0 +1,1 @@
+package backup

--- a/pkg/hostcheck/hostcheck.go
+++ b/pkg/hostcheck/hostcheck.go
@@ -1,0 +1,1 @@
+package hostcheck

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,90 @@
+/*
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+var (
+	debug      = false
+	dataLogger = log.New(os.Stderr, "[ghe] ", log.LstdFlags)
+)
+
+// Init initializes settings related to logging
+func Init(debugFlag bool, out io.Writer) {
+	debug = debugFlag
+	if debug {
+		dataLogger.SetFlags(log.LstdFlags | log.Llongfile)
+	}
+	dataLogger.SetOutput(out)
+}
+
+// DebugEnabled returns whether the debug level is set
+func DebugEnabled() bool {
+	return debug
+}
+
+// Debug is a wrapper for log.Debug
+func Debug(v ...interface{}) {
+	if debug {
+		writeLog(v...)
+	}
+}
+
+// Debugf is a wrapper for log.Debugf
+func Debugf(format string, v ...interface{}) {
+	if debug {
+		writeLog(fmt.Sprintf(format, v...))
+	}
+}
+
+// Print is a wrapper for log.Print
+func Print(v ...interface{}) {
+	writeLog(v...)
+}
+
+// Printf is a wrapper for log.Printf
+func Printf(format string, v ...interface{}) {
+	writeLog(fmt.Sprintf(format, v...))
+}
+
+// Fatal is a wrapper for log.Fatal
+func Fatal(v ...interface{}) {
+	dataLogger.Fatal(v...)
+}
+
+// Fatalf is a wrapper for log.Fatalf
+func Fatalf(format string, v ...interface{}) {
+	dataLogger.Fatalf(format, v...)
+}
+
+// Writer returns log output writer object
+func Writer() io.Writer {
+	return dataLogger.Writer()
+}
+
+func writeLog(v ...interface{}) {
+	if debug {
+		err := dataLogger.Output(3, fmt.Sprint(v...))
+		if err != nil {
+			log.Print(v...)
+			log.Print(err)
+		}
+	} else {
+		dataLogger.Print(v...)
+	}
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1,0 +1,1 @@
+package restore


### PR DESCRIPTION
- Adding in Go CICD `go.yml` to Test Go Constructs.
- Added in Cobra CLI Framework for Possible Refactor on GHE BACKUP-UTILS as a whole w/ Golang we can get actual parallel and might be able to bypass `rsync` issues plaguing our GHES Infrastructure on backups.  Furthermore, we can get more granular on the backups.
- Added in the basis for Go Project Functionality.
- TODO: Actual Packages need to be built out in `./pkg/<some_package/`.
- Added the basic Dockerfile needed to Run a Go Binary from within either a Public or Internal/Private Repository.
- Added in a pre-commit-config that works with both the current version and the possible re-factor.
- Added in a `.shellcheckrc` to halt warnings and control settings within Shell Check.
- Added in a CODEOWNERS to allow repository owners configuration controls on the overall pull-request process.