### PR TITLE
ghe-backup and ghe-restore shellcheck fixes

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -79,7 +79,7 @@ if ! output=$(rsync -a src/ dest1 2>&1 && rsync -av src/ --link-dest=../dest1 de
   exit 1
 fi
 
-if [ "$(ls -il dest1/testfile | awk '{ print $1 }')" != "$(ls -il dest2/testfile | awk '{ print $1 }')" ]; then
+if [ "$(stat -c %i dest1/testfile)" != "$(stat -c %i dest2/testfile)" ]; then
   echo "Error: the filesystem containing $GHE_DATA_DIR does not support hard links." 1>&2
   echo "Backup Utilities use hard links to store backup data efficiently." 1>&2
   exit 1
@@ -100,13 +100,13 @@ cleanup () {
     progress=$(cat ../in-progress)
     snapshot=$(echo "$progress" | cut -d ' ' -f 1)
     pid=$(echo "$progress" | cut -d ' ' -f 2)
-    if [ "$snapshot" = "$GHE_SNAPSHOT_TIMESTAMP" ] && [ "$$" = $pid ]; then
+    if [ "$snapshot" = "$GHE_SNAPSHOT_TIMESTAMP" ] && [ "$$" = "$pid" ]; then
       unlink ../in-progress
     fi
   fi
 
   rm -rf "$failures_file"
-  rm -f ${GHE_DATA_DIR}/in-progress-backup
+  rm -f "${GHE_DATA_DIR}/in-progress-backup"
 
   # Cleanup SSH multiplexing
   ghe-ssh --clean
@@ -146,10 +146,10 @@ if [ -f ../in-progress ]; then
 fi
 
 echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ../in-progress
-echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ${GHE_DATA_DIR}/in-progress-backup
+echo "$GHE_SNAPSHOT_TIMESTAMP $$" > "${GHE_DATA_DIR}/in-progress-backup"
 
 START_TIME=$(date +%s)
-echo 'Start time:' $START_TIME
+echo "Start time: $START_TIME"
 echo "Starting backup of $GHE_HOSTNAME with backup-utils v$BACKUP_UTILS_VERSION in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 
 # Perform a host connection check and establish the remote appliance version.
@@ -237,7 +237,7 @@ if [ "$GHE_BACKUP_STRATEGY" = "rsync" ]; then
 fi
 
 if [ "$GHE_PARALLEL_ENABLED" = "yes" ]; then
-  $GHE_PARALLEL_COMMAND $GHE_PARALLEL_COMMAND_OPTIONS -- "${commands[@]}"
+  "$GHE_PARALLEL_COMMAND" "${GHE_PARALLEL_COMMAND_OPTIONS[@]}" -- "${commands[@]}"
 else
   for c in "${commands[@]}"; do
     eval "$c"
@@ -250,7 +250,7 @@ fi
 
 # git fsck repositories after the backup
 if [ "$GHE_BACKUP_FSCK" = "yes" ]; then
-  ghe-backup-fsck $GHE_SNAPSHOT_DIR || failures="$failures fsck"
+  ghe-backup-fsck "$GHE_SNAPSHOT_DIR" || failures="$failures fsck"
 fi
 
 # If everything was successful, mark the snapshot as complete, update the
@@ -266,8 +266,8 @@ if [ -z "$failures" ]; then
 fi
 
 END_TIME=$(date +%s)
-echo 'End time:' $END_TIME
-echo 'Runtime:' $(($END_TIME - $START_TIME)) 'seconds'
+echo "End time: $END_TIME"
+echo "Runtime: $((END_TIME - START_TIME)) seconds"
 
 echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $(date +"%H:%M:%S")"
 
@@ -275,7 +275,7 @@ echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $
 if [ -z "$failures" ]; then
   ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP successfully."
 else
-  steps="$(echo $failures | sed 's/ /, /g')"
+  steps="${failures// /, }"
   ghe_remote_logger "Completed backup from $(hostname) / snapshot $GHE_SNAPSHOT_TIMESTAMP with failures: ${steps}."
   echo "Error: Snapshot incomplete. Some steps failed: ${steps}. "
   exit 1

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -32,13 +32,13 @@
 set -e
 
 # Parse arguments
-: ${RESTORE_SETTINGS:=false}
+: "${RESTORE_SETTINGS:=false}"
 export RESTORE_SETTINGS
 
-: ${FORCE:=false}
+: "${FORCE:=false}"
 export FORCE
 
-: ${SKIP_MYSQL:=false}
+: "${SKIP_MYSQL:=false}"
 export SKIP_MYSQL
 
 while true; do
@@ -123,7 +123,7 @@ cleanup () {
   # Cleanup SSH multiplexing
   ghe-ssh --clean
   # Remove in-progress file
-  rm -f ${GHE_DATA_DIR}/in-progress-restore
+  rm -f "${GHE_DATA_DIR}/in-progress-restore"
 }
 
 # This function's type definition is being passed to a remote host via `ghe-ssh` but is not used locally.
@@ -135,16 +135,16 @@ cleanup_cluster_nodes() {
     exit 2
   fi
 
-  ghe-spokes server evacuate git-server-$uuid 'Removing replica'
-  ghe-spokes server destroy git-server-$uuid
+  ghe-spokes server evacuate "git-server-$uuid" 'Removing replica'
+  ghe-spokes server destroy "git-server-$uuid"
 
-  ghe-storage destroy-host storage-server-$uuid --force
+  ghe-storage destroy-host "storage-server-$uuid" --force
 
-  ghe-dpages offline pages-server-$uuid
-  ghe-dpages remove pages-server-$uuid
+  ghe-dpages offline "pages-server-$uuid"
+  ghe-dpages remove "pages-server-$uuid"
 
-  ghe-redis-cli del resque:queue:maint_git-server-$uuid
-  ghe-redis-cli srem resque:queues maint_git-server-$uuid
+  ghe-redis-cli del "resque:queue:maint_git-server-$uuid"
+  ghe-redis-cli srem resque:queues "maint_git-server-$uuid"
 }
 
 # Bring in the backup configuration
@@ -257,11 +257,11 @@ fi
 
 # Log restore start message locally and in /var/log/syslog on remote instance
 START_TIME=$(date +%s)
-echo 'Start time:' $START_TIME
+echo "Start time: $START_TIME"
 echo "Starting restore of $GHE_HOSTNAME with backup-utils v$BACKUP_UTILS_VERSION from snapshot $GHE_RESTORE_SNAPSHOT"
 ghe_remote_logger "Starting restore from $(hostname) with backup-utils v$BACKUP_UTILS_VERSION / snapshot $GHE_RESTORE_SNAPSHOT ..."
 # Create an in-progress-restore file to prevent simultaneous backup or restore runs
-echo "${START_TIME} $$" > ${GHE_DATA_DIR}/in-progress-restore
+echo "${START_TIME} $$" > "${GHE_DATA_DIR}/in-progress-restore"
 
 # Keep other processes on the VM or cluster in the loop about the restore status.
 #
@@ -297,7 +297,7 @@ RELEASE_VERSION=$(ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --get core.package-vers
 
 # If the backup being restored is from an appliance with Actions disabled, restoring it onto an appliance with Actions enabled will cause
 # mismatches in the secrets needed for Actions which ultimately results in Actions not working properly. Note: xargs is to remove whitespace
-ACTIONS_ENABLED_IN_BACKUP=$(git config -f $GHE_RESTORE_SNAPSHOT_PATH/settings.json --bool app.actions.enabled | xargs)
+ACTIONS_ENABLED_IN_BACKUP=$(git config -f "$GHE_RESTORE_SNAPSHOT_PATH/settings.json" --bool app.actions.enabled | xargs)
 if [[ $ACTIONS_ENABLED_IN_BACKUP != true ]] && ghe-ssh "$GHE_HOSTNAME" -- 'ghe-config --true app.actions.enabled'; then
     echo "Error: Restoring a backup with Actions disabled onto an appliance with Actions enabled is not supported." >&2
     exit 1
@@ -388,11 +388,10 @@ fi
 # Restore UUID if present and not restoring to cluster.
 if [ -s "$GHE_RESTORE_SNAPSHOT_PATH/uuid" ] && ! $CLUSTER; then
   echo "Restoring UUID ..."
-  cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid" |
-  ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null"
+  ghe-ssh "$GHE_HOSTNAME" -- "sudo sponge '$GHE_REMOTE_DATA_USER_DIR/common/uuid' 2>/dev/null" <"$GHE_RESTORE_SNAPSHOT_PATH/uuid"
   ghe-ssh "$GHE_HOSTNAME" -- "sudo systemctl stop consul" || true
   ghe-ssh "$GHE_HOSTNAME" -- "sudo rm -rf /data/user/consul/raft"
-  fi
+fi
 
 if is_external_database_snapshot; then
    appliance_strategy="external"
@@ -474,13 +473,13 @@ if ! $CLUSTER && [ -d "$GHE_RESTORE_SNAPSHOT_PATH/elasticsearch" ]; then
 fi
 
 # Restore the audit log migration sentinel file, if it exists in the snapshot
-if test -f $GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete; then
+if test -f "$GHE_RESTORE_SNAPSHOT_PATH/es-scan-complete"; then
   ghe-ssh "$GHE_HOSTNAME" -- "sudo touch $GHE_REMOTE_DATA_USER_DIR/common/es-scan-complete"
 fi
 
 # Restore exported audit logs to 2.12.9 and newer single nodes and
 # all releases of cluster
-if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.12.9)" ]; then
+if $CLUSTER || [ "$(version "$GHE_REMOTE_VERSION")" -ge "$(version 2.12.9)" ]; then
   if [[ "$GHE_RESTORE_SKIP_AUDIT_LOGS" = "yes" ]]; then
     echo "Skipping restore of audit logs."
   else
@@ -492,7 +491,7 @@ if $CLUSTER || [ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 2.12.9)" ]; the
 fi
 
 if [ "$GHE_PARALLEL_ENABLED" = "yes" ]; then
-  $GHE_PARALLEL_COMMAND $GHE_PARALLEL_COMMAND_OPTIONS -- "${commands[@]}"
+  "$GHE_PARALLEL_COMMAND" "${GHE_PARALLEL_COMMAND_OPTIONS[@]}" -- "${commands[@]}"
 else
   for c in "${commands[@]}"; do
     eval "$c"
@@ -545,7 +544,7 @@ CRON_RUNNING=true
 
 # Clean up all stale replicas on configured instances.
 if ! $CLUSTER && $instance_configured; then
-  restored_uuid=$(cat $GHE_RESTORE_SNAPSHOT_PATH/uuid)
+  restored_uuid=$(cat "$GHE_RESTORE_SNAPSHOT_PATH/uuid")
   other_nodes=$(echo "
     set -o pipefail; \
     ghe-spokes server show --json \
@@ -585,8 +584,8 @@ else
 fi
 
 END_TIME=$(date +%s)
-echo 'End time:' $END_TIME
-echo 'Runtime:' $(($END_TIME - $START_TIME)) 'seconds'
+echo "End time: $END_TIME"
+echo "Runtime: $((END_TIME - START_TIME)) seconds"
 
 echo "Restore of $GHE_HOSTNAME from snapshot $GHE_RESTORE_SNAPSHOT finished."
 ghe_restore_finished

--- a/share/github-backup-utils/ghe-backup-config
+++ b/share/github-backup-utils/ghe-backup-config
@@ -27,7 +27,7 @@ if [ -n "$GHE_SHOW_VERSION" ]; then
 fi
 
 # Check for "--help|-h" in args or GHE_SHOW_HELP=true and show usage
-# shellcheck disable=SC2120 # the script name is always referenced
+# shellcheck disable=SC2120 # Our arguments are optional and not meant to be the owning script's
 print_usage() {
   grep '^#/' <"$0" | cut -c 4-
   exit "${1:-1}"
@@ -121,6 +121,8 @@ ghe_backup_finished() {
 }
 
 ghe_parallel_check() {
+  GHE_PARALLEL_COMMAND_OPTIONS=()
+
   if [ "$GHE_PARALLEL_ENABLED" != "yes" ]; then
     return 0
   fi
@@ -142,13 +144,13 @@ ghe_parallel_check() {
   done
 
   # Check that the GHE_PARALLEL_COMMAND is pointing to moreutils parallel
-  if ! $GHE_PARALLEL_COMMAND -h | grep -q "parallel \[OPTIONS\] command -- arguments"; then
+  if ! "$GHE_PARALLEL_COMMAND" -h | grep -q "parallel \[OPTIONS\] command -- arguments"; then
     echo "Error: moreutils not found. Please install https://joeyh.name/code/moreutils" 1>&2
     exit 1
   fi
 
   if [ -n "$GHE_PARALLEL_MAX_JOBS" ]; then
-    GHE_PARALLEL_COMMAND_OPTIONS="-j $GHE_PARALLEL_MAX_JOBS"
+    GHE_PARALLEL_COMMAND_OPTIONS+=(-j "$GHE_PARALLEL_MAX_JOBS")
     # Default to the number of max rsync jobs to the same as GHE_PARALLEL_MAX_JOBS, if not set.
     # This is only applicable to ghe-restore-repositories currently.
     : "${GHE_PARALLEL_RSYNC_MAX_JOBS:="$GHE_PARALLEL_MAX_JOBS"}"
@@ -159,7 +161,7 @@ ghe_parallel_check() {
   fi
 
   if [ -n "$GHE_PARALLEL_MAX_LOAD" ]; then
-    GHE_PARALLEL_COMMAND_OPTIONS+=" -l $GHE_PARALLEL_MAX_LOAD"
+    GHE_PARALLEL_COMMAND_OPTIONS+=(-l "$GHE_PARALLEL_MAX_LOAD")
     GHE_PARALLEL_RSYNC_COMMAND_OPTIONS+=" -l $GHE_PARALLEL_MAX_LOAD"
   fi
 }
@@ -335,6 +337,7 @@ fi
 # that need the remote version should use this function instead of calling
 # ghe-host-check directly to reduce ssh roundtrips. The top-level ghe-backup and
 # ghe-restore commands establish the version for all subcommands.
+# shellcheck disable=SC2120 # Our arguments are optional and not meant to be the owning script's
 ghe_remote_version_required() {
   if [ -z "$GHE_REMOTE_VERSION" ]; then
     _out=$(ghe-host-check "$@")


### PR DESCRIPTION
This is the first of several PRs to harden and improve the backup scripts, initially focusing on shellcheck compliance, in this case 36 conditions were fixed. I have focused on only the main `ghe-backup` and `ghe-restore` scripts in this PR in order to limit the scope, only touching `share/github-backup-utils/ghe-backup-config` where necessary.

The following is a count of the types of fixes:

```
24  SC2086: Double quote to prevent globbing and word splitting.
 4  SC2004: $/${} is unnecessary on arithmetic variables.
 3  SC2223: This default assignment may cause DoS due to globbing. Quote it.
 2  SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
 1  SC2001: See if you can use ${variable//search/replace} instead.
 1  SC2119: Use ghe_remote_version_required "$@" if function's $1 should mean script's $1.
```