### PR TITLE
Add Secret Scanning encrypted content scanning keys to backup utils

### DIFF
--- a/share/github-backup-utils/ghe-backup-settings
+++ b/share/github-backup-utils/ghe-backup-settings
@@ -90,6 +90,7 @@ backup-secret "secret scanning encrypted secrets current storage key" "secret-sc
 backup-secret "secret scanning encrypted secrets delimited storage keys" "secret-scanning-encrypted-secrets-delimited-storage-keys" "secrets.secret-scanning.encrypted-secrets-delimited-storage-keys"
 backup-secret "secret scanning encrypted secrets current shared transit key" "secret-scanning-encrypted-secrets-current-shared-transit-key" "secrets.secret-scanning.encrypted-secrets-current-shared-transit-key"
 backup-secret "secret scanning encrypted secrets delimited shared transit keys" "secret-scanning-encrypted-secrets-delimited-shared-transit-keys" "secrets.secret-scanning.encrypted-secrets-delimited-shared-transit-keys"
+backup-secret "secret scanning encrypted content keys" "secret-scanning-user-content-delimited-encryption-root-keys" "secrets.secret-scanning.secret-scanning-user-content-delimited-encryption-root-keys"
 
 # Backup argon secrets for multiuser from ghes version 3.8 onwards
 if [[ "$(version $GHE_REMOTE_VERSION)" -ge "$(version 3.8.0)" && "$(version $GHE_REMOTE_VERSION)" -lt "$(version 3.8.2)" ]]; then

--- a/share/github-backup-utils/ghe-restore-secret-scanning-encryption-keys
+++ b/share/github-backup-utils/ghe-restore-secret-scanning-encryption-keys
@@ -36,4 +36,8 @@ log_info "Restoring secret scanning encrypted secrets transit keys"
 restore-secret "secret scanning encrypted secrets current shared transit key" "secret-scanning-encrypted-secrets-current-shared-transit-key" "secrets.secret-scanning.encrypted-secrets-current-shared-transit-key"
 restore-secret "secret scanning encrypted secrets delimited shared transit keys" "secret-scanning-encrypted-secrets-delimited-shared-transit-keys" "secrets.secret-scanning.encrypted-secrets-delimited-shared-transit-keys"
 
+# Restore secret scanning encrypted content keys if present
+log_info "Restoring secret scanning encrypted content scanning keys"
+restore-secret "secret scanning encrypted content keys" "secret-scanning-user-content-delimited-encryption-root-keys" "secrets.secret-scanning.secret-scanning-user-content-delimited-encryption-root-keys"
+
 bm_end "$(basename $0)"

--- a/test/test-ghe-backup.sh
+++ b/test/test-ghe-backup.sh
@@ -802,6 +802,32 @@ begin_test "ghe-backup takes backup of secret scanning encrypted secrets encrypt
 )
 end_test
 
+
+begin_test "ghe-backup takes backup of secret scanning encrypted content encryption keys"
+(
+  set -e
+
+  required_secrets=(
+    "secrets.secret-scanning.secret-scanning-user-content-delimited-encryption-root-keys"
+  )
+
+  for secret in "${required_secrets[@]}"; do
+    ghe-ssh "$GHE_HOSTNAME" -- ghe-config "$secret" "foo"
+  done
+
+  ghe-backup
+
+  required_files=(
+    "secret-scanning-user-content-delimited-encryption-root-keys"
+  )
+
+  for file in "${required_files[@]}"; do
+    [ "$(cat "$GHE_DATA_DIR/current/$file")" = "foo" ]
+  done
+)
+end_test
+
+
 begin_test "ghe-backup takes backup of Actions settings"
 (
   set -e

--- a/test/test-ghe-restore.sh
+++ b/test/test-ghe-restore.sh
@@ -454,6 +454,34 @@ begin_test "ghe-restore with secret scanning encrypted secrets encryption keys f
 )
 end_test
 
+
+begin_test "ghe-restore with secret scanning encrypted content encryption keys"
+(
+  set -e
+  rm -rf "$GHE_REMOTE_ROOT_DIR"
+  setup_remote_metadata
+
+  required_files=(
+    "secret-scanning-user-content-delimited-encryption-root-keys"
+  )
+
+  for file in "${required_files[@]}"; do
+    echo "foo" >"$GHE_DATA_DIR/current/$file"
+  done
+
+  GHE_REMOTE_VERSION=3.11.0 ghe-restore -v -f localhost
+
+  required_secrets=(
+    "secrets.secret-scanning.secret-scanning-user-content-delimited-encryption-root-keys"
+  )
+
+  for secret in "${required_secrets[@]}"; do
+    [ "$(ghe-ssh "$GHE_HOSTNAME" -- ghe-config "$secret")" = "" ] # expecting these to not be set for versions below 3.8.0
+  done
+)
+end_test
+
+
 # Setup Actions data for the subsequent tests
 setup_actions_test_data "$GHE_DATA_DIR/1"
 


### PR DESCRIPTION
Add the new encryption keys for Secret Scanning encrypted content scanning to the GHES backup utils.

Addresses https://github.com/github/secret-scanning/issues/5616
See also https://github.com/github/enterprise2/pull/34843
