### PR TITLE
Install jq utility

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,7 @@
 FROM alpine:latest
 
 RUN apk --update --no-cache add \
+    jq \
     tar \
     rsync \
     ca-certificates \


### PR DESCRIPTION
# PR Details

## Description
'backup-utils' v3.9.5 will not run without 'jq' - the script checks for existence and stops.
The tool is not part of the Alpine base, at least not now.
Therefore, explicitly install it.

## Testing
Deployed the new image and tested it.
The backup-utils script sees the installed 'jq' package and proceeds.

## Ownership

## Related Links
