### PR TITLE
Bump version: 3.6.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,11 @@
 github-backup-utils (3.6.1) UNRELEASED; urgency=medium
 
 
+ -- Joseph Franks <joefranks1993@github.com>  Wed, 14 Jun 2023 21:31:54 +0000
+
+github-backup-utils (3.6.1) UNRELEASED; urgency=medium
+
+
  -- Joseph Franks <joefranks1993@github.com>  Wed, 14 Jun 2023 21:28:28 +0000
 
 github-backup-utils (3.6.0) UNRELEASED; urgency=medium


### PR DESCRIPTION
Includes general improvements & bug fixes

/cc @github/backup-utils