### PR TITLE
Remove link to 404 on backup.config-example in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@
     **Note**: you will need to use [Backup Utilities v2.11.x][2] or the `legacy` branch to
     backup and restore GitHub Enterprise Server 2.10 and earlier.
 
- 2. Copy the [`backup.config-example`][3] file to `backup.config` and modify as
+ 2. Copy the `backup.config-example` file to `backup.config` and modify as
     necessary. The `GHE_HOSTNAME` value must be set to the primary GitHub Enterprise Server
     hostname. Additional options are available and documented in the
     configuration file but none are required for basic backup functionality.
@@ -28,7 +28,7 @@
       with the `-i <abs path to private key>` SSH option.
 
  3. Add the backup host's SSH public key to the GitHub Enterprise Server appliance, in order to grant it administrative shell access.
-    See [Accessing the GitHub Enterprise Server administrative shell (SSH)][4] for instructions.
+    See [Accessing the GitHub Enterprise Server administrative shell (SSH)][3] for instructions.
 
  4. Run `bin/ghe-host-check` to verify SSH connectivity with the GitHub
     appliance.
@@ -37,5 +37,4 @@
 
 [1]: https://github.com/github/backup-utils/releases
 [2]: https://github.com/github/backup-utils/releases/tag/v2.11.4
-[3]: https://github.com/github/enterprise-backup-site/blob/master/backup.config-example
-[4]: https://docs.github.com/enterprise-server/admin/configuration/configuring-your-enterprise/accessing-the-administrative-shell-ssh
+[3]: https://docs.github.com/enterprise-server/admin/configuration/configuring-your-enterprise/accessing-the-administrative-shell-ssh


### PR DESCRIPTION
This file is no longer included in this repository. Since it actually is included in tarball referenced in the first step, we can remove the hyperlink.