### PR TITLE
Adding new option to support Pages lazy-build strategy

### DIFF
--- a/backup.config-example
+++ b/backup.config-example
@@ -90,3 +90,6 @@ GHE_NUM_SNAPSHOTS=10
 # When running an external mysql database, run this script to trigger a MySQL restore
 # rather than attempting to backup via backup-utils directly.
 #EXTERNAL_DATABASE_RESTORE_SCRIPT="/bin/false"
+
+# If set to 'yes', Pages data will be included in backup and restore. Defaults to 'no'
+#GHE_BACKUP_PAGES=no

--- a/backup.config-example
+++ b/backup.config-example
@@ -91,5 +91,5 @@ GHE_NUM_SNAPSHOTS=10
 # rather than attempting to backup via backup-utils directly.
 #EXTERNAL_DATABASE_RESTORE_SCRIPT="/bin/false"
 
-# If set to 'yes', Pages data will be included in backup and restore. Defaults to 'no'
+# If set to 'yes', Pages data will be included in backup and restore. Defaults to 'yes'
 #GHE_BACKUP_PAGES=no

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -218,9 +218,11 @@ commands+=("
 echo \"Backing up Git repositories ...\"
 ghe-backup-repositories || printf %s \"repositories \" >> \"$failures_file\"")
 
-commands+=("
-echo \"Backing up GitHub Pages artifacts ...\"
-ghe-backup-pages || printf %s \"pages \" >> \"$failures_file\"")
+if [ "$GHE_BACKUP_PAGES" = "yes" ]; then
+  commands+=("
+  echo \"Backing up GitHub Pages artifacts ...\"
+  ghe-backup-pages || printf %s \"pages \" >> \"$failures_file\"")
+fi
 
 commands+=("
 echo \"Backing up storage data ...\"

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -218,7 +218,7 @@ commands+=("
 echo \"Backing up Git repositories ...\"
 ghe-backup-repositories || printf %s \"repositories \" >> \"$failures_file\"")
 
-if [ "$GHE_BACKUP_PAGES" = "yes" ]; then
+if [ "$GHE_BACKUP_PAGES" != "no" ]; then
   commands+=("
   echo \"Backing up GitHub Pages artifacts ...\"
   ghe-backup-pages || printf %s \"pages \" >> \"$failures_file\"")

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -451,7 +451,7 @@ commands+=("
 echo \"Restoring Gists ...\"
 ghe-restore-repositories-gist \"$GHE_HOSTNAME\"")
 
-if [ "$GHE_BACKUP_PAGES" = "yes" ]; then
+if [ "$GHE_BACKUP_PAGES" != "no" ]; then
   commands+=("
   echo \"Restoring GitHub Pages artifacts ...\"
   ghe-restore-pages \"$GHE_HOSTNAME\" 1>&3")

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -451,9 +451,11 @@ commands+=("
 echo \"Restoring Gists ...\"
 ghe-restore-repositories-gist \"$GHE_HOSTNAME\"")
 
-commands+=("
-echo \"Restoring GitHub Pages artifacts ...\"
-ghe-restore-pages \"$GHE_HOSTNAME\" 1>&3")
+if [ "$GHE_BACKUP_PAGES" = "yes" ]; then
+  commands+=("
+  echo \"Restoring GitHub Pages artifacts ...\"
+  ghe-restore-pages \"$GHE_HOSTNAME\" 1>&3")
+fi
 
 commands+=("
 echo \"Restoring SSH authorized keys ...\"


### PR DESCRIPTION
This PR adds a new option to exclude Pages artifacts from backup and restore:

> If set to 'yes', Pages data will be included in backup and restore. Defaults to 'yes'
> GHE_BACKUP_PAGES=no

Pages Lazy-build was introduced in GHES 3.4 and allows Pages to be rebuild on-demand on a restored host.
According to the ADR, backups should include Pages artifacts by default, with an option to exclude:

> Lazy build is enabled for all enterprise customers and the behavior cannot be disabled. Customers have the choice to include (default) or exclude Pages from their backups.