### PR TITLE
Small PR to fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Customers will need to download a specific version of backup-utils from the [rel
 Below is the two phase timeline we will follow to roll out the changes described above:
 
 * **Phase 1 (rolled out on 2023-11-30):** We have closed all open pull requests and issues (after reviewing each one and porting them to our internal repository if merited),
-and updated the repository settings so that new issues cannot be opened. Also, we have stop syncing code from our internal repository to this repository.
+and updated the repository settings so that new issues cannot be opened. Also, we have stopped syncing code from our internal repository to this repository.
   * As of 2023-11-30, you can still get a working copy of backup-utils by cloning the repository.
       But the code will not be updated in the repository; you can access updated versions of backup-utils via the [release page](https://github.com/github/backup-utils/releases).
 * **Phase 2 (rolling out 2024-02-20):** The backup-utils code will be removed and the repository will be used to host documentation for backup-utils.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,6 +22,7 @@ CPU and memory requirements are dependent on the size of the GitHub Enterprise S
 The [fix in rsync `3.2.5`](https://github.com/WayneD/rsync/blob/master/NEWS.md#news-for-rsync-325-14-aug-2022) for [CVE-2022-29154](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29154) can cause severe performance degradation to `backup-utils`.
 
 If you encounter this degradation you can mitigate it by using the `--trust-sender` flag, which is available in rsync >= v3.2.5.
+**Note**: If you are using backup-utils 3.9 or greater, `--trust-sender` is automatically used if your rsync version supports it and no further changes are needed.
 
 If your backup host is running rsync < v3.2.5 you may or may not need to make changes to your rsync package, depending on whether your rsync package has backported the fix for CVE-2022-29154 without also backporting the `--trust-sender` flag.
 


### PR DESCRIPTION
This small PR makes two text only changes:

1. Fixes a typo (changes "stop" to "stopped")
2. Adds a clarification about when the `--trust-sender` flag is automatically used with `rsync`.